### PR TITLE
Fix deprecation warnings

### DIFF
--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -635,17 +635,17 @@ class Customer(CreateableAPIResource, UpdateableAPIResource,
 
     def invoices(self, **params):
         params['customer'] = self.id
-        invoices = Invoice.all(self.api_key, **params)
+        invoices = Invoice.list(self.api_key, **params)
         return invoices
 
     def invoice_items(self, **params):
         params['customer'] = self.id
-        iis = InvoiceItem.all(self.api_key, **params)
+        iis = InvoiceItem.list(self.api_key, **params)
         return iis
 
     def charges(self, **params):
         params['customer'] = self.id
-        charges = Charge.all(self.api_key, **params)
+        charges = Charge.list(self.api_key, **params)
         return charges
 
     def update_subscription(self, idempotency_key=None, **params):
@@ -784,7 +784,7 @@ class Recipient(CreateableAPIResource, UpdateableAPIResource,
 
     def transfers(self, **params):
         params['recipient'] = self.id
-        transfers = Transfer.all(self.api_key, **params)
+        transfers = Transfer.list(self.api_key, **params)
         return transfers
 
 

--- a/stripe/test/resources/test_accounts.py
+++ b/stripe/test/resources/test_accounts.py
@@ -24,7 +24,7 @@ class AccountTest(StripeResourceTest):
         )
 
     def test_list_accounts(self):
-        stripe.Account.all()
+        stripe.Account.list()
         self.requestor_mock.request.assert_called_with(
             'get',
             '/v1/accounts',

--- a/stripe/test/resources/test_application_fees.py
+++ b/stripe/test/resources/test_application_fees.py
@@ -5,7 +5,7 @@ from stripe.test.helper import StripeResourceTest
 class ApplicationFeeTest(StripeResourceTest):
 
     def test_list_application_fees(self):
-        stripe.ApplicationFee.all()
+        stripe.ApplicationFee.list()
         self.requestor_mock.request.assert_called_with(
             'get',
             '/v1/application_fees',
@@ -42,7 +42,7 @@ class ApplicationFeeRefundTest(StripeResourceTest):
             }
         }, 'api_key')
 
-        fee.refunds.all()
+        fee.refunds.list()
 
         self.requestor_mock.request.assert_called_with(
             'get',

--- a/stripe/test/resources/test_balances.py
+++ b/stripe/test/resources/test_balances.py
@@ -18,7 +18,7 @@ class BalanceTest(StripeResourceTest):
 class BalanceTransactionTest(StripeResourceTest):
 
     def test_list_balance_transactions(self):
-        stripe.BalanceTransaction.all()
+        stripe.BalanceTransaction.list()
         self.requestor_mock.request.assert_called_with(
             'get',
             '/v1/balance/history',

--- a/stripe/test/resources/test_bitcoin.py
+++ b/stripe/test/resources/test_bitcoin.py
@@ -14,7 +14,7 @@ class BitcoinReceiverTest(StripeResourceTest):
         )
 
     def test_list_receivers(self):
-        stripe.BitcoinReceiver.all()
+        stripe.BitcoinReceiver.list()
         self.requestor_mock.request.assert_called_with(
             'get',
             '/v1/bitcoin/receivers',
@@ -102,7 +102,7 @@ class BitcoinReceiverTest(StripeResourceTest):
             }
         }, 'api_key')
 
