### PR TITLE
Make stripe-python work with requests 1.x.x

### DIFF
--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -41,12 +41,13 @@ if not _httplib:
 
   try:
     # Require version 0.8.8, but don't want to depend on distutils
-    version = pkg_resources.parse_version(requests.__version__)
+    version = requests.__version__
   except:
     # Probably some new-fangled version, so it should support verify
     pass
   else:
-    if version < pkg_resources.parse_version("0.8.8"):
+    minimum_version = pkg_resources.parse_version("0.8.8")
+    if pkg_resources.parse_version(version) < minimum_version:
       print >>sys.stderr, 'Warning: the Stripe library requires that your Python "requests" library has a version no older than 0.8.8, but your "requests" library has version %s. Stripe will fall back to an alternate HTTP library, so everything should work, though we recommend upgrading your "requests" library. If you have any questions, please contact support@stripe.com. (HINT: running "pip install -U requests" should upgrade your requests library to the latest version.)' % (version, )
       _httplib = None
 


### PR DESCRIPTION
The current version of stripe-python spews a warning message if you attempt to use it with requests 1.x.x, because it does a naive version comparison.  This pull request fixes the issue by using
setuptools/distribute's version parsing capabilities.
