### PR TITLE
Remove raw PANs from our test suite

### DIFF
--- a/examples/charge.py
+++ b/examples/charge.py
@@ -7,11 +7,7 @@ print "Attempting charge..."
 resp = stripe.Charge.create(
     amount=200,
     currency='usd',
-    card={
-        'number': '4242424242424242',
-        'exp_month': 10,
-        'exp_year': 2014
-    },
+    card='tok_visa',
     description='customer@gmail.com'
 )
 

--- a/examples/proxy.py
+++ b/examples/proxy.py
@@ -27,11 +27,7 @@ for c in clients:
     resp = stripe.Charge.create(
         amount=200,
         currency='usd',
-        card={
-            'number': '4242424242424242',
-            'exp_month': 10,
-            'exp_year': 2019
-        },
+        card='tok_visa',
         description='customer@gmail.com'
     )
     print( 'Success: %s, %r' % ( c.name, resp, ) )

--- a/stripe/test/helper.py
+++ b/stripe/test/helper.py
@@ -11,20 +11,10 @@ import stripe
 
 NOW = datetime.datetime.now()
 
-DUMMY_CARD = {
-    'number': '4242424242424242',
-    'exp_month': NOW.month,
-    'exp_year': NOW.year + 4
-}
-DUMMY_DEBIT_CARD = {
-    'number': '4000056655665556',
-    'exp_month': NOW.month,
-    'exp_year': NOW.year + 4
-}
 DUMMY_CHARGE = {
     'amount': 100,
     'currency': 'usd',
-    'card': DUMMY_CARD
+    'source': 'tok_visa'
 }
 
 DUMMY_DISPUTE = {

--- a/stripe/test/resources/test_customers.py
+++ b/stripe/test/resources/test_customers.py
@@ -3,9 +3,7 @@ import time
 import warnings
 
 import stripe
-from stripe.test.helper import (
-    StripeResourceTest, DUMMY_CARD, DUMMY_PLAN, NOW
-)
+from stripe.test.helper import (StripeResourceTest, DUMMY_PLAN, NOW)
 
 
 class CustomerTest(StripeResourceTest):
@@ -19,7 +17,7 @@ class CustomerTest(StripeResourceTest):
         )
 
     def test_create_customer(self):
-        stripe.Customer.create(description="foo bar", card=DUMMY_CARD,
+        stripe.Customer.create(description="foo bar", source='tok_visa',
                                coupon='cu_discount', idempotency_key='foo')
         self.requestor_mock.request.assert_called_with(
             'post',
@@ -27,7 +25,7 @@ class CustomerTest(StripeResourceTest):
             {
                 'coupon': 'cu_discount',
                 'description': 'foo bar',
-                'card': DUMMY_CARD
+                'source': 'tok_visa'
             },
             {'Idempotency-Key': 'foo'}
         )
@@ -74,13 +72,13 @@ class CustomerTest(StripeResourceTest):
                 'url': '/v1/customers/cus_add_card/sources',
             },
         }, 'api_key')
-        customer.sources.create(card=DUMMY_CARD, idempotency_key='foo')
+        customer.sources.create(source='tok_visa', idempotency_key='foo')
 
         self.requestor_mock.request.assert_called_with(
             'post',
             '/v1/customers/cus_add_card/sources',
             {
-                'card': DUMMY_CARD,
+                'source': 'tok_visa',
             },
             {'Idempotency-Key': 'foo'}
         )
@@ -93,13 +91,13 @@ class CustomerTest(StripeResourceTest):
                 'url': '/v1/customers/cus_add_source/sources',
             },
         }, 'api_key')
-        customer.sources.create(source=DUMMY_CARD, idempotency_key='foo')
+        customer.sources.create(source='tok_visa', idempotency_key='foo')
 
         self.requestor_mock.request.assert_called_with(
             'post',
             '/v1/customers/cus_add_source/sources',
             {
-                'source': DUMMY_CARD,
+                'source': 'tok_visa',
             },
             {'Idempotency-Key': 'foo'}
         )
@@ -244,13 +242,13 @@ class CustomerTest(StripeResourceTest):
 class CustomerPlanTest(StripeResourceTest):
 
     def test_create_customer(self):
-        stripe.Customer.create(plan=DUMMY_PLAN['id'], card=DUMMY_CARD)
+        stripe.Customer.create(plan=DUMMY_PLAN['id'], source='tok_visa')
 
         self.requestor_mock.request.assert_called_with(
             'post',
             '/v1/customers',
             {
-                'card': DUMMY_CARD,
+                'source': 'tok_visa',
                 'plan': DUMMY_PLAN['id'],
             },
             None

--- a/stripe/test/resources/test_recipients.py
+++ b/stripe/test/resources/test_recipients.py
@@ -1,7 +1,5 @@
 import stripe
-from stripe.test.helper import (
-    StripeResourceTest, DUMMY_CARD
-)
+from stripe.test.helper import (StripeResourceTest)
 
 
 class RecipientTest(StripeResourceTest):
@@ -32,13 +30,13 @@ class RecipientTest(StripeResourceTest):
                 'url': '/v1/recipients/rp_add_card/sources',
             },
         }, 'api_key')
-        recipient.sources.create(card=DUMMY_CARD)
+        recipient.sources.create(card='tok_visa_debit')
 
         self.requestor_mock.request.assert_called_with(
             'post',
             '/v1/recipients/rp_add_card/sources',
             {
-                'card': DUMMY_CARD,
+                'card': 'tok_visa_debit',
             },
             None
         )


### PR DESCRIPTION
This PR aims to use the new test tokens such as `tok_visa` instead or hardcoding raw PANs in the test suite. It also cleans up the example to not mention raw PANs.

r? @brandur-stripe