-        receiver.transactions.all()
+        receiver.transactions.list()
         self.requestor_mock.request.assert_called_with(
             'get',
             '/v1/bitcoin/receivers/btcrcv_foo/transactions',

--- a/stripe/test/resources/test_charges.py
+++ b/stripe/test/resources/test_charges.py
@@ -6,8 +6,8 @@ from stripe.test.helper import (
 
 class ChargeTest(StripeResourceTest):
 
-    def test_charge_list_all(self):
-        stripe.Charge.all(created={'lt': NOW})
+    def test_charge_list(self):
+        stripe.Charge.list(created={'lt': NOW})
 
         self.requestor_mock.request.assert_called_with(
             'get',
@@ -17,7 +17,7 @@ class ChargeTest(StripeResourceTest):
             }
         )
 
-    def test_charge_list_create(self):
+    def test_charge_create(self):
         stripe.Charge.create(idempotency_key='foo', **DUMMY_CHARGE)
 
         self.requestor_mock.request.assert_called_with(
@@ -27,7 +27,7 @@ class ChargeTest(StripeResourceTest):
             {'Idempotency-Key': 'foo'},
         )
 
-    def test_charge_list_retrieve(self):
+    def test_charge_retrieve(self):
         stripe.Charge.retrieve('ch_test_id')
 
         self.requestor_mock.request.assert_called_with(

--- a/stripe/test/resources/test_disputes.py
+++ b/stripe/test/resources/test_disputes.py
@@ -7,7 +7,7 @@ from stripe.test.helper import (
 class DisputeTest(StripeResourceTest):
 
     def test_list_all_disputes(self):
-        stripe.Dispute.all(created={'lt': NOW})
+        stripe.Dispute.list(created={'lt': NOW})
 
         self.requestor_mock.request.assert_called_with(
             'get',

--- a/stripe/test/resources/test_list_object.py
+++ b/stripe/test/resources/test_list_object.py
@@ -30,8 +30,8 @@ class ListObjectTests(StripeApiTestCase):
 
         self.assertEqual(['foo'], seen)
 
-    def test_all(self):
-        res = self.lo.all(myparam='you')
+    def test_list(self):
+        res = self.lo.list(myparam='you')
 
         self.requestor_mock.request.assert_called_with(
             'get', '/my/path', {'myparam': 'you'}, None)

--- a/stripe/test/resources/test_recipients.py
+++ b/stripe/test/resources/test_recipients.py
@@ -7,7 +7,7 @@ from stripe.test.helper import (
 class RecipientTest(StripeResourceTest):
 
     def test_list_recipients(self):
-        stripe.Recipient.all()
+        stripe.Recipient.list()
         self.requestor_mock.request.assert_called_with(
             'get',
             '/v1/recipients',

--- a/stripe/test/resources/test_refunds.py
+++ b/stripe/test/resources/test_refunds.py
@@ -25,7 +25,7 @@ class RefundTest(StripeResourceTest):
         )
 
     def test_list_refunds(self):
-        stripe.Refund.all(limit=3, charge='ch_foo')
+        stripe.Refund.list(limit=3, charge='ch_foo')
 
         self.requestor_mock.request.assert_called_with(
             'get',
@@ -131,7 +131,7 @@ class ChargeRefundTest(StripeResourceTest):
             }
         }, 'api_key')
 
-        charge.refunds.all()
+        charge.refunds.list()
 
         self.requestor_mock.request.assert_called_with(
             'get',

--- a/stripe/test/resources/test_relay.py
+++ b/stripe/test/resources/test_relay.py
@@ -5,7 +5,7 @@ from stripe.test.helper import StripeResourceTest
 class ProductTest(StripeResourceTest):
 
     def test_list_products(self):
-        stripe.Product.all()
+        stripe.Product.list()
         self.requestor_mock.request.assert_called_with(
             'get',
             '/v1/products',
@@ -27,7 +27,7 @@ class ProductTest(StripeResourceTest):
 class SKUTest(StripeResourceTest):
 
     def test_list_skus(self):
-        stripe.SKU.all()
+        stripe.SKU.list()
         self.requestor_mock.request.assert_called_with(
             'get',
             '/v1/skus',
@@ -49,7 +49,7 @@ class SKUTest(StripeResourceTest):
 class OrderTest(StripeResourceTest):
 
     def test_list_orders(self):
-        stripe.Order.all()
+        stripe.Order.list()
         self.requestor_mock.request.assert_called_with(
             'get',
             '/v1/orders',

--- a/stripe/test/resources/test_reversals.py
+++ b/stripe/test/resources/test_reversals.py
@@ -31,7 +31,7 @@ class ReversalTest(StripeResourceTest):
             }
         }, 'api_key')
 
-        transfer.reversals.all()
+        transfer.reversals.list()
 
         self.requestor_mock.request.assert_called_with(
             'get',

--- a/stripe/test/resources/test_transfers.py
+++ b/stripe/test/resources/test_transfers.py
@@ -5,7 +5,7 @@ from stripe.test.helper import StripeResourceTest
 class TransferTest(StripeResourceTest):
 
     def test_list_transfers(self):
-        stripe.Transfer.all()
+        stripe.Transfer.list()
         self.requestor_mock.request.assert_called_with(
             'get',
             '/v1/transfers',

--- a/stripe/test/test_requestor.py
+++ b/stripe/test/test_requestor.py
@@ -403,7 +403,7 @@ class DefaultClientTests(unittest2.TestCase):
         hc.request = Mock(return_value=("{}", 200, {}))
 
         stripe.default_http_client = hc
-        stripe.Charge.all(limit=3)
+        stripe.Charge.list(limit=3)
 
         hc.request.assert_called_with(
             'get', 'https://api.stripe.com/v1/charges?limit=3', ANY, None)


### PR DESCRIPTION
This PR fixes deprecation warnings:
- updated `resource.py` to use `.list()` instead of `.all()` in some convenience methods
- updated a lot of tests to use `.list()` instead of `.all()` 
- updated a couple tests for legacy methods to catch the warnings and assert their presence

The test suite's output should now be much cleaner! :)