### PR TITLE
Persist parameters with auto_paging_iter()

### DIFF
--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -393,7 +393,10 @@ class ListableAPIResource(APIResource):
         requestor = api_requestor.APIRequestor(api_key, account=stripe_account)
         url = cls.class_url()
         response, api_key = requestor.request('get', url, params)
-        return convert_to_stripe_object(response, api_key, stripe_account)
+        stripe_object = convert_to_stripe_object(response, api_key,
+                                                 stripe_account)
+        stripe_object._retrieve_params = params
+        return stripe_object
 
 
 class CreateableAPIResource(APIResource):

--- a/stripe/test/resources/test_listable.py
+++ b/stripe/test/resources/test_listable.py
@@ -7,23 +7,29 @@ from stripe.test.helper import (
 class ListableAPIResourceTests(StripeApiTestCase):
 
     def test_all(self):
-        self.mock_response([
-            {
-                'object': 'charge',
-                'name': 'jose',
-            },
-            {
-                'object': 'charge',
-                'name': 'curly',
-            }
-        ])
+        self.mock_response({
+            'object': 'list',
+            'data': [
+                {
+                    'object': 'charge',
+                    'name': 'jose',
+                },
+                {
+                    'object': 'charge',
+                    'name': 'curly',
+                }
+            ],
+            'url': '/v1/charges',
+            'has_more': False,
+        })
 
-        res = MyListable.all()
+        res = MyListable.list()
 
         self.requestor_mock.request.assert_called_with(
             'get', '/v1/mylistables', {})
 
-        self.assertEqual(2, len(res))
-        self.assertTrue(all(isinstance(obj, stripe.Charge) for obj in res))
-        self.assertEqual('jose', res[0].name)
-        self.assertEqual('curly', res[1].name)
+        self.assertEqual(2, len(res.data))
+        self.assertTrue(all(isinstance(obj, stripe.Charge)
+                            for obj in res.data))
+        self.assertEqual('jose', res.data[0].name)
+        self.assertEqual('curly', res.data[1].name)


### PR DESCRIPTION
This PR fixes #221: `auto_paging_iter()` should now persist parameters.

r? @brandur 
cc @stripe/api-libraries 