### PR TITLE
Implement copy overrides on StripeObject

### DIFF
--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -1,6 +1,7 @@
 import urllib
 import warnings
 import sys
+from copy import deepcopy
 
 from stripe import api_requestor, error, util, upload_api_base
 
@@ -279,6 +280,18 @@ class StripeObject(dict):
                 params[k] = _serialize_list(v, previous.get(k, None))
 
         return params
+
+    def __deepcopy__(self, memo):
+        copy = StripeObject(self.get('id'), self.api_key,
+                            stripe_account=self.stripe_account)
+        memo[id(self)] = copy
+
+        copy._retrieve_params = self._retrieve_params
+
+        for k, v in self.items():
+            super(StripeObject, copy).__setitem__(k, deepcopy(v, memo))
+
+        return copy
 
 
 class StripeObjectEncoder(util.json.JSONEncoder):

--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -281,9 +281,11 @@ class StripeObject(dict):
 
         return params
 
-    # Override copy methods so that we can avoid having exceptions thrown as
-    # deepcopy tries to call into this class' __setitem__ with arguments that
-    # it doesn't like.
+    # This class overrides __setitem__ to throw exceptions on inputs that it
+    # doesn't like. This can cause problems when we try to copy an object
+    # wholesale because some data that's returned from the API may not be valid
+    # if it was set to be set manually. Here we override the class' copy
+    # arguments so that we can bypass these possible exceptions on __setitem__.
     def __copy__(self):
         copied = StripeObject(self.get('id'), self.api_key,
                               stripe_account=self.stripe_account)
@@ -297,9 +299,11 @@ class StripeObject(dict):
 
         return copied
 
-    # Override copy methods so that we can avoid having exceptions thrown as
-    # deepcopy tries to call into this class' __setitem__ with arguments that
-    # it doesn't like.
+    # This class overrides __setitem__ to throw exceptions on inputs that it
+    # doesn't like. This can cause problems when we try to copy an object
+    # wholesale because some data that's returned from the API may not be valid
+    # if it was set to be set manually. Here we override the class' copy
+    # arguments so that we can bypass these possible exceptions on __setitem__.
     def __deepcopy__(self, memo):
         copied = self.__copy__()
         memo[id(self)] = copied

--- a/stripe/test/resources/test_stripe_object.py
+++ b/stripe/test/resources/test_stripe_object.py
@@ -1,6 +1,6 @@
 import pickle
 import sys
-from copy import deepcopy
+from copy import copy, deepcopy
 
 import stripe
 from stripe import util
@@ -163,6 +163,28 @@ class StripeObjectTests(StripeUnitTestCase):
 
         obj.refresh_from({'coupon': 'foo'}, api_key='bar', partial=True)
         self.assertEqual('foo', obj.coupon)
+
+    def test_copy(self):
+        nested = stripe.resource.StripeObject.construct_from({
+            'value': 'bar',
+        }, 'mykey')
+        obj = stripe.resource.StripeObject.construct_from({
+            'empty': '',
+            'value': 'foo',
+            'nested': nested,
+        }, 'mykey', stripe_account='myaccount')
+
+        copied = copy(obj)
+
+        self.assertEqual('', copied.empty)
+        self.assertEqual('foo', copied.value)
+        self.assertEqual('bar', copied.nested.value)
+
+        self.assertEqual('mykey', copied.api_key)
+        self.assertEqual('myaccount', copied.stripe_account)
+
+        # Verify that we're not deep copying nested values.
+        self.assertEqual(id(nested), id(copied.nested))
 
     def test_deepcopy(self):
         nested = stripe.resource.StripeObject.construct_from({


### PR DESCRIPTION
As described in #259, the fact that we have overridden the setter on StripeObject to throw an error on an empty string means that when copy or deepcopy are used on it, an exception is thrown.

It makes sense to be able to able to copy a StripeObject, so here we override __copy__ and __deepcopy__ and add implementations that don't succumb to the same problem as the built-in versions.

Fixes #259.

r? @dpetrovics Would you mind taking a look at this one? Thanks!