### PR TITLE
Adds Customer.modify_source and Account.modify_external_account methods

### DIFF
--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -538,6 +538,13 @@ class Account(CreateableAPIResource, ListableAPIResource,
         )
         return self
 
+    @classmethod
+    def modify_external_account(cls, sid, external_account_id, **params):
+        url = "%s/%s/external_accounts/%s" % (
+            cls.class_url(), urllib.quote_plus(util.utf8(sid)),
+            urllib.quote_plus(util.utf8(external_account_id)))
+        return cls._modify(url, **params)
+
 
 class AlipayAccount(UpdateableAPIResource, DeletableAPIResource):
 
@@ -799,6 +806,13 @@ class Customer(CreateableAPIResource, UpdateableAPIResource,
         url = self.instance_url() + '/discount'
         _, api_key = requestor.request('delete', url)
         self.refresh_from({'discount': None}, api_key, True)
+
+    @classmethod
+    def modify_source(cls, sid, source_id, **params):
+        url = "%s/%s/sources/%s" % (
+            cls.class_url(), urllib.quote_plus(util.utf8(sid)),
+            urllib.quote_plus(util.utf8(source_id)))
+        return cls._modify(url, **params)
 
 
 class Invoice(CreateableAPIResource, ListableAPIResource,

--- a/stripe/test/resources/test_accounts.py
+++ b/stripe/test/resources/test_accounts.py
@@ -1,5 +1,5 @@
 import stripe
-from stripe.test.helper import StripeResourceTest
+from stripe.test.helper import (StripeResourceTest, NOW)
 
 
 class AccountTest(StripeResourceTest):
@@ -151,4 +151,19 @@ class AccountTest(StripeResourceTest):
                 },
             },
             None,
+        )
+
+    def test_modify_external_account(self):
+        stripe.Account.modify_external_account(
+            'acct_test', 'card_test',
+            exp_month=NOW.month, exp_year=NOW.year + 1)
+
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/v1/accounts/acct_test/external_accounts/card_test',
+            {
+                'exp_month': NOW.month,
+                'exp_year': NOW.year + 1,
+            },
+            None
         )

--- a/stripe/test/resources/test_customers.py
+++ b/stripe/test/resources/test_customers.py
@@ -4,7 +4,7 @@ import warnings
 
 import stripe
 from stripe.test.helper import (
-    StripeResourceTest, DUMMY_CARD, DUMMY_PLAN
+    StripeResourceTest, DUMMY_CARD, DUMMY_PLAN, NOW
 )
 
 
@@ -222,6 +222,21 @@ class CustomerTest(StripeResourceTest):
             'post',
             '/v1/customers/cus_verify_source/sources/ba_verify_source/verify',
             {},
+            None
+        )
+
+    def test_customer_modify_source(self):
+        stripe.Customer.modify_source(
+            'cus_test', 'card_test',
+            exp_month=NOW.month, exp_year=NOW.year + 1)
+
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/v1/customers/cus_test/sources/card_test',
+            {
+                'exp_month': NOW.month,
+                'exp_year': NOW.year + 1,
+            },
             None
         )
 


### PR DESCRIPTION
r? @brandur-stripe
cc @stripe/api-libraries

This PR adds two class methods:
- `Customer.modify_source`
- `Account.modify_external_account`

These methods lets users modify cards and bank accounts that are attached to customers/accounts without having to first retrieve the resources, e.g.:

```python
updated_card = stripe.Customer.modify_source(
    'cus_...',  # customer ID
    'card_...',  # card ID
    # update parameters
    exp_month=12,
    exp_year=2020,
    name='Stripey McStripe'
)
```

Fixes #282.
