### PR TITLE
Add bank account verification.

### DIFF
--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -455,7 +455,16 @@ class Card(UpdateableAPIResource, DeletableAPIResource):
             "account.external_accounts.retrieve('card_id') instead.")
 
 
-class BankAccount(UpdateableAPIResource, DeletableAPIResource):
+class VerifyMixin(object):
+
+    def verify(self, idempotency_key=None, **params):
+        url = self.instance_url() + '/verify'
+        headers = populate_headers(idempotency_key)
+        self.refresh_from(self.request('post', url, params, headers))
+        return self
+
+
+class BankAccount(UpdateableAPIResource, DeletableAPIResource, VerifyMixin):
 
     def instance_url(self):
         self.id = util.utf8(self.id)

--- a/stripe/test/test_resources.py
+++ b/stripe/test/test_resources.py
@@ -1186,6 +1186,20 @@ class CustomerTest(StripeResourceTest):
             None
         )
 
+    def test_customer_verify_bank_account(self):
+        source = stripe.BankAccount.construct_from({
+            'customer': 'cus_verify_source',
+            'id': 'ba_verify_source',
+        }, 'api_key')
+        source.verify()
+
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/v1/customers/cus_verify_source/sources/ba_verify_source/verify',
+            {},
+            None
+        )
+
 
 class TransferTest(StripeResourceTest):
 


### PR DESCRIPTION
You can now verify a bank account. Let the API tell us if a source can't be verified.