### PR TITLE
skip pycurl if gevent is used

### DIFF
--- a/stripe/http_client.py
+++ b/stripe/http_client.py
@@ -15,10 +15,14 @@ try:
 except ImportError:
     pass
 
-try:
-    import pycurl
-except ImportError:
+if 'gevent' in sys.modules:
+    # pycurl is not compatible with gevent's green threads
     pycurl = None
+else:
+    try:
+        import pycurl
+    except ImportError:
+        pycurl = None
 
 try:
     import requests


### PR DESCRIPTION
pycurl, being a wrapper around C library, blocks the whole process and all green threads rather than the current one.

Unlike urllib2 and requests which are compatible with gevent through monkey patching.

More info about gevent at http://gevent.org
