### PR TITLE
Fixes FileUpload.list()

### DIFF
--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -390,7 +390,9 @@ class ListableAPIResource(APIResource):
     @classmethod
     def list(cls, api_key=None, idempotency_key=None,
              stripe_account=None, **params):
-        requestor = api_requestor.APIRequestor(api_key, account=stripe_account)
+        requestor = api_requestor.APIRequestor(api_key,
+                                               api_base=cls.api_base(),
+                                               account=stripe_account)
         url = cls.class_url()
         response, api_key = requestor.request('get', url, params)
         stripe_object = convert_to_stripe_object(response, api_key,

--- a/stripe/test/resources/test_file_uploads.py
+++ b/stripe/test/resources/test_file_uploads.py
@@ -32,7 +32,7 @@ class FileUploadTest(StripeResourceTest):
         )
 
     def test_list_file_uploads(self):
-        stripe.FileUpload.all()
+        stripe.FileUpload.list()
         self.requestor_mock.request.assert_called_with(
             'get',
             '/v1/files',


### PR DESCRIPTION
`FileUpload.list()` (or `.all()`)  fails because it tries to hit `https://api.stripe.com` instead of `https://uploads.stripe.com`. This PR fixes that.

r? @brandur 
cc @stripe/api-libraries 
