### PR TITLE
Use latest mock version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     package_data={'stripe': ['data/ca-certificates.crt']},
     install_requires=install_requires,
     test_suite='stripe.test.all',
-    tests_require=['unittest2', 'mock == 1.0.1'],
+    tests_require=['unittest2', 'mock'],
     use_2to3=True,
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/stripe/test/resources/test_refunds.py
+++ b/stripe/test/resources/test_refunds.py
@@ -95,7 +95,14 @@ class ChargeRefundTest(StripeResourceTest):
         charge.refunds.data[0].description = 'bar'
         charge.save()
 
-        self.requestor_mock.request.assert_not_called()
+        # Note: ideally, we'd want the library to NOT issue requests in this
+        # case (i.e. the assert should actually be `assert_not_called()`).
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/v1/charges/ch_nested_update',
+            {'refunds': {'has_more': True}},
+            None
+        )
 
     def test_fetch_refund(self):
         charge = stripe.Charge.construct_from({

--- a/stripe/test/resources/test_updateable.py
+++ b/stripe/test/resources/test_updateable.py
@@ -105,7 +105,15 @@ class UpdateableAPIResourceTests(StripeApiTestCase):
         }, 'mykey')
 
         self.assertTrue(acct is acct.save())
-        self.requestor_mock.request.assert_not_called()
+
+        # Note: ideally, we'd want the library to NOT issue requests in this
+        # case (i.e. the assert should actually be `assert_not_called()`).
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/v1/myupdateables/myid',
+            {'metadata': {}},
+            None
+        )
 
     def test_replace_nested_object(self):
         acct = MyUpdateable.construct_from({


### PR DESCRIPTION
Fixes #189 and #205.

This PR updates `setup.py` to use the latest mock version.

It also updates two tests (`ChargeRefundTest.test_non_recursive_save()` and `UpdateableAPIResourceTests.test_save_nothing()`) to reflect the current behavior of the library (see #205 for more context on this).

r? @brandur
cc @stripe/api-libraries 