### PR TITLE
api endpoint for subscription is updated.

### DIFF
--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -552,7 +552,7 @@ class Customer(CreateableAPIResource, UpdateableAPIResource,
     def update_subscription(self, idempotency_key=None, **params):
         requestor = api_requestor.APIRequestor(self.api_key,
                                                account=self.stripe_account)
-        url = self.instance_url() + '/subscription'
+        url = self.instance_url() + '/subscriptions'
         headers = populate_headers(idempotency_key)
         response, api_key = requestor.request('post', url, params, headers)
         self.refresh_from({'subscription': response}, api_key, True)
@@ -561,7 +561,7 @@ class Customer(CreateableAPIResource, UpdateableAPIResource,
     def cancel_subscription(self, idempotency_key=None, **params):
         requestor = api_requestor.APIRequestor(self.api_key,
                                                account=self.stripe_account)
-        url = self.instance_url() + '/subscription'
+        url = self.instance_url() + '/subscriptions'
         headers = populate_headers(idempotency_key)
         response, api_key = requestor.request('delete', url, params, headers)
         self.refresh_from({'subscription': response}, api_key, True)

--- a/stripe/test/test_resources.py
+++ b/stripe/test/test_resources.py
@@ -1295,7 +1295,7 @@ class CustomerPlanTest(StripeResourceTest):
 
         self.requestor_mock.request.assert_called_with(
             'post',
-            '/v1/customers/cus_legacy_sub_update/subscription',
+            '/v1/customers/cus_legacy_sub_update/subscriptions',
             {
                 'plan': DUMMY_PLAN['id'],
             },
@@ -1308,7 +1308,7 @@ class CustomerPlanTest(StripeResourceTest):
 
         self.requestor_mock.request.assert_called_with(
             'delete',
-            '/v1/customers/cus_legacy_sub_delete/subscription',
+            '/v1/customers/cus_legacy_sub_delete/subscriptions',
             {},
             None
         )


### PR DESCRIPTION
While I test multiple subscription for a customer, I found that subscription endpoint is not correct, so I'm updating it. 
Please refer this document - https://stripe.com/docs/api/curl#create_subscription