### PR TITLE
Add SubscriptionItem to support multiplan subscriptions

### DIFF
--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -43,6 +43,7 @@ from stripe.resource import (  # noqa
     Refund,
     SKU,
     Subscription,
+    SubscriptionItem,
     ThreeDSecure,
     Token,
     Transfer)

--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -30,6 +30,7 @@ def convert_to_stripe_object(resp, api_key, account):
         'recipient': Recipient,
         'refund': Refund,
         'subscription': Subscription,
+        'subscription_item': SubscriptionItem,
         'three_d_secure': ThreeDSecure,
         'token': Token,
         'transfer': Transfer,
@@ -786,6 +787,13 @@ class Subscription(CreateableAPIResource, DeletableAPIResource,
         url = self.instance_url() + '/discount'
         _, api_key = requestor.request('delete', url)
         self.refresh_from({'discount': None}, api_key, True)
+
+
+class SubscriptionItem(CreateableAPIResource, DeletableAPIResource,
+                       UpdateableAPIResource, ListableAPIResource):
+    @classmethod
+    def class_name(cls):
+        return 'subscription_item'
 
 
 class Refund(CreateableAPIResource, ListableAPIResource,

--- a/stripe/test/resources/test_subscription_items.py
+++ b/stripe/test/resources/test_subscription_items.py
@@ -1,0 +1,88 @@
+import stripe
+from stripe.test.helper import (
+    StripeResourceTest, DUMMY_PLAN
+)
+
+
+class SubscriptionItemTest(StripeResourceTest):
+
+    def test_list_subscriptions(self):
+        stripe.SubscriptionItem.all(subscription='test_sub', limit=3)
+        self.requestor_mock.request.assert_called_with(
+            'get',
+            '/v1/subscription_items',
+            {
+                'subscription': 'test_sub',
+                'limit': 3,
+            },
+        )
+
+    def test_retrieve_subscription(self):
+        stripe.SubscriptionItem.retrieve('test_sub_item')
+
+        self.requestor_mock.request.assert_called_with(
+            'get',
+            '/v1/subscription_items/test_sub_item',
+            {},
+            None
+        )
+
+    def test_create_subscription(self):
+        stripe.SubscriptionItem.create(subscription='test_sub',
+                                       plan=DUMMY_PLAN['id'])
+
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/v1/subscription_items',
+            {
+                'subscription': 'test_sub',
+                'plan': DUMMY_PLAN['id']
+            },
+            None
+        )
+
+    def test_update_subscription(self):
+        item = stripe.SubscriptionItem.construct_from({
+            'id': 'test_sub_item',
+            'plan': 'test_plan',
+        }, 'api_key')
+
+        item.plan = DUMMY_PLAN['id']
+        item.save()
+
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/v1/subscription_items/test_sub_item',
+            {
+                'plan': DUMMY_PLAN['id'],
+            },
+            None
+        )
+
+    def test_modify_subscription(self):
+        stripe.SubscriptionItem.modify('test_sub_item',
+                                       plan=DUMMY_PLAN['id'])
+
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/v1/subscription_items/test_sub_item',
+            {
+                'plan': DUMMY_PLAN['id'],
+            },
+            None
+        )
+
+    def test_delete_subscription(self):
+        item = stripe.SubscriptionItem.construct_from({
+            'id': 'test_sub_item',
+            'plan': 'test_plan',
+        }, 'api_key')
+
+        item.delete()
+
+        self.requestor_mock.request.assert_called_with(
+            'delete',
+            '/v1/subscription_items/test_sub_item',
+            {},
+            None
+        )


### PR DESCRIPTION
Add the SubscriptionItem resource that supports listing, creation, update, retrieval, and deletion through the `v1/subscription_items` endpoint.