### PR TITLE
Creating the FileUpload resource.

### DIFF
--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -9,13 +9,14 @@
 
 api_key = None
 api_base = 'https://api.stripe.com'
+upload_api_base = 'https://uploads.stripe.com'
 api_version = None
 verify_ssl_certs = True
 
 # Resource
 from stripe.resource import (  # noqa
     Account, Balance, BalanceTransaction, Card, Charge, Customer, Invoice,
-    InvoiceItem, Plan, Token, Coupon, Event, Transfer, Recipient,
+    InvoiceItem, Plan, Token, Coupon, Event, Transfer, Recipient, FileUpload,
     ApplicationFee, Subscription)
 
 # Error imports.  Note that we may want to move these out of the root

--- a/stripe/multipart_data_generator.py
+++ b/stripe/multipart_data_generator.py
@@ -1,0 +1,60 @@
+import random
+import sys
+import io
+
+
+class MultipartDataGenerator(object):
+    def __init__(self, chunk_size=1028):
+        self.data = io.BytesIO()
+        self.line_break = "\r\n"
+        self.boundary = self._initialize_boundary()
+        self.chunk_size = chunk_size
+
+    def add_params(self, params):
+        for key, value in params.iteritems():
+            if value is None:
+                continue
+
+            self._write(self.param_header())
+            self._write(self.line_break)
+            if hasattr(value, 'read'):
+                self._write("Content-Disposition: form-data; name=\"%s\"; "
+                            "filename=\"%s\"" % (key, value.name))
+                self._write(self.line_break)
+                self._write("Content-Type: application/octet-stream")
+                self._write(self.line_break)
+                self._write(self.line_break)
+
+                self._write_file(value)
+            else:
+                self._write("Content-Disposition: form-data; name=\"%s\"" %
+                            (key,))
+                self._write(self.line_break)
+                self._write(self.line_break)
+                self._write(value)
+
+            self._write(self.line_break)
+
+    def param_header(self):
+        return "--%s" % self.boundary
+
+    def get_post_data(self):
+        self._write("--%s--" % (self.boundary,))
+        self._write(self.line_break)
+        return self.data.getvalue()
+
+    def _write(self, value):
+        if sys.version_info < (3, 0):
+            self.data.write(value)
+        else:
+            self.data.write(bytes(value, 'utf-8'))
+
+    def _write_file(self, f):
+        while True:
+            file_contents = f.read(self.chunk_size)
+            if not file_contents:
+                break
+            self._write(file_contents)
+
+    def _initialize_boundary(self):
+        return random.randint(0, 2**63)

--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -2,7 +2,7 @@ import urllib
 import warnings
 import sys
 
-from stripe import api_requestor, error, util
+from stripe import api_requestor, error, util, upload_api_base
 
 
 def convert_to_stripe_object(resp, api_key):
@@ -12,6 +12,7 @@ def convert_to_stripe_object(resp, api_key):
              'transfer': Transfer, 'list': ListObject, 'recipient': Recipient,
              'card': Card, 'application_fee': ApplicationFee,
              'subscription': Subscription, 'refund': Refund,
+             'file': FileUpload,
              'fee_refund': ApplicationFeeRefund}
 
     if isinstance(resp, list):
@@ -123,11 +124,16 @@ class StripeObject(dict):
 
         self._previous_metadata = values.get('metadata')
 
+    @classmethod
+    def api_base(cls):
+        return None
+
     def request(self, method, url, params=None, headers=None):
         if params is None:
             params = self._retrieve_params
 
-        requestor = api_requestor.APIRequestor(self.api_key)
+        requestor = api_requestor.APIRequestor(
+            self.api_key, api_base=self.api_base())
         response, api_key = requestor.request(method, url, params, headers)
 
         return convert_to_stripe_object(response, api_key)
