### PR TITLE
Adds support for sources

### DIFF
--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -43,6 +43,7 @@ from stripe.resource import (  # noqa
     Recipient,
     Refund,
     SKU,
+    Source,
     Subscription,
     SubscriptionItem,
     ThreeDSecure,

--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -29,6 +29,7 @@ def convert_to_stripe_object(resp, api_key, account):
         'plan': Plan,
         'recipient': Recipient,
         'refund': Refund,
+        'source': Source,
         'subscription': Subscription,
         'subscription_item': SubscriptionItem,
         'three_d_secure': ThreeDSecure,
@@ -1013,3 +1014,7 @@ class ApplePayDomain(CreateableAPIResource, ListableAPIResource,
     @classmethod
     def class_url(cls):
         return '/v1/apple_pay/domains'
+
+
+class Source(CreateableAPIResource):
+    pass

--- a/stripe/test/resources/test_sources.py
+++ b/stripe/test/resources/test_sources.py
@@ -1,0 +1,29 @@
+import stripe
+from stripe.test.helper import StripeResourceTest
+
+
+class SourceTest(StripeResourceTest):
+
+    def test_retrieve_resource(self):
+        stripe.Source.retrieve("src_foo")
+        self.requestor_mock.request.assert_called_with(
+            'get',
+            '/v1/sources/src_foo',
+            {},
+            None
+        )
+
+    def test_create_source(self):
+        stripe.Source.create(type="bitcoin", amount=1000, currency="usd",
+                             owner={"email": "jenny.rosen@example.com"})
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/v1/sources',
+            {
+                'type': 'bitcoin',
+                'amount': 1000,
+                'currency': 'usd',
+                'owner': {'email': 'jenny.rosen@example.com'}
+            },
+            None
+        )


### PR DESCRIPTION
r? @brandur
cc @stripe/api-libraries

It seems like we forgot to update the Python bindings when we switched to using [sources](https://stripe.com/docs/api#sources) for Bitcoin payments a few weeks ago. This PR fixes that.
