### PR TITLE
Use the new docker-based container Travis environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ python:
   - "3.4"
 env: PYCURL_SSL_LIBRARY=gnutls
 before_install:
-  - sudo apt-get update
-  - sudo apt-get install libcurl4-gnutls-dev librtmp-dev
+  - apt-get update
+  - apt-get install libcurl4-gnutls-dev librtmp-dev
 install:
   - pip install pycurl flake8 --use-mirrors
   - python setup.py install
@@ -20,3 +20,4 @@ cache: apt
 matrix:
   allow_failures:
     - python: pypy
+sudo: false


### PR DESCRIPTION
We used `sudo` to install some packages, so I'm expecting this to fail.
