### PR TITLE
Add Travis CI build status to the README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,4 @@
-= Stripe Python bindings
-
-{<img src="https://travis-ci.org/stripe/stripe-python.svg?branch=master" alt="Build Status" />}[https://travis-ci.org/stripe/stripe-python]
+= Stripe Python bindings {<img src="https://travis-ci.org/stripe/stripe-python.svg?branch=master" alt="Build Status" />}[https://travis-ci.org/stripe/stripe-python]
 
 == Installation
 


### PR DESCRIPTION
I noticed that while we test with Travis, we don't have the badge in the README.
