### PR TITLE
Configurable default HTTP client

### DIFF
--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -12,6 +12,7 @@ api_base = 'https://api.stripe.com'
 upload_api_base = 'https://uploads.stripe.com'
 api_version = None
 verify_ssl_certs = True
+default_http_client = None
 
 # Resource
 from stripe.resource import (  # noqa

--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -71,10 +71,10 @@ class APIRequestor(object):
         self.api_key = key
         self.stripe_account = account
 
-        from stripe import verify_ssl_certs
+        from stripe import verify_ssl_certs as verify
 
-        self._client = client or http_client.new_default_http_client(
-            verify_ssl_certs=verify_ssl_certs)
+        self._client = client or stripe.default_http_client or \
+            http_client.new_default_http_client(verify_ssl_certs=verify)
 
     @classmethod
     def api_url(cls, url=''):

--- a/stripe/http_client.py
+++ b/stripe/http_client.py
@@ -144,6 +144,12 @@ class RequestsClient(HTTPClient):
 class UrlFetchClient(HTTPClient):
     name = 'urlfetch'
 
+    def __init__(self, verify_ssl_certs=True, deadline=55):
+        self._verify_ssl_certs = verify_ssl_certs
+        # GAE requests time out after 60 seconds, so make sure to default
+        # to 55 seconds to allow for a slow Stripe
+        self._deadline = deadline
+
     def request(self, method, url, headers, post_data=None):
         try:
             result = urlfetch.fetch(
@@ -154,9 +160,7 @@ class UrlFetchClient(HTTPClient):
                 # However, that's ok because the CA bundle they use recognizes
                 # api.stripe.com.
                 validate_certificate=self._verify_ssl_certs,
-                # GAE requests time out after 60 seconds, so make sure we leave
-                # some time for the application to handle a slow Stripe
-                deadline=55,
+                deadline=self._deadline,
                 payload=post_data
             )
         except urlfetch.Error, e:


### PR DESCRIPTION
You can now override the HTTP client that Stripe uses with your own client. Note that this client must implement the `HTTPClient` interface defined in `http_client.py`.