### PR TITLE
Rename pycurl environment flag to sensible value.

### DIFF
--- a/stripe/test/test_integration.py
+++ b/stripe/test/test_integration.py
@@ -107,8 +107,8 @@ class UrlfetchFunctionalTests(FunctionalTests):
 
 class PycurlFunctionalTests(FunctionalTests):
     def setUp(self):
-        if not os.environ.get('SKIP_PYCURL_TESTS'):
-            self.skipTest('Pycurl skipped as SKIP_PYCURL_TESTS is set')
+        if not os.environ.get('STRIPE_TEST_PYCURL'):
+            self.skipTest('Pycurl skipped as STRIPE_TEST_PYCURL is not set')
         if sys.version_info >= (3, 0):
             self.skipTest('Pycurl is not supported in Python 3')
         else:

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =
     python setup.py clean --all
     python -W always setup.py test {posargs}
 setenv =
-    SKIP_PYCURL_TESTS = true
+    STRIPE_TEST_PYCURL = true
 
 [testenv:py27]
 deps =


### PR DESCRIPTION
If STRIPE_PYCURL_TEST is set, we'll execute the tests.