### PR TITLE
Add OAuth methods

### DIFF
--- a/examples/oauth.py
+++ b/examples/oauth.py
@@ -1,0 +1,54 @@
+import os
+
+import stripe
+from flask import Flask, request, redirect
+
+
+stripe.api_key = os.environ.get('STRIPE_SECRET_KEY')
+stripe.client_id = os.environ.get('STRIPE_CLIENT_ID')
+
+app = Flask(__name__)
+
+
+@app.route('/')
+def index():
+    return '<a href="/authorize">Connect with Stripe</a>'
+
+
+@app.route('/authorize')
+def authorize():
+    url = stripe.OAuth.authorize_url(scope='read_only')
+    return redirect(url)
+
+
+@app.route('/oauth/callback')
+def callback():
+    code = request.args.get('code')
+    try:
+        resp = stripe.OAuth.token(grant_type='authorization_code', code=code)
+    except stripe.error.OAuthError as e:
+        return 'Error: ' + str(e)
+
+    return '''
+<p>Success! Account <code>{stripe_user_id}</code> is connected.</p>
+<p>Click <a href="/deauthorize?stripe_user_id={stripe_user_id}">here</a> to
+disconnect the account.</p>
+'''.format(stripe_user_id=resp['stripe_user_id'])
+
+
+@app.route('/deauthorize')
+def deauthorize():
+    stripe_user_id = request.args.get('stripe_user_id')
+    try:
+        stripe.OAuth.deauthorize(stripe_user_id=stripe_user_id)
+    except stripe.error.OAuthError as e:
+        return 'Error: ' + str(e)
+
+    return '''
+<p>Success! Account <code>{stripe_user_id}</code> is disconnected.</p>
+<p>Click <a href="/">here</a> to restart the OAuth flow.</p>
+'''.format(stripe_user_id=stripe_user_id)
+
+
+if __name__ == '__main__':
+    app.run(port=int(os.environ.get('PORT', 5000)))

--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -8,7 +8,9 @@
 # Configuration variables
 
 api_key = None
+client_id = None
 api_base = 'https://api.stripe.com'
+connect_api_base = 'https://connect.stripe.com'
 upload_api_base = 'https://uploads.stripe.com'
 api_version = None
 verify_ssl_certs = True
@@ -53,6 +55,9 @@ from stripe.resource import (  # noqa
     Token,
     Transfer)
 
+# OAuth
+from stripe.oauth import OAuth  # noqa
+
 # Error imports.  Note that we may want to move these out of the root
 # namespace in the future and you should prefer to access them via
 # the fully qualified `stripe.error` module.
@@ -65,6 +70,7 @@ from stripe.error import (  # noqa
     RateLimitError,
     CardError,
     InvalidRequestError,
+    OAuthError,
     StripeError)
 
 # DEPRECATED: These imports will be moved out of the root stripe namespace

--- a/stripe/error.py
+++ b/stripe/error.py
@@ -76,3 +76,12 @@ class PermissionError(StripeError):
 
 class RateLimitError(StripeError):
     pass
+
+
+class OAuthError(StripeError):
+    def __init__(self, type, description=None, http_body=None,
+                 http_status=None, json_body=None, headers=None):
+        description = description or type
+        super(OAuthError, self).__init__(
+            description, http_body, http_status, json_body, headers)
+        self.type = type

