### PR TITLE
Adds deauthorize method to Account class

### DIFF
--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -10,6 +10,7 @@
 api_key = None
 api_base = 'https://api.stripe.com'
 upload_api_base = 'https://uploads.stripe.com'
+connect_api_base = 'https://connect.stripe.com'
 api_version = None
 verify_ssl_certs = True
 proxy = None

--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -272,20 +272,20 @@ class APIRequestor(object):
             if hasattr(rbody, 'decode'):
                 rbody = rbody.decode('utf-8')
             resp = util.json.loads(rbody)
+            if not (200 <= rcode < 300):
+                util.log_info(
+                    'Stripe API error received',
+                    error_code=resp.get('error', {}).get('code'),
+                    error_type=resp.get('error', {}).get('type'),
+                    error_message=resp.get('error', {}).get('message'),
+                    error_param=resp.get('error', {}).get('param'),
+                )
+                self.handle_api_error(rbody, rcode, resp, rheaders)
         except Exception:
             raise error.APIError(
                 "Invalid response body from API: %s "
                 "(HTTP response code was %d)" % (rbody, rcode),
                 rbody, rcode, rheaders)
-        if not (200 <= rcode < 300):
-            util.log_info(
-                'Stripe API error received',
-                error_code=resp.get('error', {}).get('code'),
-                error_type=resp.get('error', {}).get('type'),
-                error_message=resp.get('error', {}).get('message'),
-                error_param=resp.get('error', {}).get('param'),
-            )
-            self.handle_api_error(rbody, rcode, resp, rheaders)
         return resp
 
     # Deprecated request handling.  Will all be removed in 2.0

--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -3,7 +3,8 @@ import warnings
 import sys
 from copy import deepcopy
 
-from stripe import api_requestor, error, util, upload_api_base
+from stripe import (api_requestor, connect_api_base, error, upload_api_base,
+                    util)
 
 
 def convert_to_stripe_object(resp, api_key, account):
@@ -537,6 +538,17 @@ class Account(CreateableAPIResource, ListableAPIResource,
             self.request('post', url, params, headers)
         )
         return self
+
+    def deauthorize(self, client_id, api_key=None):
+        requestor = api_requestor.APIRequestor(
+            api_key, api_base=connect_api_base)
+        url = '/oauth/deauthorize'
+        params = {
+            'client_id': client_id,
+            'stripe_user_id': self.id,
+        }
+        response, api_key = requestor.request('post', url, params, None)
+        return convert_to_stripe_object(response, api_key, self.stripe_account)
 
 
 class AlipayAccount(UpdateableAPIResource, DeletableAPIResource):

--- a/stripe/test/resources/test_accounts.py
+++ b/stripe/test/resources/test_accounts.py
@@ -152,3 +152,21 @@ class AccountTest(StripeResourceTest):
             },
             None,
         )
+
+    def test_deauthorize_account(self):
+        acct = stripe.Account.construct_from({
+            'id': 'acct_deauth',
+            'managed': False,
+        }, 'api_key')
+
+        acct.deauthorize('ca_test')
+
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/oauth/deauthorize',
+            {
+                'client_id': 'ca_test',
+                'stripe_user_id': 'acct_deauth',
+            },
+            None
+        )


### PR DESCRIPTION
r? @brandur-stripe
cc @stripe/api-libraries

This PR adds a `deauthorize()` method to the `Account` class, similar to what already exists in [stripe-ruby](https://github.com/stripe/stripe-ruby/blob/5dd5d2b608af8b597b5298b22eab171d570d6408/lib/stripe/account.rb#L94-L99).

Because the `https://connect.stripe.com/oauth/deauthorize` endpoint doesn't return standard error objects, I had to tweak the error handling code slightly. This isn't ideal, but it works, and it's aligned with what stripe-ruby does.
