### PR TITLE
Cleaned test documentation and fixes testing for Python 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Note that PyCurl doesn't currently play nicely with our tox configuration.  Tox 
 
 ### Running specific tests
 
-You can specify a module, TestCase or single test to run by passing it as an argument to tox.  For example, to run only the `test_save` test of the `UpdateableAPIResourceTests` case from the `test_resources` module on Python 2.7:
+You can specify a module, TestCase or single test to run by passing it as an argument to tox.  For example, to run only the `test_save` test of the `UpdateableAPIResourceTests` case from the `test.resources` module on Python 2.7:
 
-    tox -e py27 -- --test-suite stripe.test.test_resources.UpdateableAPIResourceTests.test_save
+    tox -e py27 -- --test-suite stripe.test.resources.UpdateableAPIResourceTests.test_save
 
 ### Linting
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     author='Stripe',
     author_email='support@stripe.com',
     url='https://github.com/stripe/stripe-python',
-    packages=['stripe', 'stripe.test'],
+    packages=['stripe', 'stripe.test', 'stripe.test.resources'],
     package_data={'stripe': ['data/ca-certificates.crt']},
     install_requires=install_requires,
     test_suite='stripe.test.all',


### PR DESCRIPTION
* Command to execute tests in the README reflected old directory structure.
* test.resources module was ignored in Python 3.x such that not all tests were executed, see #188.

