### PR TITLE
setup.py url should point to URL of package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     long_description=long_description,
     author='Stripe',
     author_email='support@stripe.com',
-    url='https://stripe.com/',
+    url='https://github.com/stripe/stripe-python',
     packages=['stripe', 'stripe.test'],
     package_data={'stripe': ['data/ca-certificates.crt', '../VERSION']},
     install_requires=install_requires,


### PR DESCRIPTION
https://docs.python.org/2/distutils/setupscript.html#additional-meta-data

"home page for the package"