### PR TITLE
Remove sys import hack

### DIFF
--- a/stripe/test/test_integration.py
+++ b/stripe/test/test_integration.py
@@ -2,12 +2,9 @@
 import os
 import sys
 import unittest
-
-from mock import patch
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 import stripe
 
+from mock import patch
 from stripe.test.helper import (StripeTestCase, NOW, DUMMY_CHARGE, DUMMY_CARD)
 
 


### PR DESCRIPTION
I'm a bit worried that this change will mean we're just testing the latest version of stripe on PyPI.