### PR TITLE
Fixed flake8 errors

### DIFF
--- a/stripe/error.py
+++ b/stripe/error.py
@@ -30,9 +30,11 @@ class StripeError(Exception):
             return self._message
 
     if sys.version_info > (3, 0):
-        __str__ = lambda self: self.__unicode__()
+        def __str__(self):
+            return self.__unicode__()
     else:
-        __str__ = lambda self: unicode(self).encode('utf-8')
+        def __str__(self):
+            return unicode(self).encode('utf-8')
 
 
 class APIError(StripeError):


### PR DESCRIPTION
PR #196 introduced two flake8 errors:

    stripe/error.py:33:9: E731 do not assign a lambda expression, use a def
    stripe/error.py:35:9: E731 do not assign a lambda expression, use a def

This PR changes the code to be flake8-compliant.