### PR TITLE
Configure GAE urlfetch timeout

### DIFF
--- a/stripe/http_client.py
+++ b/stripe/http_client.py
@@ -141,6 +141,9 @@ class RequestsClient(HTTPClient):
 
 
 class UrlFetchClient(HTTPClient):
+    # GAE requests time out after 60 seconds, so make sure we leave
+    # some time for the application to handle a slow Stripe
+    deadline = 55
     name = 'urlfetch'
 
     def request(self, method, url, headers, post_data=None):
@@ -153,9 +156,7 @@ class UrlFetchClient(HTTPClient):
                 # However, that's ok because the CA bundle they use recognizes
                 # api.stripe.com.
                 validate_certificate=self._verify_ssl_certs,
-                # GAE requests time out after 60 seconds, so make sure we leave
-                # some time for the application to handle a slow Stripe
-                deadline=55,
+                deadline=self.deadline,
                 payload=post_data
             )
         except urlfetch.Error, e:

--- a/stripe/test/test_http_client.py
+++ b/stripe/test/test_http_client.py
@@ -48,7 +48,7 @@ class HttpClientTests(StripeUnitTestCase):
                            stripe.http_client.Urllib2Client)
 
 
-class ClientTestBase():
+class ClientTestBase(object):
 
     @property
     def request_mock(self):
@@ -153,6 +153,31 @@ class UrlFetchClientTests(StripeUnitTestCase, ClientTestBase):
             validate_certificate=True,
             deadline=55,
             payload=post_data
+        )
+
+    def test_configure_deadline(self):
+        self.mock_response(self.request_mock, '{"foo": "baz"}', 200)
+
+        headers = {'my-header': 'header val'}
+
+        stripe.http_client.UrlFetchClient.deadline = 80
+
+        try:
+            body, code = self.make_request(
+                'GET', self.valid_url, headers, '')
+        finally:
+            stripe.http_client.UrlFetchClient.deadline = 55
+
+        self.assertEqual(200, code)
+        self.assertEqual('{"foo": "baz"}', body)
+
+        self.request_mock.fetch.assert_called_with(
+            url=self.valid_url,
+            method='GET',
+            headers=headers,
+            validate_certificate=True,
+            deadline=80,
+            payload=''
         )
 
 


### PR DESCRIPTION
Fix #40. To configure the deadline, set the `deadline` property on the UrlFetchClient.

```python
import stripe
import stripe.http_client

http_client.UrlFetchClient.deadline = 999

...
```

r? @metcalf @wangjohn 