### PR TITLE
Deprecate Python 2.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import warnings
 
 try:
     from setuptools import setup
@@ -14,13 +15,18 @@ except ImportError:
 path, script = os.path.split(sys.argv[0])
 os.chdir(os.path.abspath(path))
 
-requests = 'requests >= 0.8.8'
-if sys.version_info < (2, 6):
-    requests += ', < 0.10.1'
-install_requires = [requests]
+install_requires = []
 
 if sys.version_info < (2, 6):
+    warnings.warn(
+        'Python 2.5 is no longer officially supported by Stripe. '
+        'If you have any questions, please file an issue on Github or '
+        'contact us at support@stripe.com.',
+        DeprecationWarning)
+    install_requires.append('requests >= 0.8.8, < 0.10.1')
     install_requires.append('ssl')
+else:
+    install_requires.append('requests >= 0.8.8')
 
 
 # Don't import stripe module here, since deps may not be installed
@@ -54,7 +60,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.5",
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py25, py26, py27, pypy, py31, py32, py33
+envlist = py26, py27, pypy, py31, py32, py33
 
 [testenv]
 deps =
@@ -24,12 +24,3 @@ deps =
 commands =
     python -W always setup.py test {posargs}
     flake8 stripe
-
-[testenv:py25]
-deps =
-    pycurl>=7.19
-    requests<0.10.1
-    mock>=1.0.1
-    simplejson
-setenv =
-   PIP_INSECURE = 1


### PR DESCRIPTION
Neither of our testing tools (Travis and tox) support Python 2.5 anymore.  This means that continuing to claim support is either (a) onerous or (b) a lie.  Based on our data, almost no one is currently using Python 2.5 in production and none of them have updated their bindings this year.  

I'd like to officially deprecate Python 2.5 without doing anything to intentionally break it.  For the time being, we won't refactor the code to use `with`, `except ... as` or libraries unavailable in 2.5.  We simply won't commit to maintaining that compatibility in the future.

@danielhfrank @kyleconroy does this seem fair given the context from our email thread?