--- a/stripe/oauth.py
+++ b/stripe/oauth.py
@@ -1,0 +1,50 @@
+import urllib
+
+from stripe import api_requestor, connect_api_base, error
+
+
+class OAuth(object):
+
+    @staticmethod
+    def _set_client_id(params):
+        if 'client_id' in params:
+            return
+
+        from stripe import client_id
+        if client_id:
+            params['client_id'] = client_id
+            return
+
+        raise error.AuthenticationError(
+            'No client_id provided. (HINT: set your client_id using '
+            '"stripe.client_id = <CLIENT-ID>"). You can find your client_ids '
+            'in your Stripe dashboard at '
+            'https://dashboard.stripe.com/account/applications/settings, '
+            'after registering your account as a platform. See '
+            'https://stripe.com/docs/connect/standalone-accounts for details, '
+            'or email support@stripe.com if you have any questions.')
+
+    @staticmethod
+    def authorize_url(**params):
+        path = '/oauth/authorize'
+        OAuth._set_client_id(params)
+        if 'response_type' not in params:
+            params['response_type'] = 'code'
+        query = urllib.urlencode(list(api_requestor._api_encode(params)))
+        url = connect_api_base + path + '?' + query
+        return url
+
+    @staticmethod
+    def token(**params):
+        requestor = api_requestor.OAuthRequestor(api_base=connect_api_base)
+        response, api_key = requestor.request(
+            'post', '/oauth/token', params, None)
+        return response
+
+    @staticmethod
+    def deauthorize(**params):
+        requestor = api_requestor.OAuthRequestor(api_base=connect_api_base)
+        OAuth._set_client_id(params)
+        response, api_key = requestor.request(
+            'post', '/oauth/deauthorize', params, None)
+        return response

--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -3,7 +3,7 @@ import warnings
 import sys
 from copy import deepcopy
 
-from stripe import api_requestor, error, util, upload_api_base
+from stripe import api_requestor, error, oauth, util, upload_api_base
 
 
 def convert_to_stripe_object(resp, api_key, account):
@@ -537,6 +537,10 @@ class Account(CreateableAPIResource, ListableAPIResource,
             self.request('post', url, params, headers)
         )
         return self
+
+    def deauthorize(self, **params):
+        params['stripe_user_id'] = self.id
+        return oauth.OAuth.deauthorize(**params)
 
     @classmethod
     def modify_external_account(cls, sid, external_account_id, **params):

