### PR TITLE
Add `modify` class method for updateable resources

### DIFF
--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -859,13 +859,22 @@ class ApplicationFee(ListableAPIResource):
 
 class ApplicationFeeRefund(UpdateableAPIResource):
 
-    def instance_url(self):
-        token = util.utf8(self.id)
-        fee = util.utf8(self.fee)
+    @classmethod
+    def _build_instance_url(cls, fee, sid):
+        fee = util.utf8(fee)
+        sid = util.utf8(sid)
         base = ApplicationFee.class_url()
         cust_extn = urllib.quote_plus(fee)
-        extn = urllib.quote_plus(token)
+        extn = urllib.quote_plus(sid)
         return "%s/%s/refunds/%s" % (base, cust_extn, extn)
+
+    @classmethod
+    def modify(cls, fee, sid, **params):
+        url = cls._build_instance_url(fee, sid)
+        return cls._modify(url, **params)
+
+    def instance_url(self):
+        return self._build_instance_url(self.fee, self.id)
 
     @classmethod
     def retrieve(cls, id, api_key=None, **params):

--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -417,6 +417,19 @@ class CreateableAPIResource(APIResource):
 
 class UpdateableAPIResource(APIResource):
 
+    @classmethod
+    def update_url(cls, sid):
+        return "%s/%s" % (cls.class_url(), urllib.quote_plus(util.utf8(sid)))
+
+    @classmethod
+    def modify(cls, sid, api_key=None, idempotency_key=None,
+               stripe_account=None, **params):
+        url = cls.update_url(sid)
+        requestor = api_requestor.APIRequestor(api_key, account=stripe_account)
+        headers = populate_headers(idempotency_key)
+        response, api_key = requestor.request('post', url, params, headers)
+        return convert_to_stripe_object(response, api_key, stripe_account)
+
     def save(self, idempotency_key=None):
         updated_params = self.serialize(None)
         headers = populate_headers(idempotency_key)

--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -466,13 +466,13 @@ class Account(CreateableAPIResource, ListableAPIResource,
     def _build_instance_url(cls, sid):
         if not sid:
             return "/v1/account"
-        sid = util.utf8(id)
+        sid = util.utf8(sid)
         base = cls.class_url()
-        extn = urllib.quote_plus(id)
+        extn = urllib.quote_plus(sid)
         return "%s/%s" % (base, extn)
 
     def instance_url(self):
-        self._build_instance_url(self.get('id'))
+        return self._build_instance_url(self.get('id'))
 
     def reject(self, reason=None, idempotency_key=None):
         url = self.instance_url() + '/reject'

--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -501,7 +501,7 @@ class AlipayAccount(UpdateableAPIResource, DeletableAPIResource):
         return "%s/%s/sources/%s" % (base, owner_extn, extn)
 
     def instance_url(self):
-        self._build_instance_url(self.customer, self.id)
+        return self._build_instance_url(self.customer, self.id)
 
     @classmethod
     def modify(cls, customer, id, **params):

--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -561,6 +561,14 @@ class Card(UpdateableAPIResource, DeletableAPIResource):
         return "%s/%s/%s/%s" % (base, owner_extn, class_base, extn)
 
     @classmethod
+    def modify(cls, sid, **params):
+        raise NotImplementedError(
+            "Can't modify a card without a customer, recipient or account "
+            "ID. Call save on customer.sources.retrieve('card_id'), "
+            "recipient.cards.retrieve('card_id'), or "
+            "account.external_accounts.retrieve('card_id') instead.")
+
+    @classmethod
     def retrieve(cls, id, api_key=None, stripe_account=None, **params):
         raise NotImplementedError(
             "Can't retrieve a card without a customer, recipient or account "
@@ -603,6 +611,13 @@ class BankAccount(UpdateableAPIResource, DeletableAPIResource, VerifyMixin):
                 "attached to a customer or an account." % token, 'id')
 
         return "%s/%s/%s/%s" % (base, owner_extn, class_base, extn)
+
+    @classmethod
+    def modify(cls, sid, **params):
+        raise NotImplementedError(
+            "Can't modify a bank account without a customer or account ID. "
+            "Call save on customer.sources.retrieve('bank_account_id') or "
+            "account.external_accounts.retrieve('bank_account_id') instead.")
 
     @classmethod
     def retrieve(cls, id, api_key=None, stripe_account=None, **params):
@@ -806,6 +821,12 @@ class Reversal(UpdateableAPIResource):
         cust_extn = urllib.quote_plus(transfer)
         extn = urllib.quote_plus(token)
         return "%s/%s/reversals/%s" % (base, cust_extn, extn)
+
+    @classmethod
+    def modify(cls, sid, **params):
+        raise NotImplementedError(
+            "Can't modify a reversal without a transfer"
+            "ID. Call save on transfer.reversals.retrieve('reversal_id')")
 
     @classmethod
     def retrieve(cls, id, api_key=None, **params):

--- a/stripe/test/resources/test_application_fees.py
+++ b/stripe/test/resources/test_application_fees.py
@@ -96,3 +96,18 @@ class ApplicationFeeRefundTest(StripeResourceTest):
             },
             None
         )
+
+    def test_modify_refund(self):
+        stripe.resource.ApplicationFeeRefund.modify("fee_update", "ref_update",
+                                                    metadata={'key': 'foo'},
+                                                    api_key='api_key')
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/v1/application_fees/fee_update/refunds/ref_update',
+            {
+                'metadata': {
+                    'key': 'foo',
+                }
+            },
+            None
+        )

--- a/stripe/test/resources/test_charges.py
+++ b/stripe/test/resources/test_charges.py
@@ -37,6 +37,18 @@ class ChargeTest(StripeResourceTest):
             None
         )
 
+    def test_charge_modify(self):
+        stripe.Charge.modify('ch_test_id', refund=True)
+
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/v1/charges/ch_test_id',
+            {
+                'refund': True,
+            },
+            None
+        )
+
     def test_charge_update_dispute(self):
         charge = stripe.Charge(id='ch_update_id')
         charge.update_dispute(idempotency_key='foo')

--- a/stripe/test/resources/test_subscriptions.py
+++ b/stripe/test/resources/test_subscriptions.py
@@ -68,6 +68,24 @@ class SubscriptionTest(StripeResourceTest):
             None
         )
 
+    def test_modify_subscription(self):
+        trial_end_dttm = datetime.datetime.now() + datetime.timedelta(days=15)
+        trial_end_int = int(time.mktime(trial_end_dttm.timetuple()))
+
+        stripe.Subscription.modify('test_sub',
+                                   plan=DUMMY_PLAN['id'],
+                                   trial_end=trial_end_int)
+
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/v1/subscriptions/test_sub',
+            {
+                'plan': DUMMY_PLAN['id'],
+                'trial_end': trial_end_int
+            },
+            None
+        )
+
     def test_delete_subscription(self):
         subscription = stripe.Subscription.construct_from({
             'id': 'test_sub',


### PR DESCRIPTION
I'd much rather call this method `update`, but we can't use that name because `StripeObject` already has an `update` method, and I'd rather not make this a breaking change. Note that this PR is not ready merge. There are a few resources that are going to need a custom `modify` method due to URL format.