@@ -551,6 +557,28 @@ class Recipient(CreateableAPIResource, UpdateableAPIResource,
         params['recipient'] = self.id
         transfers = Transfer.all(self.api_key, **params)
         return transfers
+
+
+class FileUpload(APIResource):
+    @classmethod
+    def api_base(cls):
+        return upload_api_base
+
+    @classmethod
+    def class_name(cls):
+        return 'file'
+
+    @classmethod
+    def create(cls, api_key=None, **params):
+        requestor = api_requestor.APIRequestor(
+            api_key, api_base=cls.api_base())
+        url = cls.class_url()
+        supplied_headers = {
+            "Content-Type": "multipart/form-data"
+        }
+        response, api_key = requestor.request(
+            'post', url, params=params, headers=supplied_headers)
+        return convert_to_stripe_object(response, api_key)
 
 
 class ApplicationFee(ListableAPIResource):

--- a/stripe/test/test_multipart_data_generator.py
+++ b/stripe/test/test_multipart_data_generator.py
@@ -1,0 +1,40 @@
+import re
+import sys
+
+from stripe.multipart_data_generator import MultipartDataGenerator
+from stripe.test.helper import StripeTestCase
+
+
+class MultipartDataGeneratorTests(StripeTestCase):
+
+    def test_generate_simple_multipart_data(self):
+        test_file = open(__file__)
+
+        params = {
+            "key1": "value1",
+            "key2": "value2",
+            "key3": test_file
+            }
+        generator = MultipartDataGenerator()
+        generator.add_params(params)
+        post_data = generator.get_post_data()
+
+        if sys.version_info < (3, 0):
+            http_body = "".join([line for line in post_data])
+        else:
+            byte_array = bytearray([i for i in post_data])
+            http_body = byte_array.decode('utf-8')
+
+        self.assertTrue(re.search(
+            r"Content-Disposition: form-data; name=\"key1\"", http_body))
+        self.assertTrue(re.search(
+            r"Content-Disposition: form-data; name=\"key2\"", http_body))
+        self.assertTrue(re.search(
+            r"Content-Disposition: form-data; name=\"key3\"; filename=\".+\"",
+            http_body))
+        self.assertTrue(re.search(
+            r"Content-Type: application/octet-stream", http_body))
+
+        test_file.seek(0)
+        file_contents = test_file.read()
+        self.assertNotEqual(-1, http_body.find(file_contents))

--- a/stripe/test/test_resources.py
+++ b/stripe/test/test_resources.py
@@ -2,6 +2,7 @@ import pickle
 import sys
 import time
 import datetime
+import tempfile
 
 import stripe
 import stripe.resource
@@ -996,6 +997,33 @@ class PlanTest(StripeResourceTest):
             {
                 'name': 'Plan Name',
             },
+            None
+        )
+
+
+class FileUploadTest(StripeResourceTest):
+    def test_create_file_upload(self):
+        test_file = tempfile.TemporaryFile()
+        stripe.FileUpload.create(
+            purpose='dispute_evidence',
+            file=test_file
+            )
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/v1/files',
+            params={
+                'purpose': 'dispute_evidence',
+                'file': test_file
+            },
+            headers={'Content-Type': 'multipart/form-data'}
+        )
+
+    def test_fetch_file_upload(self):
+        stripe.FileUpload.retrieve("fil_foo")
+        self.requestor_mock.request.assert_called_with(
+            'get',
+            '/v1/files/fil_foo',
+            {},
             None
         )
 


### PR DESCRIPTION
This PR adds support for posting multipart/form data and file uploads. It does a number of things in order to allow file uploads to be included in the python bindings. These are:
1. It allows subclasses of StripeObjects to specify an api_base url from which the base endpoint will be directed. This allows a method to point to something other than `https://api.stripe.com`.
2. By specifying `Content-Type: multipart/form-data` in the headers of a post request, a multipart request will be created. To send a file, one simply needs to pass a file like object as a value for one of the parameters.
3. Creates the FileUpload resource which can be used to create and retrieve file uploads from the Stripe upload API.

r? @kyleconroy 
