### PR TITLE
Support arrays of StripeObjects

### DIFF
--- a/stripe/test/test_requestor.py
+++ b/stripe/test/test_requestor.py
@@ -199,6 +199,20 @@ class APIRequestorRequestTests(StripeUnitTestCase):
 
         self.check_call('get', QueryMatcher(expectation))
 
+    def test_dictionary_list_encoding(self):
+        params = {
+            'foo': {
+                '0': {
+                    'bar': 'bat',
+                }
+            }
+        }
+        encoded = list(stripe.api_requestor._api_encode(params))
+        key, value = encoded[0]
+
+        self.assertEqual('foo[0][bar]', key)
+        self.assertEqual('bat', value)
+
     def test_url_construction(self):
         CASES = (
             ('https://api.stripe.com?foo=bar', '', {'foo': 'bar'}),


### PR DESCRIPTION
r? @kyleconroy 

Because the iteration syntax between lists and dicts are different, I couldn't globally make the list-is-now-a-dict change. Hardcoding it to `additional_owners` for now until we can figure out a better solution.