### PR TITLE
Fix ASCII/Unicode handling in Python 2 and 3

### DIFF
--- a/stripe/multipart_data_generator.py
+++ b/stripe/multipart_data_generator.py
@@ -18,8 +18,11 @@ class MultipartDataGenerator(object):
             self._write(self.param_header())
             self._write(self.line_break)
             if hasattr(value, 'read'):
-                self._write("Content-Disposition: form-data; name=\"%s\"; "
-                            "filename=\"%s\"" % (key, value.name))
+                self._write("Content-Disposition: form-data; name=\"")
+                self._write(key)
+                self._write("\"; filename=\"")
+                self._write(value.name)
+                self._write("\"")
                 self._write(self.line_break)
                 self._write("Content-Type: application/octet-stream")
                 self._write(self.line_break)
@@ -27,8 +30,9 @@ class MultipartDataGenerator(object):
 
                 self._write_file(value)
             else:
-                self._write("Content-Disposition: form-data; name=\"%s\"" %
-                            (key,))
+                self._write("Content-Disposition: form-data; name=\"")
+                self._write(key)
+                self._write("\"")
                 self._write(self.line_break)
                 self._write(self.line_break)
                 self._write(value)
@@ -44,10 +48,22 @@ class MultipartDataGenerator(object):
         return self.data.getvalue()
 
     def _write(self, value):
-        if sys.version_info < (3, 0):
-            self.data.write(value)
+        if sys.version_info < (3,):
+            binary_type = str
+            text_type = unicode
         else:
-            self.data.write(bytes(value, 'utf-8'))
+            binary_type = bytes
+            text_type = str
+
+        if isinstance(value, binary_type):
+            array = bytearray(value)
+        elif isinstance(value, text_type):
+            array = bytearray(value, encoding='utf-8')
+        else:
+            raise TypeError("unexpected type: {value_type}"
+                            .format(value_type=type(value)))
+
+        self.data.write(array)
 
     def _write_file(self, f):
         while True:

--- a/stripe/test/test_multipart_data_generator.py
+++ b/stripe/test/test_multipart_data_generator.py
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 import re
 import sys
 
@@ -7,34 +9,44 @@ from stripe.test.helper import StripeTestCase
 
 class MultipartDataGeneratorTests(StripeTestCase):
 
-    def test_generate_simple_multipart_data(self):
-        with open(__file__) as test_file:
-            params = {
-                "key1": "value1",
-                "key2": "value2",
-                "key3": test_file
-            }
-            generator = MultipartDataGenerator()
-            generator.add_params(params)
-            post_data = generator.get_post_data()
+    def run_test_multipart_data_with_file(self, test_file):
+        params = {
+            "key1": b"ASCII value",
+            "key2": u"Üñìçôdé value",
+            "key3": test_file
+        }
+        generator = MultipartDataGenerator()
+        generator.add_params(params)
+        http_body = generator.get_post_data()
 
-            if sys.version_info < (3, 0):
-                http_body = "".join([line for line in post_data])
-            else:
-                byte_array = bytearray([i for i in post_data])
-                http_body = byte_array.decode('utf-8')
+        if sys.version_info >= (3,):
+            http_body = http_body.decode('utf-8')
 
-            self.assertTrue(re.search(
-                r"Content-Disposition: form-data; name=\"key1\"", http_body))
-            self.assertTrue(re.search(
-                r"Content-Disposition: form-data; name=\"key2\"", http_body))
-            self.assertTrue(re.search(
-                r"Content-Disposition: form-data; name=\"key3\"; "
-                r"filename=\".+\"",
-                http_body))
-            self.assertTrue(re.search(
-                r"Content-Type: application/octet-stream", http_body))
+        self.assertTrue(re.search(
+            r"Content-Disposition: form-data; name=\"key1\"", http_body))
+        self.assertTrue(re.search(r"ASCII value", http_body))
+        self.assertTrue(re.search(
+            r"Content-Disposition: form-data; name=\"key2\"", http_body))
+        self.assertTrue(re.search(r"Üñìçôdé value", http_body))
+        self.assertTrue(re.search(
+            r"Content-Disposition: form-data; name=\"key3\"; "
+            r"filename=\".+\"",
+            http_body))
+        self.assertTrue(re.search(
+            r"Content-Type: application/octet-stream", http_body))
 
-            test_file.seek(0)
-            file_contents = test_file.read()
-            self.assertNotEqual(-1, http_body.find(file_contents))
+        test_file.seek(0)
+        file_contents = test_file.read()
+
+        if sys.version_info >= (3,) and isinstance(file_contents, bytes):
+            file_contents = file_contents.decode('utf-8')
+
+        self.assertNotEqual(-1, http_body.find(file_contents))
+
+    def test_multipart_data_file_text(self):
+        with open(__file__, mode='r') as test_file:
+            self.run_test_multipart_data_with_file(test_file)
+
+    def test_multipart_data_file_binary(self):
+        with open(__file__, mode='rb') as test_file:
+            self.run_test_multipart_data_with_file(test_file)


### PR DESCRIPTION
Fixes #217.

This PR ensures that `MultipartDataGenerator` can handle keys and values of all encodings in both Python 2 and 3.
