### PR TITLE
Add legacy rate limit error handling

### DIFF
--- a/stripe/test/test_requestor.py
+++ b/stripe/test/test_requestor.py
@@ -360,6 +360,16 @@ class APIRequestorRequestTests(StripeUnitTestCase):
                           self.requestor.request,
                           'get', self.valid_path, {})
 
+    def test_old_rate_limit_error(self):
+        """
+        Tests legacy rate limit error pre-2015-09-18
+        """
+        self.mock_response('{"error": {"code":"rate_limit"}}', 400)
+
+        self.assertRaises(stripe.error.RateLimitError,
+                          self.requestor.request,
+                          'get', self.valid_path, {})
+
     def test_server_error(self):
         self.mock_response('{"error": {}}', 500)
 


### PR DESCRIPTION
The stripe api pre-2015-09-18 returned rate limit errors as 400 with code 'rate_limit'. This change adds support for that legacy behavior.