### PR TITLE
Don't check for request ID on invalid credentials

### DIFF
--- a/stripe/test/test_integration.py
+++ b/stripe/test/test_integration.py
@@ -129,7 +129,9 @@ class AuthenticationErrorTest(StripeTestCase):
             self.assertEqual(401, e.http_status)
             self.assertTrue(isinstance(e.http_body, basestring))
             self.assertTrue(isinstance(e.json_body, dict))
-            self.assertTrue(e.request_id.startswith('req_'))
+            # Note that an invalid API key bypasses many of the standard
+            # facilities in the API server so currently no Request ID is
+            # returned.
         finally:
             stripe.api_key = key
 


### PR DESCRIPTION
It seems that some middleware tweaks inside the API server have resulted
in a request ID no longer being returned when invalid credentials are
passed in. This patch removes the check given that it's currently
failing our test suite.

~~/cc @kyleconroy Would you mind reviewing this one? Thanks!~~