### PR TITLE
Updated tests to pass

### DIFF
--- a/test/test_stripe.py
+++ b/test/test_stripe.py
@@ -1,12 +1,32 @@
 # -*- coding: utf-8 -*-
+import datetime
 import os
 import sys
-import unittest
-import datetime
 import time
+import unittest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 import stripe
+
+# dummy information used in the tests below
+NOW = datetime.datetime.now()
+DUMMY_CARD = {
+    'number': '4242424242424242',
+    'exp_month': NOW.month + 1,
+    'exp_year': NOW.year + 4
+}
+DUMMY_CHARGE = {
+    'amount': 100,
+    'currency': 'usd',
+    'card': DUMMY_CARD
+}
+DUMMY_PLAN = {
+    'amount': 2000,
+    'interval': 'month',
+    'name': 'Amazing Gold Plan',
+    'currency': 'usd',
+    'id': 'gold'
+}
 
 class FunctionalTests(unittest.TestCase):
     def test_dns_failure(self):
@@ -18,36 +38,44 @@ class FunctionalTests(unittest.TestCase):
             stripe.api_base = api_base
 
     def test_run(self):
-        c = stripe.Charge.create(amount=100, currency='usd', card={ 'number' : '4242424242424242', 'exp_month' : 03, 'exp_year' : 2015 })
-        self.assertFalse(c.refunded)
-        c.refund()
-        self.assertTrue(c.refunded)
+        charge = stripe.Charge.create(**DUMMY_CHARGE)
+        self.assertFalse(charge.refunded)
+        charge.refund()
+        self.assertTrue(charge.refunded)
 
     def test_refresh(self):
-        c = stripe.Charge.create(amount=100, currency='usd', card={ 'number' : '4242424242424242', 'exp_month' : 03, 'exp_year' : 2015 })
-        d = stripe.Charge.retrieve(c.id)
-        self.assertEqual(d.created, c.created)
+        charge = stripe.Charge.create(**DUMMY_CHARGE)
+        charge2 = stripe.Charge.retrieve(charge.id)
+        self.assertEqual(charge2.created, charge.created)
 
-        d.junk = 'junk'
-        d.refresh()
-        self.assertRaises(AttributeError, lambda: d.junk)
+        charge2.junk = 'junk'
+        charge2.refresh()
+        self.assertRaises(AttributeError, lambda: charge2.junk)
 
     def test_list_accessors(self):
-        c = stripe.Customer.create(plan='gold', card={ 'number' : '4242424242424242', 'exp_month' : 03, 'exp_year' : 2015 })
-        self.assertEqual(c['created'], c.created)
-        c['foo'] = 'bar'
-        self.assertEqual(c.foo, 'bar')
+        plan_obj = stripe.Plan.create(**DUMMY_PLAN)
+        customer = stripe.Customer.create(plan=DUMMY_PLAN['id'], card=DUMMY_CARD)
+        self.assertEqual(customer['created'], customer.created)
+        customer['foo'] = 'bar'
+        self.assertEqual(customer.foo, 'bar')
+        plan = stripe.Plan.retrieve(plan_obj.id)
+        plan.delete()
 
     def test_raise(self):
-        self.assertRaises(stripe.CardError, stripe.Charge.create, amount=100, currency='usd', card={ 'number' : '4242424242424241', 'exp_month' : 03, 'exp_year' : 2015 })
+        EXPIRED_CARD = DUMMY_CARD.copy()
+        EXPIRED_CARD['exp_month'] = NOW.month - 2
+        EXPIRED_CARD['exp_year'] = NOW.year - 2
+        self.assertRaises(stripe.CardError, stripe.Charge.create, amount=100,
+                          currency='usd', card=EXPIRED_CARD)
 
     def test_unicode(self):
         # Make sure unicode requests can be sent
-        self.assertRaises(stripe.InvalidRequestError, stripe.Charge.retrieve, id=u'☃')
+        self.assertRaises(stripe.InvalidRequestError, stripe.Charge.retrieve,
+                          id=u'☃')
 
     def test_none_values(self):
-        c = stripe.Customer.create(plan=None)
-        self.assertTrue(c.id)
+        customer = stripe.Customer.create(plan=None)
+        self.assertTrue(customer.id)
 
     def test_missing_id(self):
         customer = stripe.Customer()
@@ -55,50 +83,76 @@ class FunctionalTests(unittest.TestCase):
 
 class ChargeTest(unittest.TestCase):
     def test_create_uncaptured_charge(self):
-        c = stripe.Charge.create(amount=100, currency='usd', card={ 'number' : '4242424242424242', 'exp_month' : 03, 'exp_year' : 2015 }, uncaptured=True)
-        self.assertTrue(c.paid)
-        self.assertFalse(c.refunded)
-        self.assertTrue(c.uncaptured)
+        charge = stripe.Charge.create(uncaptured=True, **DUMMY_CHARGE)
+        self.assertTrue(charge.paid)
+        self.assertFalse(charge.refunded)
+        self.assertTrue(charge.uncaptured)
 
