### PR TITLE
Allow unicode error messages in `StripeError`

### DIFF
--- a/stripe/error.py
+++ b/stripe/error.py
@@ -1,4 +1,7 @@
 # Exceptions
+import sys
+
+
 class StripeError(Exception):
 
     def __init__(self, message=None, http_body=None, http_status=None,
@@ -25,8 +28,10 @@ class StripeError(Exception):
         else:
             return self._message
 
-    def __str__(self):
-        return unicode(self).encode('utf-8')
+    if sys.version_info > (3, 0):
+        __str__ = lambda self: self.__unicode__()
+    else:
+        __str__ = lambda self: unicode(self).encode('utf-8')
 
 
 class APIError(StripeError):

--- a/stripe/error.py
+++ b/stripe/error.py
@@ -12,18 +12,21 @@ class StripeError(Exception):
                 http_body = ('<Could not decode body as utf-8. '
                              'Please report to support@stripe.com>')
 
+        self._message = message
         self.http_body = http_body
         self.http_status = http_status
         self.json_body = json_body
         self.headers = headers or {}
         self.request_id = self.headers.get('request-id', None)
 
-    def __str__(self):
-        msg = super(StripeError, self).__str__()
+    def __unicode__(self):
         if self.request_id is not None:
-            return "Request {0}: {1}".format(self.request_id, msg)
+            return u"Request {0}: {1}".format(self.request_id, self._message)
         else:
-            return msg
+            return self._message
+
+    def __str__(self):
+        return unicode(self).encode('utf-8')
 
 
 class APIError(StripeError):

--- a/stripe/test/test_error.py
+++ b/stripe/test/test_error.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+import unittest2
+
+from stripe import StripeError
+from stripe.test.helper import StripeUnitTestCase
+
+
+class StripeErrorTests(StripeUnitTestCase):
+
+    def test_bytestring(self):
+        err = StripeError('error')
+        assert str(err) == 'error'
+
+    def test_bytestring_with_request_id(self):
+        err = StripeError('error', headers={'request-id': '123'})
+        assert str(err) == 'Request 123: error'
+
+    def test_unicode(self):
+        err = StripeError(u'öre')
+        assert unicode(err) == u'öre'
+
+    def test_unicode_with_request_id(self):
+        err = StripeError(u'öre', headers={'request-id': '123'})
+        assert unicode(err) == u'Request 123: öre'
+
+
+if __name__ == '__main__':
+    unittest2.main()

--- a/stripe/test/test_error.py
+++ b/stripe/test/test_error.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import sys
+
 import unittest2
 
 from stripe import StripeError
@@ -7,21 +9,21 @@ from stripe.test.helper import StripeUnitTestCase
 
 class StripeErrorTests(StripeUnitTestCase):
 
-    def test_bytestring(self):
-        err = StripeError('error')
-        assert str(err) == 'error'
-
-    def test_bytestring_with_request_id(self):
-        err = StripeError('error', headers={'request-id': '123'})
-        assert str(err) == 'Request 123: error'
-
-    def test_unicode(self):
+    def test_formatting(self):
         err = StripeError(u'öre')
-        assert unicode(err) == u'öre'
+        if sys.version_info > (3, 0):
+            assert str(err) == u'öre'
+        else:
+            assert str(err) == '\xc3\xb6re'
+            assert unicode(err) == u'öre'
 
-    def test_unicode_with_request_id(self):
+    def test_formatting_with_request_id(self):
         err = StripeError(u'öre', headers={'request-id': '123'})
-        assert unicode(err) == u'Request 123: öre'
+        if sys.version_info > (3, 0):
+            assert str(err) == u'Request 123: öre'
+        else:
+            assert str(err) == 'Request 123: \xc3\xb6re'
+            assert unicode(err) == u'Request 123: öre'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR fixes https://github.com/stripe/stripe-python/issues/165.