--- a/stripe/test/helper.py
+++ b/stripe/test/helper.py
@@ -120,7 +120,7 @@ SAMPLE_INVOICE = stripe.util.json.loads("""
 
 
 class StripeTestCase(unittest2.TestCase):
-    RESTORE_ATTRIBUTES = ('api_version', 'api_key')
+    RESTORE_ATTRIBUTES = ('api_version', 'api_key', 'client_id')
 
     def setUp(self):
         super(StripeTestCase, self).setUp()
@@ -186,12 +186,38 @@ class StripeUnitTestCase(StripeTestCase):
             patcher.stop()
 
 
+class StripeAPIRequestorTestCase(StripeUnitTestCase):
+    REQUESTOR_CLS = stripe.api_requestor.APIRequestor
+
+    def setUp(self):
+        super(StripeAPIRequestorTestCase, self).setUp()
+
+        self.http_client = Mock(stripe.http_client.HTTPClient)
+        self.http_client._verify_ssl_certs = True
+        self.http_client.name = 'mockclient'
+
+        self.requestor = self.REQUESTOR_CLS(client=self.http_client)
+
+    def mock_response(self, return_body, return_code, requestor=None,
+                      headers=None):
+        if not requestor:
+            requestor = self.requestor
+
+        self.http_client.request = Mock(
+            return_value=(return_body, return_code, headers or {}))
+
+
+class StripeOAuthRequestorTestCase(StripeAPIRequestorTestCase):
+    REQUESTOR_CLS = stripe.api_requestor.OAuthRequestor
+
+
 class StripeApiTestCase(StripeTestCase):
+    REQUESTOR_CLS_NAME = 'stripe.api_requestor.APIRequestor'
 
     def setUp(self):
         super(StripeApiTestCase, self).setUp()
 
-        self.requestor_patcher = patch('stripe.api_requestor.APIRequestor')
+        self.requestor_patcher = patch(self.REQUESTOR_CLS_NAME)
         requestor_class_mock = self.requestor_patcher.start()
         self.requestor_mock = requestor_class_mock.return_value
 
@@ -202,6 +228,14 @@ class StripeApiTestCase(StripeTestCase):
 
     def mock_response(self, res):
         self.requestor_mock.request = Mock(return_value=(res, 'reskey'))
+
+
+class StripeOAuthTestCase(StripeApiTestCase):
+    REQUESTOR_CLS_NAME = 'stripe.api_requestor.OAuthRequestor'
+
+    def setUp(self):
+        super(StripeOAuthTestCase, self).setUp()
+        self.mock_response({})
 
 
 class StripeResourceTest(StripeApiTestCase):

--- a/stripe/test/test_oauth.py
+++ b/stripe/test/test_oauth.py
@@ -1,0 +1,87 @@
+import urlparse
+
+import stripe
+from stripe.test.helper import StripeOAuthTestCase
+
+
+class OAuthTests(StripeOAuthTestCase):
+    def setUp(self):
+        super(OAuthTests, self).setUp()
+
+        stripe.client_id = 'ca_test'
+
+    def tearDown(self):
+        super(OAuthTests, self).tearDown()
+
+        stripe.client_id = None
+
+    def test_authorize_url(self):
+        url = stripe.OAuth.authorize_url(
+            scope='read_write',
+            state='csrf_token',
+            stripe_user={
+                'email': 'test@example.com',
+                'url': 'https://example.com/profile/test',
+                'country': 'US',
+            })
+
+        o = urlparse.urlparse(url)
+        params = urlparse.parse_qs(o.query)
+
+        self.assertEqual('https', o.scheme)
+        self.assertEqual('connect.stripe.com', o.netloc)
+        self.assertEqual('/oauth/authorize', o.path)
+
+        self.assertEqual(['ca_test'], params['client_id'])
+        self.assertEqual(['read_write'], params['scope'])
+        self.assertEqual(['test@example.com'], params['stripe_user[email]'])
+        self.assertEqual(
+            ['https://example.com/profile/test'],
+            params['stripe_user[url]']
+        )
+        self.assertEqual(['US'], params['stripe_user[country]'])
+
+    def test_token(self):
+        stripe.OAuth.token(
+            grant_type='authorization_code',
+            code='this_is_an_authorization_code',
+        )
+
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/oauth/token',
+            {
+                'grant_type': 'authorization_code',
+                'code': 'this_is_an_authorization_code',
+            },
+            None
+        )
+
+    def test_deauthorize(self):
+        stripe.OAuth.deauthorize(stripe_user_id='acct_deauth')
+
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/oauth/deauthorize',
+            {
+                'client_id': 'ca_test',
+                'stripe_user_id': 'acct_deauth',
+            },
+            None
+        )
+
+    def test_deauthorize_account_instance(self):
+        acct = stripe.Account.construct_from({
+            'id': 'acct_deauth',
+        }, 'api_key')
+        acct.deauthorize()
+
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/oauth/deauthorize',
+            {
+                'client_id': 'ca_test',
+                'stripe_user_id': 'acct_deauth',
+            },
+            None
+        )


### PR DESCRIPTION
Currently, our docs advise users to send requests to `connect.stripe.com` by their own means. This PR adds support for OAuth directly in the Python bindings.

The design is a little bit awkward and could probably be improved -- I'm open to suggestions :)

To recap:
- I added a new `oauth` module containing a single static `OAuth` class
- the `OAuth` class has 3 static methods:
    - `authorize_url` returns the URL that platforms need to redirect their users to start the OAuth flow (https://stripe.com/docs/connect/reference#get-authorize)
    - `token` is used to turn an authorization code into an access token (https://stripe.com/docs/connect/reference#post-token)
    - `deauthorize` is used to deauthorize a currently connected account (https://stripe.com/docs/connect/reference#post-deauthorize)
- the `client_id` can be set globally or per request (just like API keys)
- since the errors that are returned by `connect.stripe.com` are different from those used by `api.stripe.com`, I created a new `OAuthRequestor` class (derived from `APIRequestor`) that will raise an `OAuthError` if the API returns an error
- because there are now two different types of requestors, I made some test classes abstract, and specified the appropriate class / class name in derived classes
- finally, I added a basic example in `examples/oauth.py` that demonstrates how to use all 3 new methods to connect and disconnect accounts to a platform

@stripe/api-libraries wdyt?
