### PR TITLE
[WIP] Unexpose BitcoinTransaction routes

### DIFF
--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -638,8 +638,5 @@ class BitcoinReceiver(CreateableAPIResource, ListableAPIResource):
         return '/v1/bitcoin/receivers'
 
 
-class BitcoinTransaction(ListableAPIResource):
-
-    @classmethod
-    def class_url(cls):
-        return '/v1/bitcoin/transactions'
+class BitcoinTransaction(StripeObject):
+    pass

--- a/stripe/test/test_resources.py
+++ b/stripe/test/test_resources.py
@@ -1297,23 +1297,3 @@ class BitcoinReceiverTest(StripeResourceTest):
             },
             None
         )
-
-
-class BitcoinTransactionTest(StripeResourceTest):
-
-    def test_retrieve_resource(self):
-        stripe.BitcoinTransaction.retrieve("btctxn_test_transaction")
-        self.requestor_mock.request.assert_called_with(
-            'get',
-            '/v1/bitcoin/transactions/btctxn_test_transaction',
-            {},
-            None
-        )
-
-    def test_list_transactions(self):
-        stripe.BitcoinTransaction.all()
-        self.requestor_mock.request.assert_called_with(
-            'get',
-            '/v1/bitcoin/transactions',
-            {},
-        )


### PR DESCRIPTION
Removed interface to query BitcoinTransactions -- only it should only be a child property of BitcoinReceiver