### PR TITLE
Fix ssl import error in GAE

### DIFF
--- a/stripe/util.py
+++ b/stripe/util.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import os
 
 logger = logging.getLogger('stripe')
 
@@ -49,3 +50,8 @@ def utf8(value):
         return value.encode('utf-8')
     else:
         return value
+
+
+def is_appengine_dev():
+    return ('APPENGINE_RUNTIME' in os.environ and
+            'Dev' in os.environ.get('SERVER_SOFTWARE', ''))


### PR DESCRIPTION
This avoids an `ImportError` when loading the SSL library in a Google App Engine dev environment.  For more details, see:
https://code.google.com/p/googleappengine/issues/detail?id=9246

This PR is a followup from an internal ticket.  I'll merge once the reporter has confirmed that this fixes the issue in his environment.
