### PR TITLE
Return values when creating/modifying subscriptions

### DIFF
--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -802,13 +802,13 @@ class Subscription(CreateableAPIResource, DeletableAPIResource,
     def modify(cls, sid, **params):
         if "items" in params:
             params["items"] = convert_array_to_dict(params["items"])
-        super(Subscription, cls).modify(sid, **params)
+        return super(Subscription, cls).modify(sid, **params)
 
     @classmethod
     def create(cls, **params):
         if "items" in params:
             params["items"] = convert_array_to_dict(params["items"])
-        super(Subscription, cls).create(**params)
+        return super(Subscription, cls).create(**params)
 
 
 class SubscriptionItem(CreateableAPIResource, DeletableAPIResource,

--- a/stripe/test/resources/test_subscriptions.py
+++ b/stripe/test/resources/test_subscriptions.py
@@ -33,7 +33,9 @@ class SubscriptionTest(StripeResourceTest):
         )
 
     def test_create_subscription(self):
-        stripe.Subscription.create(customer="test_cus", plan=DUMMY_PLAN['id'])
+        subscription = stripe.Subscription.create(customer="test_cus",
+                                                  plan=DUMMY_PLAN['id'])
+        self.assertEqual({}, subscription)
 
         self.requestor_mock.request.assert_called_with(
             'post',
@@ -72,9 +74,10 @@ class SubscriptionTest(StripeResourceTest):
         trial_end_dttm = datetime.datetime.now() + datetime.timedelta(days=15)
         trial_end_int = int(time.mktime(trial_end_dttm.timetuple()))
 
-        stripe.Subscription.modify('test_sub',
-                                   plan=DUMMY_PLAN['id'],
-                                   trial_end=trial_end_int)
+        subscription = stripe.Subscription.modify('test_sub',
+                                                  plan=DUMMY_PLAN['id'],
+                                                  trial_end=trial_end_int)
+        self.assertEqual({}, subscription)
 
         self.requestor_mock.request.assert_called_with(
             'post',


### PR DESCRIPTION
A bug was introduced with subscription items [1] that overrode methods
on the subscription and model and resulted in create/modify no longer
return objects.

This patch addresses that problem by adding return statements.

Fixes #252.

r? @kyleconroy Can you check this one out? Thanks!

[1] https://github.com/stripe/stripe-python/pull/249/commits/48856aea2e35d82d5fa76d0ab4483513039883a0