-    def test_create_uncaptured_charge(self):
-        c = stripe.Charge.create(amount=100, currency='usd', card={ 'number' : '4242424242424242', 'exp_month' : 03, 'exp_year' : 2015 }, uncaptured=True)
-        c.capture()
-        self.assertTrue(c.paid)
-        self.assertFalse(c.refunded)
-        self.assertEqual(c.get('uncaptured'), None)
+    def test_create_uncaptured_charge_and_capture(self):
+        charge = stripe.Charge.create(uncaptured=True, **DUMMY_CHARGE)
+        charge.capture()
+        self.assertTrue(charge.paid)
+        self.assertFalse(charge.refunded)
+        self.assertEqual(charge.get('uncaptured'), None)
 
 class CustomerTest(unittest.TestCase):
+    def test_create_plan(self):
+        plan_obj = stripe.Plan.create(**DUMMY_PLAN)
+        self.assertTrue(hasattr(plan_obj, 'amount'))
+        self.assertEquals(DUMMY_PLAN['amount'], plan_obj.amount)
+        plan = stripe.Plan.retrieve(plan_obj.id)
+        self.assertFalse(hasattr(plan, 'deleted'))
+        plan.delete()
+        self.assertTrue(hasattr(plan, 'deleted'))
+        self.assertTrue(plan.deleted)
+    
     def test_create_customer(self):
-        self.assertRaises(stripe.InvalidRequestError, stripe.Customer.create, plan='gold')
-        c = stripe.Customer.create(plan='gold', card={ 'number' : '4242424242424242', 'exp_month' : 03, 'exp_year' : 2015 })
-        self.assertTrue(hasattr(c, 'subscription'))
-        self.assertFalse(hasattr(c, 'plan'))
-        c.delete()
-        self.assertFalse(hasattr(c, 'subscription'))
-        self.assertFalse(hasattr(c, 'plan'))
-        self.assertTrue(c.deleted)
+        plan_obj = stripe.Plan.create(**DUMMY_PLAN)
+        self.assertRaises(stripe.InvalidRequestError, stripe.Customer.create,
+                          plan=DUMMY_PLAN['id'])
+        customer = stripe.Customer.create(plan=DUMMY_PLAN['id'], card=DUMMY_CARD)
+        self.assertTrue(hasattr(customer, 'subscription'))
+        self.assertFalse(hasattr(customer, 'plan'))
+        customer.delete()
+        self.assertFalse(hasattr(customer, 'subscription'))
+        self.assertFalse(hasattr(customer, 'plan'))
+        self.assertTrue(customer.deleted)
+        stripe.Plan.retrieve(plan_obj.id).delete()
 
     def test_list_customers(self):
-        cs = stripe.Customer.all()
-        self.assertTrue(isinstance(cs, list))
+        customers = stripe.Customer.all()
+        self.assertTrue(isinstance(customers.data, list))
 
     def test_cancel_subscription(self):
-        c = stripe.Customer.create(plan='gold', card={ 'number' : '4242424242424242', 'exp_month' : 03, 'exp_year' : 2015 })
-        c.cancel_subscription(at_period_end=True)
-        self.assertEqual(c.subscription.status, 'active')
-        self.assertTrue(c.subscription.cancel_at_period_end)
-        c.cancel_subscription()
-        self.assertEqual(c.subscription.status, 'canceled')
+        plan_obj = stripe.Plan.create(**DUMMY_PLAN)
+        customer = stripe.Customer.create(plan=DUMMY_PLAN['id'],
+                                          card=DUMMY_CARD)
+        customer.cancel_subscription(at_period_end=True)
+        self.assertEqual(customer.subscription.status, 'active')
+        self.assertTrue(customer.subscription.cancel_at_period_end)
+        customer.cancel_subscription()
+        self.assertEqual(customer.subscription.status, 'canceled')
+        plan = stripe.Plan.retrieve(plan_obj.id)
+        plan.delete()
 
     def test_datetime_trial_end(self):
-        c = stripe.Customer.create(plan='gold', card={ 'number' : '4242424242424242', 'exp_month' : 03, 'exp_year' : 2015 }, trial_end=datetime.datetime.now()+datetime.timedelta(days=15))
-        self.assertTrue(c.id)
+        plan_obj = stripe.Plan.create(**DUMMY_PLAN)
+        customer = stripe.Customer.create(plan=DUMMY_PLAN['id'], card=DUMMY_CARD,
+            trial_end=datetime.datetime.now()+datetime.timedelta(days=15))
+        self.assertTrue(customer.id)
+        plan = stripe.Plan.retrieve(plan_obj.id)
+        plan.delete()
 
     def test_integer_trial_end(self):
+        plan_obj = stripe.Plan.create(**DUMMY_PLAN)
         trial_end_dttm = datetime.datetime.now() + datetime.timedelta(days=15)
         trial_end_int = int(time.mktime(trial_end_dttm.timetuple()))
-        c = stripe.Customer.create(plan='gold', card={ 'number' : '4242424242424242', 'exp_month' : 03, 'exp_year' : 2015 }, trial_end=trial_end_int)
-        self.assertTrue(c.id)
+        customer = stripe.Customer.create(plan=DUMMY_PLAN['id'],
+                                          card=DUMMY_CARD,
+                                          trial_end=trial_end_int)
+        self.assertTrue(customer.id)
+        plan = stripe.Plan.retrieve(plan_obj.id)
+        plan.delete()
 
 if __name__ == '__main__':
     api_base = os.environ.get('STRIPE_API_BASE')


### PR DESCRIPTION
Corrected dupe functions and added functionality that allowed the tests to pass on a new account.
Shortened all lines to 80 cols re PEP-8.
Replaced repeated lines with reusable objects to comply with DRY.
