### PR TITLE
Suggest adding contributors via script

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -44,6 +44,8 @@ Ross Boucher <rboucher@gmail.com>
 Sheena Pakanati <spakanati@gmail.com>
 Stephen Wan <stephen@stephenwan.net>
 Stephen Wan <stephen@stripe.com>
+Trey <trey@ktrl.com>
+Trey Long <trey@ktrl.com>
 Tyler G. Hicks-Wright <ty@tghw.com>
 agoel <_@anur.ag>
 darraghbuckley <darragh.buckley@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,3 +1,57 @@
-Greg Brockman <gdb@stripe.com>
-Patrick Collison <patrick@stripe.com>
-Ray Ventura <rayvace@gmail.com>
+Amber Feng <amber.feng@gmail.com>
+Amber Feng <amber@stripe.com>
+Andrew Metcalf <agmetcalf@gmail.com>
+Andrew Metcalf <andrew@stripe.com>
+Andy Brody <andy@stripe.com>
+Anurag GOel <_@anur.ag>
+Anurag Goel <_@anur.ag>
+Brian Krausz <bkrausz@stripe.com>
+Christian Anderson <christian@stripe.com>
+Corey Farwell <coreyf@rwell.org>
+Cosmin Nicolaescu <cosmin.nicolaescu@gmail.com>
+Daniel Chatfield <chatfielddaniel@gmail.com>
+Eli Courtwright <eli@courtwright.org>
+Evan Broder <evan@ebroder.net>
+Evan Broder <evan@stripe.com>
+Fletcher Tomalty <fletcher@tomalty.com>
+Greg Brockman <gdb@gregbrockman.com>
+Greg Sabo <gregsabo@stripe.com>
+Jeff Balogh <jeff@jbalogh.me>
+Jim Danz <jim@stripe.com>
+John J. Wang <john.jian.wang@gmail.com>
+John J. Wang <wangjohn@mit.edu>
+Jonathan Hernandez <jon.hernandez@gmail.com>
+Kiran Bhattaram <kiran@stripe.com>
+Kyle Conroy <kjc@stripe.com>
+Kyle Conroy <kyle@kyleconroy.com>
+Lachy Groom <lachy@stripe.com>
+Lachy Groom <lachygroom+collectivejam@gmail.com>
+Lee Trout <lee@leetrout.com>
+Marc Abramowitz <marc@marc-abramowitz.com>
+Max Lahey <maxwellslahey@gmail.com>
+Max Lahey <mlahey@stripe.com>
+Michael B <mike@belfrage.net>
+Michael B. <mike@belfrage.net>
+Michael Manapat <mlm@stripe.com>
+Michael Schade <michael@spearheaddev.com>
+Michelle Bu <michelle@michellebu.com>
+Nelson Elhage <nelhage@nelhage.com>
+Pascal Borreli <pascal@borreli.com>
+Patrick Collison <patrick@collison.ie>
+Richo Healey <healey.rich@gmail.com>
+Richo Healey <richo@psych0tik.net>
+Ross Boucher <rboucher@gmail.com>
+Sheena Pakanati <spakanati@gmail.com>
+Stephen Wan <stephen@stephenwan.net>
+Stephen Wan <stephen@stripe.com>
+Tyler G. Hicks-Wright <ty@tghw.com>
+agoel <_@anur.ag>
+darraghbuckley <darragh.buckley@gmail.com>
+eli <eli@haku.(none)>
+jimdanz <jim.danz@gmail.com>
+kiran-b <kiran@stripe.com>
+mlmanapat <mlm@stripe.com>
+mrmicjam <dataconcise@gmail.com>
+spakanati <spakanati@gmail.com>
+wangjohn <john.jian.wang@gmail.com>
+wangjohn <wangjohn@mit.edu>

--- a/bin/update_contrib.sh
+++ b/bin/update_contrib.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+git log --format='%aN <%aE>' | sort -u > CONTRIBUTORS


### PR DESCRIPTION
You can cancel or ignore this PR if it doesn't fit with your internal policies but I thought I would offer it anyway. Just an update to more accurately reflect the contributors of your project generated from the git history.
