### PR TITLE
Fix lint like problems revealed by lgtm

### DIFF
--- a/stripe/error.py
+++ b/stripe/error.py
@@ -11,7 +11,7 @@ class StripeError(Exception):
         if http_body and hasattr(http_body, 'decode'):
             try:
                 http_body = http_body.decode('utf-8')
-            except:
+            except BaseException:
                 http_body = ('<Could not decode body as utf-8. '
                              'Please report to support@stripe.com>')
 

--- a/stripe/http_client.py
+++ b/stripe/http_client.py
@@ -14,6 +14,7 @@ from stripe import error, util
 try:
     import urllib2
 except ImportError:
+    # Try to load in urllib2, but don't sweat it if it's not available.
     pass
 
 try:
@@ -163,6 +164,8 @@ class UrlFetchClient(HTTPClient):
     name = 'urlfetch'
 
     def __init__(self, verify_ssl_certs=True, proxy=None, deadline=55):
+        super(UrlFetchClient, self).__init__(
+            verify_ssl_certs=verify_ssl_certs, proxy=proxy)
 
         # no proxy support in urlfetch. for a patch, see:
         # https://code.google.com/p/googleappengine/issues/detail?id=544

--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -122,8 +122,9 @@ class StripeObject(dict):
     def __setattr__(self, k, v):
         if k[0] == '_' or k in self.__dict__:
             return super(StripeObject, self).__setattr__(k, v)
-        else:
-            self[k] = v
+
+        self[k] = v
+        return None
 
     def __getattr__(self, k):
         if k[0] == '_':
@@ -133,6 +134,8 @@ class StripeObject(dict):
             return self[k]
         except KeyError as err:
             raise AttributeError(*err.args)
+
+        return None
 
     def __delattr__(self, k):
         if k[0] == '_' or k in self.__dict__:
@@ -400,8 +403,8 @@ class ListableAPIResource(APIResource):
         return cls.list(*args, **params)
 
     @classmethod
-    def auto_paging_iter(self, *args, **params):
-        return self.list(*args, **params).auto_paging_iter()
+    def auto_paging_iter(cls, *args, **params):
+        return cls.list(*args, **params).auto_paging_iter()
 
     @classmethod
     def list(cls, api_key=None, idempotency_key=None,
@@ -986,8 +989,6 @@ class Order(CreateableAPIResource, UpdateableAPIResource,
 
 
 class OrderReturn(ListableAPIResource):
-    pass
-
     @classmethod
     def class_url(cls):
         return '/v1/order_returns'


### PR DESCRIPTION
Details:

* Rescue BaseException instead of default Exception so that we don't
  accidentally handle an exit or keyboard interrupt.
* Make sure to call parent constructor of UrlFetchClient.
* Don't mix explicit and implicit return values.
* Remove unnecessary pass statement from OrderReturn.
* Comment empty exception rescue.
* Remove unused logger.

r? @dpetrovics Mind taking a look here? Thanks!