### PR TITLE
Rename error class to be singular "permissions"

### DIFF
--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -58,7 +58,7 @@ from stripe.error import (  # noqa
     APIConnectionError,
     APIError,
     AuthenticationError,
-    PermissionsError,
+    PermissionError,
     RateLimitError,
     CardError,
     InvalidRequestError,

--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -166,7 +166,7 @@ class APIRequestor(object):
                                   err.get('code'), rbody, rcode, resp,
                                   rheaders)
         elif rcode == 403:
-            raise error.PermissionsError(
+            raise error.PermissionError(
                 err.get('message'), rbody, rcode, resp,
                 rheaders)
         else:

--- a/stripe/error.py
+++ b/stripe/error.py
@@ -70,7 +70,7 @@ class AuthenticationError(StripeError):
     pass
 
 
-class PermissionsError(StripeError):
+class PermissionError(StripeError):
     pass
 
 

--- a/stripe/test/test_requestor.py
+++ b/stripe/test/test_requestor.py
@@ -349,7 +349,7 @@ class APIRequestorRequestTests(StripeUnitTestCase):
     def test_permissions_error(self):
         self.mock_response('{"error": {}}', 403)
 
-        self.assertRaises(stripe.error.PermissionsError,
+        self.assertRaises(stripe.error.PermissionError,
                           self.requestor.request,
                           'get', self.valid_path, {})
 


### PR DESCRIPTION
The addition of this class was unreleased so this is not a breaking
change.