### PR TITLE
Ultra verbose logging should be in DEBUG

### DIFF
--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -233,10 +233,7 @@ class APIRequestor(object):
         rbody, rcode = self._client.request(
             method, abs_url, headers, post_data)
 
-        util.logger.info(
-            'API request to %s returned (response code) of '
-            '(%d)',
-            abs_url, rcode)
+        util.logger.info('%s %s %d', method.upper(), abs_url, rcode)
         util.logger.debug(
             'API request to %s returned (response code, response body) of '
             '(%d, %r)',

--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -234,6 +234,10 @@ class APIRequestor(object):
             method, abs_url, headers, post_data)
 
         util.logger.info(
+            'API request to %s returned (response code) of '
+            '(%d)',
+            abs_url, rcode)
+        util.logger.debug(
             'API request to %s returned (response code, response body) of '
             '(%d, %r)',
             abs_url, rcode, rbody)


### PR DESCRIPTION
Log output of the entire HTTP response should be in DEBUG not in INFO. Putting everything in INFO gives me no ability to allow stripe to log without completely clobbering the logs in other ways.