### PR TITLE
Balance.retrieve support for managed accounts.

### DIFF
--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -299,10 +299,8 @@ class ListObject(StripeObject):
 class SingletonAPIResource(APIResource):
 
     @classmethod
-    def retrieve(cls, api_key=None, stripe_account=None):
-        return super(SingletonAPIResource, cls).retrieve(None,
-                                                         api_key=api_key,
-                                                         stripe_account=stripe_account)
+    def retrieve(cls, **params):
+        return super(SingletonAPIResource, cls).retrieve(None, **params)
 
     @classmethod
     def class_url(cls):

--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -244,7 +244,7 @@ class StripeObjectEncoder(util.json.JSONEncoder):
 class APIResource(StripeObject):
 
     @classmethod
-    def retrieve(cls, id, api_key=None, stripe_account=None, **params):
+    def retrieve(cls, id, api_key=None, **params):
         instance = cls(id, api_key, **params)
         instance.refresh()
         return instance
@@ -301,7 +301,8 @@ class SingletonAPIResource(APIResource):
     @classmethod
     def retrieve(cls, api_key=None, stripe_account=None):
         return super(SingletonAPIResource, cls).retrieve(None,
-                                                         api_key=api_key)
+                                                         api_key=api_key,
+                                                         stripe_account=stripe_account)
 
     @classmethod
     def class_url(cls):


### PR DESCRIPTION
Makes sure the "stripe_account" parameter to the Balance.retrieve query gets passed all the way to the API call