### PR TITLE
Add a BankAccount object

### DIFF
--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -15,8 +15,9 @@ verify_ssl_certs = True
 
 # Resource
 from stripe.resource import (  # noqa
-    Account, Balance, BalanceTransaction, Card, Charge, Customer, Invoice,
-    InvoiceItem, Plan, Token, Coupon, Event, Transfer, Recipient, FileUpload,
+    Account, Balance, BalanceTransaction, BankAccount, Card,
+    Charge, Customer, Invoice, InvoiceItem, Plan, Token, Coupon,
+    Event, Transfer, Recipient, FileUpload,
     ApplicationFee, Subscription, BitcoinReceiver, BitcoinTransaction)
 
 # Error imports.  Note that we may want to move these out of the root

--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -10,6 +10,7 @@ def convert_to_stripe_object(resp, api_key, account):
              'invoice': Invoice, 'invoiceitem': InvoiceItem,
              'plan': Plan, 'coupon': Coupon, 'token': Token, 'event': Event,
              'transfer': Transfer, 'list': ListObject, 'recipient': Recipient,
+             'bank_account': BankAccount,
              'card': Card, 'application_fee': ApplicationFee,
              'subscription': Subscription, 'refund': Refund,
              'file_upload': FileUpload,
@@ -420,6 +421,42 @@ class Card(UpdateableAPIResource, DeletableAPIResource):
             "Can't retrieve a card without a customer or recipient"
             "ID. Use customer.cards.retrieve('card_id') or "
             "recipient.cards.retrieve('card_id') instead.")
+
+
+class BankAccount(UpdateableAPIResource, DeletableAPIResource):
+
+    def instance_url(self):
+        self.id = util.utf8(self.id)
+        extn = urllib.quote_plus(self.id)
+        if (hasattr(self, 'customer')):
+            self.customer = util.utf8(self.customer)
+
+            base = Customer.class_url()
+            owner_extn = urllib.quote_plus(self.customer)
+            class_base = "sources"
+
+        elif (hasattr(self, 'account')):
+            self.account = util.utf8(self.account)
+
+            base = Account.class_url()
+            owner_extn = urllib.quote_plus(self.account)
+            class_base = "bank_accounts"
+
+        else:
+            raise error.InvalidRequestError(
+                "Could not determine whether bank_account_id %s is "
+                "attached to a customer "
+                "or an account." % self.id, 'id')
+
+        return "%s/%s/%s/%s" % (base, owner_extn, class_base, extn)
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, stripe_account=None, **params):
+        raise NotImplementedError(
+            "Can't retrieve a bank account without a customer or "
+            "account ID. Use "
+            "customer.sources.retrieve('bank_account_id') or "
+            "recipient.sources.retrieve('bank_account_id') instead.")
 
 
 class Charge(CreateableAPIResource, ListableAPIResource,

--- a/stripe/test/test_resources.py
+++ b/stripe/test/test_resources.py
@@ -861,6 +861,20 @@ class AccountTest(StripeResourceTest):
             None,
         )
 
+    def test_account_delete_bank_account(self):
+        source = stripe.BankAccount.construct_from({
+            'account': 'acc_delete_ba',
+            'id': 'ba_delete_ba',
+        }, 'api_key')
+        source.delete()
+
+        self.requestor_mock.request.assert_called_with(
+            'delete',
+            '/v1/accounts/acc_delete_ba/bank_accounts/ba_delete_ba',
+            {},
+            None
+        )
+
     def test_verify_additional_owner(self):
         acct = stripe.Account.construct_from({
             'id': 'acct_update',

--- a/stripe/test/test_resources.py
+++ b/stripe/test/test_resources.py
@@ -1066,6 +1066,20 @@ class CustomerTest(StripeResourceTest):
             None
         )
 
+    def test_customer_delete_bank_account(self):
+        source = stripe.BankAccount.construct_from({
+            'customer': 'cus_delete_source',
+            'id': 'ba_delete_source',
+        }, 'api_key')
+        source.delete()
+
+        self.requestor_mock.request.assert_called_with(
+            'delete',
+            '/v1/customers/cus_delete_source/sources/ba_delete_source',
+            {},
+            None
+        )
+
 
 class TransferTest(StripeResourceTest):
 
@@ -1504,7 +1518,7 @@ class FileUploadTest(StripeResourceTest):
         stripe.FileUpload.create(
             purpose='dispute_evidence',
             file=test_file
-            )
+        )
         self.requestor_mock.request.assert_called_with(
             'post',
             '/v1/files',


### PR DESCRIPTION
Currently, bank accounts that were added as a source to Customers cannot be deleted in the same way as Cards. This patch takes care of that.