### PR TITLE
Add debug and info logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,42 @@ To install from source, run:
 
 Please see https://stripe.com/docs/api/python for the most up-to-date documentation.
 
+## Logging
+
+There are a few ways to get some insight into what requests and responses the client is making and getting back from the Stripe API.
+The python client can be told to emit either `debug` or `info` logs.
+`debug` will give more verbose information, and `info` will be more compact, but omit things like request/response bodies.
+
+You can enable logging in a few ways:
+    1. Set the environment variable `STRIPE_LOG` to the value `debug` or to `info`
+       ```
+       $ export STRIPE_LOG=debug
+       ```
+    2. set `stripe.log` to `'debug'` or `'info'`
+       ```py
+       import stripe
+       stripe.log = 'debug'
+       ```
+    3. Set up python logging and set the logging level to the level you desire
+       ```py
+       import logging
+       logging.basicConfig()
+       logging.getLogger('stripe').setLevel(logging.DEBUG)
+       ```
+
+If you are running code in production, it's preferable to set up [python logging explicitly](https://docs.python.org/2/library/logging.html). This will give you control over filtering logs, and where the logs are output. Using the `STRIPE_LOG` and `stripe.log` methods will always result in logs going to standard out, which you may or may not want.
+
+Note that setting `stripe.log` will supersede the setting of `STRIPE_LOG`, but it can be turned off by setting it back to `None`. Example:
+
+```py
+import os
+import stripe
+
+print os.environ['STRIPE_LOG']  # => 'info'
+stripe.log = 'debug'  # debug logs will also print now
+stripe.log = None  # now only info logs will print
+```
+
 ## Testing
 
 We commit to being compatible with Python 2.6+, Python 3.1+ and PyPy.  We need to test against all of these environments to ensure compatibility.  Travis CI will automatically run our tests on push.  For local testing, we use [tox](http://tox.readthedocs.org/) to handle testing across environments.

--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -15,6 +15,9 @@ verify_ssl_certs = True
 proxy = None
 default_http_client = None
 
+# Set to either 'debug' or 'info', controls console logging
+log = None
+
 # Resource
 from stripe.resource import (  # noqa
     Account,

--- a/stripe/test/test_util.py
+++ b/stripe/test/test_util.py
@@ -1,0 +1,139 @@
+from __future__ import print_function
+
+from collections import namedtuple
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from stripe import util
+from stripe.test.helper import StripeUnitTestCase
+
+import __builtin__
+
+PRINT_FUNC_STRING = __builtin__.__name__ + '.print'
+
+LogTestCase = namedtuple('LogTestCase', 'env flag should_output')
+FmtTestCase = namedtuple('FmtTestCase', 'props expected')
+
+
+class UtilTests(StripeUnitTestCase):
+    DUMMY_REQ_ID = 'req_qsxPhqHyLxcoaM'
+
+    def test_test_apikey(self):
+        with mock.patch('stripe.api_key', 'sk_test_KOWobxXidxNlIx'):
+            link = util.dashboard_link(self.DUMMY_REQ_ID)
+            self.assertEqual(
+                link,
+                'https://dashboard.stripe.com/test/logs/' + self.DUMMY_REQ_ID,
+            )
+
+    def test_live_apikey(self):
+        with mock.patch('stripe.api_key', 'sk_live_axwITqZSgTUXSN'):
+            link = util.dashboard_link(self.DUMMY_REQ_ID)
+            self.assertEqual(
+                link,
+                'https://dashboard.stripe.com/live/logs/' + self.DUMMY_REQ_ID,
+            )
+
+    def test_no_apikey(self):
+        with mock.patch('stripe.api_key', None):
+            link = util.dashboard_link(self.DUMMY_REQ_ID)
+            self.assertEqual(
+                link,
+                'https://dashboard.stripe.com/test/logs/' + self.DUMMY_REQ_ID,
+            )
+
+    def test_old_apikey(self):
+        with mock.patch('stripe.api_key', 'axwITqZSgTUXSN'):
+            link = util.dashboard_link(self.DUMMY_REQ_ID)
+            self.assertEqual(
+                link,
+                'https://dashboard.stripe.com/test/logs/' + self.DUMMY_REQ_ID,
+            )
+
+    def patch_val(self, var, value):
+        patcher = mock.patch(var, value)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def patch_mock(self, var):
+        patcher = mock.patch(var)
+        mock_val = patcher.start()
+        self.addCleanup(patcher.stop)
+        return mock_val
+
+    def log_test_loop(self, test_cases, logging_func, logger_name):
+        for case in test_cases:
+            with self.subTest(env=case.env, flag=case.flag):
+                try:
+                    logger_mock = self.patch_mock(logger_name)
+                    print_mock = self.patch_mock(PRINT_FUNC_STRING)
+                    self.patch_val('stripe.log', case.flag)
+                    self.patch_val('stripe.util.STRIPE_LOG', case.env)
+
+                    logging_func('foo \nbar', y=3)  # function under test
+
+                    if case.should_output:
+                        print_mock.assert_called_once_with(
+                            "message='foo \\nbar' y=3")
+                    else:
+                        print_mock.assert_not_called()
+                    logger_mock.assert_called_once_with('foo \nbar', {'y': 3})
+                finally:
+                    self.doCleanups()
+
+    def test_log_debug(self):
+        # (STRIPE_LOG, stripe.log): should_output?
+        test_cases = [
+            LogTestCase(env=None, flag=None, should_output=False),
+            LogTestCase(env=None, flag='debug', should_output=True),
+            LogTestCase(env=None, flag='info', should_output=False),
+            LogTestCase(env='debug', flag=None, should_output=True),
+            LogTestCase(env='debug', flag='debug', should_output=True),
+            LogTestCase(env='debug', flag='info', should_output=False),
+            LogTestCase(env='info', flag=None, should_output=False),
+            LogTestCase(env='info', flag='debug', should_output=True),
+            LogTestCase(env='info', flag='info', should_output=False),
+        ]
+        self.log_test_loop(
+            test_cases,
+            logging_func=util.log_debug,
+            logger_name='stripe.util.logger.debug',
+        )
+
+    def test_log_info(self):
+        # (STRIPE_LOG, stripe.log): should_output?
+        test_cases = [
+            LogTestCase(env=None, flag=None, should_output=False),
+            LogTestCase(env=None, flag='debug', should_output=True),
+            LogTestCase(env=None, flag='info', should_output=True),
+            LogTestCase(env='debug', flag=None, should_output=True),
+            LogTestCase(env='debug', flag='debug', should_output=True),
+            LogTestCase(env='debug', flag='info', should_output=True),
+            LogTestCase(env='info', flag=None, should_output=True),
+            LogTestCase(env='info', flag='debug', should_output=True),
+            LogTestCase(env='info', flag='info', should_output=True),
+        ]
+        self.log_test_loop(
+            test_cases,
+            logging_func=util.log_info,
+            logger_name='stripe.util.logger.info',
+        )
+
+    def test_logfmt(self):
+        cases = [
+            FmtTestCase(props={'foo': 'bar', 'message': 'yes'},
+                        expected='foo=bar message=yes'),
+            FmtTestCase(props={'foo': 'bar baz'},
+                        expected="foo='bar baz'"),
+            FmtTestCase(props={'b': 2, 'a': 1, 'c': 3},
+                        expected='a=1 b=2 c=3'),
+            FmtTestCase(props={'key with space': True},
+                        expected="'key with space'=True"),
+        ]
+        for case in cases:
+            with self.subTest(props=case.props):
+                result = util.logfmt(case.props)
+                self.assertEqual(result, case.expected)


### PR DESCRIPTION
This adds debug/info logging in the client, as well as some tests for whether the env var or global flag should be in force. The remaining part would be documenting how to use the flag, and possibly mentioning how to configure logging directly.