### PR TITLE
Fix mutation side effect in Card and BankAccount

### DIFF
--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -396,24 +396,24 @@ class Card(UpdateableAPIResource, DeletableAPIResource):
         self.id = util.utf8(self.id)
         extn = urllib.quote_plus(self.id)
         if (hasattr(self, 'customer')):
-            self.customer = util.utf8(self.customer)
+            customer = util.utf8(self.customer)
 
             base = Customer.class_url()
-            owner_extn = urllib.quote_plus(self.customer)
+            owner_extn = urllib.quote_plus(customer)
             class_base = "sources"
 
         elif (hasattr(self, 'recipient')):
-            self.recipient = util.utf8(self.recipient)
+            recipient = util.utf8(self.recipient)
 
             base = Recipient.class_url()
-            owner_extn = urllib.quote_plus(self.recipient)
+            owner_extn = urllib.quote_plus(recipient)
             class_base = "cards"
 
         elif (hasattr(self, 'account')):
-            self.account = util.utf8(self.account)
+            account = util.utf8(self.account)
 
             base = Account.class_url()
-            owner_extn = urllib.quote_plus(self.account)
+            owner_extn = urllib.quote_plus(account)
             class_base = "external_accounts"
 
         else:
@@ -439,17 +439,17 @@ class BankAccount(UpdateableAPIResource, DeletableAPIResource):
         self.id = util.utf8(self.id)
         extn = urllib.quote_plus(self.id)
         if (hasattr(self, 'customer')):
-            self.customer = util.utf8(self.customer)
+            customer = util.utf8(self.customer)
 
             base = Customer.class_url()
-            owner_extn = urllib.quote_plus(self.customer)
+            owner_extn = urllib.quote_plus(customer)
             class_base = "sources"
 
         elif (hasattr(self, 'account')):
-            self.account = util.utf8(self.account)
+            account = util.utf8(self.account)
 
             base = Account.class_url()
-            owner_extn = urllib.quote_plus(self.account)
+            owner_extn = urllib.quote_plus(account)
             class_base = "external_accounts"
 
         else:


### PR DESCRIPTION
fix accidental 'self' reference causing mutation side effect on methods meant to be a functions

was causing `InvalidRequestError: A parameter provided in the URL (customer) was repeated as a GET or POST parameter. You can only provide this information as a portion of the URL.`

fixes: https://github.com/stripe/stripe-python/issues/151
