### PR TITLE
Add bindings for account.reject

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Note that PyCurl doesn't currently play nicely with our tox configuration.  Tox 
 
 You can specify a module, TestCase or single test to run by passing it as an argument to tox.  For example, to run only the `test_save` test of the `UpdateableAPIResourceTests` case from the `test.resources` module on Python 2.7:
 
-    tox -e py27 -- --test-suite stripe.test.resources.UpdateableAPIResourceTests.test_save
+    tox -e py27 -- --test-suite stripe.test.resources.test_updateable.UpdateableAPIResourceTests.test_save
 
 ### Linting
 

--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -450,9 +450,8 @@ class Account(CreateableAPIResource, ListableAPIResource,
     def reject(self, reason=None, idempotency_key=None):
         url = self.instance_url() + '/reject'
         headers = populate_headers(idempotency_key)
-        params = dict(reason=reason)
         self.refresh_from(
-            self.request('post', url, params, headers)
+            self.request('post', url, {"reason": reason}, headers)
         )
         return self
 

--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -447,6 +447,15 @@ class Account(CreateableAPIResource, ListableAPIResource,
         extn = urllib.quote_plus(id)
         return "%s/%s" % (base, extn)
 
+    def reject(self, reason=None, idempotency_key=None):
+        url = self.instance_url() + '/reject'
+        headers = populate_headers(idempotency_key)
+        params = dict(reason=reason)
+        self.refresh_from(
+            self.request('post', url, params, headers)
+        )
+        return self
+
 
 class Balance(SingletonAPIResource):
     pass

--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -450,8 +450,12 @@ class Account(CreateableAPIResource, ListableAPIResource,
     def reject(self, reason=None, idempotency_key=None):
         url = self.instance_url() + '/reject'
         headers = populate_headers(idempotency_key)
+        if reason:
+            params = {"reason": reason}
+        else:
+            params = {}
         self.refresh_from(
-            self.request('post', url, {"reason": reason}, headers)
+            self.request('post', url, params, headers)
         )
         return self
 

--- a/stripe/test/resources/test_accounts.py
+++ b/stripe/test/resources/test_accounts.py
@@ -80,6 +80,29 @@ class AccountTest(StripeResourceTest):
             None
         )
 
+    def test_reject_account(self):
+        self.mock_response({
+            'id': 'acct_reject',
+            'verification': {
+                'disabled_reason': 'rejected.fraud'
+            },
+        })
+
+        obj = stripe.Account.construct_from({
+            'id': 'acct_reject'
+        }, 'mykey')
+
+        self.assertTrue(obj is obj.reject(reason='fraud'))
+        self.assertEqual('rejected.fraud', obj.verification['disabled_reason'])
+        self.assertEqual('acct_reject', obj.id)
+
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/v1/accounts/acct_reject/reject',
+            {'reason': 'fraud'},
+            None
+        )
+
     def test_verify_additional_owner(self):
         acct = stripe.Account.construct_from({
             'id': 'acct_update',

--- a/stripe/test/resources/test_accounts.py
+++ b/stripe/test/resources/test_accounts.py
@@ -103,6 +103,29 @@ class AccountTest(StripeResourceTest):
             None
         )
 
+    def test_reject_account_without_reason(self):
+        self.mock_response({
+            'id': 'acct_reject',
+            'verification': {
+                'disabled_reason': 'rejected.fraud'
+            },
+        })
+
+        obj = stripe.Account.construct_from({
+            'id': 'acct_reject'
+        }, 'mykey')
+
+        self.assertTrue(obj is obj.reject())
+        self.assertEqual('rejected.fraud', obj.verification['disabled_reason'])
+        self.assertEqual('acct_reject', obj.id)
+
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/v1/accounts/acct_reject/reject',
+            {},
+            None
+        )
+
     def test_verify_additional_owner(self):
         acct = stripe.Account.construct_from({
             'id': 'acct_update',


### PR DESCRIPTION
Adds bindings for the [Account.reject](https://stripe.com/docs/api#reject_account) endpoint.