### PR TITLE
Peg the test suite's API version

### DIFF
--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -63,9 +63,11 @@ def _build_api_url(url, query):
 
 class APIRequestor(object):
 
-    def __init__(self, key=None, client=None, api_base=None, account=None):
+    def __init__(self, key=None, client=None, api_base=None, api_version=None,
+                 account=None):
         self.api_base = api_base or stripe.api_base
         self.api_key = key
+        self.api_version = api_version or stripe.api_version
         self.stripe_account = account
 
         from stripe import verify_ssl_certs as verify
@@ -177,7 +179,6 @@ class APIRequestor(object):
         """
         Mechanism for issuing an API call
         """
-        from stripe import api_version
 
         if self.api_key:
             my_api_key = self.api_key
@@ -245,8 +246,8 @@ class APIRequestor(object):
         if method == 'post':
             headers['Content-Type'] = 'application/x-www-form-urlencoded'
 
-        if api_version is not None:
-            headers['Stripe-Version'] = api_version
+        if self.api_version is not None:
+            headers['Stripe-Version'] = self.api_version
 
         if supplied_headers is not None:
             for key, value in supplied_headers.items():
@@ -254,7 +255,7 @@ class APIRequestor(object):
 
         util.log_info('Request to Stripe api', method=method, path=abs_url)
         util.log_debug(
-            'Post details', post_data=post_data, api_version=api_version)
+            'Post details', post_data=post_data, api_version=self.api_version)
 
         rbody, rcode, rheaders = self._client.request(
             method, abs_url, headers, post_data)

--- a/stripe/test/helper.py
+++ b/stripe/test/helper.py
@@ -135,6 +135,8 @@ class StripeTestCase(unittest2.TestCase):
             stripe.api_base = api_base
         stripe.api_key = os.environ.get(
             'STRIPE_API_KEY', 'tGN0bIwXnHdwOa85VABjPdSn8nWY7G7I')
+        stripe.api_version = os.environ.get(
+            'STRIPE_API_VERSION', '2017-02-14')
 
     def tearDown(self):
         super(StripeTestCase, self).tearDown()

--- a/stripe/test/test_requestor.py
+++ b/stripe/test/test_requestor.py
@@ -45,7 +45,7 @@ class APIHeaderMatcher(object):
                 self._extra_match(other))
 
     def _keys_match(self, other):
-        expected_keys = set(self.EXP_KEYS + self.extra.keys())
+        expected_keys = list(set(self.EXP_KEYS + self.extra.keys()))
         if self.request_method is not None and self.request_method in \
                 self.METHOD_EXTRA_KEYS:
             expected_keys.extend(self.METHOD_EXTRA_KEYS[self.request_method])

--- a/stripe/test/test_requestor.py
+++ b/stripe/test/test_requestor.py
@@ -26,7 +26,12 @@ class GMT1(datetime.tzinfo):
 
 
 class APIHeaderMatcher(object):
-    EXP_KEYS = ['X-Stripe-Client-User-Agent', 'User-Agent', 'Authorization']
+    EXP_KEYS = [
+        'Authorization',
+        'Stripe-Version',
+        'User-Agent',
+        'X-Stripe-Client-User-Agent',
+    ]
     METHOD_EXTRA_KEYS = {"post": ["Content-Type"]}
 
     def __init__(self, api_key=None, extra={}, request_method=None):


### PR DESCRIPTION
Pegs the test suite's API version so that we can upgrade it
independently of the account's implicit version. It's also to check how
much breaks when we move to a relatively modern version of the API.

See also https://github.com/stripe/stripe-php/pull/337 and https://github.com/stripe/stripe-java/pull/360.