### PR TITLE
flip conditional to prevent NameError on Python 3

### DIFF
--- a/stripe/util.py
+++ b/stripe/util.py
@@ -46,7 +46,7 @@ if not (json and hasattr(json, 'loads')):
 
 
 def utf8(value):
-    if isinstance(value, unicode) and sys.version_info < (3, 0):
+    if sys.version_info < (3, 0) and isinstance(value, unicode):
         return value.encode('utf-8')
     else:
         return value


### PR DESCRIPTION
In Python 3 `unicode` is no longer a built-in function (as it is now `str`). I'm honestly unsure how the tests currently pass, as this most certainly will throw an exception.

Let me know if you would like me to include a test :)