### PR TITLE
Handle the case where error messages are None.

### DIFF
--- a/stripe/error.py
+++ b/stripe/error.py
@@ -24,7 +24,8 @@ class StripeError(Exception):
 
     def __unicode__(self):
         if self.request_id is not None:
-            return u"Request {0}: {1}".format(self.request_id, self._message)
+            msg = self._message or "<empty message>"
+            return u"Request {0}: {1}".format(self.request_id, msg)
         else:
             return self._message
 

--- a/stripe/test/test_error.py
+++ b/stripe/test/test_error.py
@@ -25,6 +25,13 @@ class StripeErrorTests(StripeUnitTestCase):
             assert str(err) == 'Request 123: \xc3\xb6re'
             assert unicode(err) == u'Request 123: öre'
 
+    def test_formatting_with_none(self):
+        err = StripeError(None, headers={'request-id': '123'})
+        if sys.version_info > (3, 0):
+            assert str(err) == u'Request 123: <empty message>'
+        else:
+            assert str(err) == 'Request 123: <empty message>'
+            assert unicode(err) == u'Request 123: <empty message>'
 
 if __name__ == '__main__':
     unittest2.main()


### PR DESCRIPTION
Previously this would have resulted in a TypeError.

Fix #194 