### PR TITLE
Add LICENSE to PyPI source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include VERSION stripe/data/ca-certificates.crt LONG_DESCRIPTION.rst
+include LICENSE VERSION stripe/data/ca-certificates.crt LONG_DESCRIPTION.rst


### PR DESCRIPTION
Allows downstream packagers and porters to include the LICENSE in resulting OS packages