### PR TITLE
[WIP] Add stickiness/passthrough for API version through resources

### DIFF
--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 from stripe import api_requestor, error, oauth, util, upload_api_base
 
 
-def convert_to_stripe_object(resp, api_key, account):
+def convert_to_stripe_object(resp, api_key, account, api_version=None):
     types = {
         'account': Account,
         'alipay_account': AlipayAccount,
@@ -46,7 +46,9 @@ def convert_to_stripe_object(resp, api_key, account):
     }
 
     if isinstance(resp, list):
-        return [convert_to_stripe_object(i, api_key, account) for i in resp]
+        return [convert_to_stripe_object(i, api_key, account,
+                                         api_version=api_version)
+                for i in resp]
     elif isinstance(resp, dict) and not isinstance(resp, StripeObject):
         resp = resp.copy()
         klass_name = resp.get('object')
@@ -54,7 +56,8 @@ def convert_to_stripe_object(resp, api_key, account):
             klass = types.get(klass_name, StripeObject)
         else:
             klass = StripeObject
-        return klass.construct_from(resp, api_key, stripe_account=account)
+        return klass.construct_from(resp, api_key, stripe_account=account,
+                                    api_version=api_version)
     else:
         return resp
 
@@ -101,7 +104,8 @@ def _serialize_list(array, previous):
 
 
 class StripeObject(dict):
-    def __init__(self, id=None, api_key=None, stripe_account=None, **params):
+    def __init__(self, id=None, api_key=None, stripe_account=None,
+                 api_version=None, **params):
         super(StripeObject, self).__init__()
 
         self._unsaved_values = set()
@@ -111,6 +115,7 @@ class StripeObject(dict):
         self._previous = None
 
         object.__setattr__(self, 'api_key', api_key)
+        object.__setattr__(self, 'api_version', api_version)
         object.__setattr__(self, 'stripe_account', stripe_account)
 
         if id:
@@ -183,16 +188,19 @@ class StripeObject(dict):
             self._unsaved_values.remove(k)
 
     @classmethod
-    def construct_from(cls, values, key, stripe_account=None):
-        instance = cls(values.get('id'), api_key=key,
+    def construct_from(cls, values, key, stripe_account=None,
+                       api_version=None):
+        instance = cls(values.get('id'), api_key=key, api_version=api_version,
                        stripe_account=stripe_account)
-        instance.refresh_from(values, api_key=key,
+        instance.refresh_from(values, api_key=key, api_version=api_version,
                               stripe_account=stripe_account)
         return instance
 
-    def refresh_from(self, values, api_key=None, partial=False,
-                     stripe_account=None):
+    def refresh_from(self, values, api_key=None,
+                     partial=False, stripe_account=None,
+                     api_version=None):
         self.api_key = api_key or getattr(values, 'api_key', None)
+        self.api_version = api_version or getattr(values, 'api_version', None)
         self.stripe_account = \
             stripe_account or getattr(values, 'stripe_account', None)
 
@@ -211,7 +219,8 @@ class StripeObject(dict):
 
         for k, v in values.iteritems():
             super(StripeObject, self).__setitem__(
-                k, convert_to_stripe_object(v, api_key, stripe_account))
+                k, convert_to_stripe_object(v, api_key, stripe_account,
+                                            api_version=api_version))
 
         self._previous = values
 
@@ -219,15 +228,18 @@ class StripeObject(dict):
     def api_base(cls):
         return None
 
-    def request(self, method, url, params=None, headers=None):
+    def request(self, method, url, params=None, headers=None, api_key=None,
+                stripe_account=None, api_version=None):
         if params is None:
             params = self._retrieve_params
-        requestor = api_requestor.APIRequestor(
-            key=self.api_key, api_base=self.api_base(),
-            account=self.stripe_account)
+        requestor = self._api_requestor(
+            instance=self, api_key=api_key, stripe_account=stripe_account,
+            api_version=api_version)
         response, api_key = requestor.request(method, url, params, headers)
 
-        return convert_to_stripe_object(response, api_key, self.stripe_account)
+        return convert_to_stripe_object(response, api_key,
+                                        requestor.stripe_account,
+                                        api_version=requestor.api_version)
 
     def __repr__(self):
         ident_parts = [type(self).__name__]
@@ -257,6 +269,20 @@ class StripeObject(dict):
             DeprecationWarning)
 
         return dict(self)
+
+    @classmethod
+    def _api_requestor(cls, instance=None, api_key=None, stripe_account=None,
+                       api_version=None, api_base=None):
+        api_base = api_base or cls.api_base()
+
+        if instance is not None:
+            api_key = api_key or instance.api_key
+            api_version = api_version or instance.api_version
+            stripe_account = stripe_account or instance.stripe_account
+
+        return api_requestor.APIRequestor(
+            key=api_key, api_base=api_base, account=stripe_account,
+            api_version=api_version)
 
     @property
     def stripe_id(self):
@@ -288,7 +314,8 @@ class StripeObject(dict):
     # arguments so that we can bypass these possible exceptions on __setitem__.
     def __copy__(self):
         copied = StripeObject(self.get('id'), self.api_key,
-                              stripe_account=self.stripe_account)
+                              stripe_account=self.stripe_account,
+                              api_version=self.api_version)
 
         copied._retrieve_params = self._retrieve_params
 
@@ -367,8 +394,11 @@ class APIResource(StripeObject):
 
 class ListObject(StripeObject):
 
-    def list(self, **params):
-        return self.request('get', self['url'], params)
+    def list(self, api_key=None, stripe_account=None, api_version=None,
+             **params):
+        return self.request(
+            'get', self['url'], params, api_key=api_key,
+            stripe_account=stripe_account, api_version=api_version)
 
     def all(self, **params):
         warnings.warn("The `all` method is deprecated and will"
@@ -393,17 +423,23 @@ class ListObject(StripeObject):
             params['starting_after'] = item_id
             page = self.list(**params)
 
-    def create(self, idempotency_key=None, **params):
+    def create(self, idempotency_key=None, api_key=None, stripe_account=None,
+               api_version=None, **params):
         headers = populate_headers(idempotency_key)
-        return self.request('post', self['url'], params, headers)
+        return self.request(
+            'post', self['url'], params, headers, api_key=api_key,
+            stripe_account=stripe_account, api_version=api_version)
 
-    def retrieve(self, id, **params):
+    def retrieve(self, id, api_key=None, stripe_account=None,
+                 api_version=None, **params):
         base = self.get('url')
         id = util.utf8(id)
         extn = urllib.quote_plus(id)
         url = "%s/%s" % (base, extn)
 
-        return self.request('get', url, params)
+        return self.request(
+            'get', url, params, api_key=api_key, stripe_account=stripe_account,
+            api_version=api_version)
 
     def __iter__(self):
         return getattr(self, 'data', []).__iter__()
@@ -442,14 +478,16 @@ class ListableAPIResource(APIResource):
         return cls.list(*args, **params).auto_paging_iter()
 
     @classmethod
-    def list(cls, api_key=None, stripe_account=None, **params):
-        requestor = api_requestor.APIRequestor(api_key,
-                                               api_base=cls.api_base(),
-                                               account=stripe_account)
+    def list(cls, api_key=None, stripe_account=None, api_version=None,
+             **params):
+        requestor = cls._api_requestor(
+            api_key=api_key, stripe_account=stripe_account,
+            api_version=api_version)
         url = cls.class_url()
         response, api_key = requestor.request('get', url, params)
-        stripe_object = convert_to_stripe_object(response, api_key,
-                                                 stripe_account)
+        stripe_object = convert_to_stripe_object(
+            response, api_key, requestor.stripe_account,
+            api_version=requestor.api_version)
         stripe_object._retrieve_params = params
         return stripe_object
 
@@ -457,24 +495,32 @@ class ListableAPIResource(APIResource):
 class CreateableAPIResource(APIResource):
 
     @classmethod
-    def create(cls, api_key=None, idempotency_key=None,
-               stripe_account=None, **params):
-        requestor = api_requestor.APIRequestor(api_key, account=stripe_account)
+    def create(cls, api_key=None, idempotency_key=None, stripe_account=None,
+               api_version=None, **params):
+        requestor = cls._api_requestor(
+            api_key=api_key, stripe_account=stripe_account,
+            api_version=api_version)
         url = cls.class_url()
         headers = populate_headers(idempotency_key)
         response, api_key = requestor.request('post', url, params, headers)
-        return convert_to_stripe_object(response, api_key, stripe_account)
+        return convert_to_stripe_object(
+            response, api_key, requestor.stripe_account,
+            api_version=requestor.api_version)
 
 
 class UpdateableAPIResource(APIResource):
 
     @classmethod
     def _modify(cls, url, api_key=None, idempotency_key=None,
-                stripe_account=None, **params):
-        requestor = api_requestor.APIRequestor(api_key, account=stripe_account)
+                stripe_account=None, api_version=None, **params):
+        requestor = cls._api_requestor(
+            api_key=api_key, stripe_account=stripe_account,
+            api_version=api_version)
         headers = populate_headers(idempotency_key)
         response, api_key = requestor.request('post', url, params, headers)
-        return convert_to_stripe_object(response, api_key, stripe_account)
+        return convert_to_stripe_object(
+            response, api_key, requestor.stripe_account,
+            api_version=requestor.api_version)
 
     @classmethod
     def modify(cls, sid, **params):
@@ -504,8 +550,8 @@ class DeletableAPIResource(APIResource):
 class Account(CreateableAPIResource, ListableAPIResource,
               UpdateableAPIResource, DeletableAPIResource):
     @classmethod
-    def retrieve(cls, id=None, api_key=None, **params):
-        instance = cls(id, api_key, **params)
+    def retrieve(cls, id=None, api_key=None, stripe_account=None, **params):
+        instance = cls(id, **params)
         instance.refresh()
         return instance
 
@@ -532,9 +578,7 @@ class Account(CreateableAPIResource, ListableAPIResource,
             params = {"reason": reason}
         else:
             params = {}
-        self.refresh_from(
-            self.request('post', url, params, headers)
-        )
+        self.refresh_from(self.request('post', url, params, headers))
         return self
 
     def deauthorize(self, **params):
@@ -571,7 +615,8 @@ class AlipayAccount(UpdateableAPIResource, DeletableAPIResource):
         return cls._modify(url, **params)
 
     @classmethod
-    def retrieve(cls, id, api_key=None, stripe_account=None, **params):
+    def retrieve(cls, id, api_key=None, stripe_account=None,
+                 api_version=None, **params):
         raise NotImplementedError(
             "Can't retrieve an Alipay account without a customer ID. "
             "Use customer.sources.retrieve('alipay_account_id') instead.")
@@ -631,7 +676,8 @@ class Card(UpdateableAPIResource, DeletableAPIResource):
             "account.external_accounts.retrieve('card_id') instead.")
 
     @classmethod
-    def retrieve(cls, id, api_key=None, stripe_account=None, **params):
+    def retrieve(cls, id, api_key=None, stripe_account=None,
+                 api_version=None, **params):
         raise NotImplementedError(
             "Can't retrieve a card without a customer, recipient or account "
             "ID. Use customer.sources.retrieve('card_id'), "
@@ -682,7 +728,8 @@ class BankAccount(UpdateableAPIResource, DeletableAPIResource, VerifyMixin):
             "account.external_accounts.retrieve('bank_account_id') instead.")
 
     @classmethod
-    def retrieve(cls, id, api_key=None, stripe_account=None, **params):
+    def retrieve(cls, id, api_key=None, stripe_account=None,
+                 api_version=None, **params):
         raise NotImplementedError(
             "Can't retrieve a bank account without a customer or account ID. "
             "Use customer.sources.retrieve('bank_account_id') or "
@@ -704,22 +751,30 @@ class Charge(CreateableAPIResource, ListableAPIResource,
         self.refresh_from(self.request('post', url, params, headers))
         return self
 
-    def update_dispute(self, idempotency_key=None, **params):
-        requestor = api_requestor.APIRequestor(self.api_key,
-                                               account=self.stripe_account)
+    def update_dispute(self, idempotency_key=None, api_key=None,
+                       stripe_account=None, api_version=None, **params):
+        requestor = self._api_requestor(
+            instance=self, api_key=api_key, stripe_account=stripe_account,
+            api_version=api_version)
         url = self.instance_url() + '/dispute'
         headers = populate_headers(idempotency_key)
         response, api_key = requestor.request('post', url, params, headers)
-        self.refresh_from({'dispute': response}, api_key, True)
+        self.refresh_from({'dispute': response}, api_key=api_key,
+                          api_version=requestor.api_version, partial=True,
+                          stripe_account=requestor.stripe_account)
         return self.dispute
 
-    def close_dispute(self, idempotency_key=None):
-        requestor = api_requestor.APIRequestor(self.api_key,
-                                               account=self.stripe_account)
+    def close_dispute(self, idempotency_key=None, api_key=None,
+                      stripe_account=None, api_version=None, **params):
+        requestor = self._api_requestor(
+            instance=self, api_key=api_key, stripe_account=stripe_account,
+            api_version=api_version)
         url = self.instance_url() + '/dispute/close'
         headers = populate_headers(idempotency_key)
         response, api_key = requestor.request('post', url, {}, headers)
-        self.refresh_from({'dispute': response}, api_key, True)
+        self.refresh_from({'dispute': response}, api_key=api_key,
+                          api_version=requestor.api_version, partial=True,
+                          stripe_account=requestor.stripe_account)
         return self.dispute
 
     def mark_as_fraudulent(self, idempotency_key=None):
@@ -754,62 +809,98 @@ class Dispute(CreateableAPIResource, ListableAPIResource,
 class Customer(CreateableAPIResource, UpdateableAPIResource,
                ListableAPIResource, DeletableAPIResource):
 
-    def add_invoice_item(self, idempotency_key=None, **params):
+    def add_invoice_item(self, idempotency_key=None, api_key=None,
+                         stripe_account=None, api_version=None, **params):
+        requestor = self._api_requestor(
+            instance=self, api_key=api_key, stripe_account=stripe_account,
+            api_version=api_version)
         params['customer'] = self.id
-        ii = InvoiceItem.create(self.api_key,
-                                idempotency_key=idempotency_key, **params)
+        ii = InvoiceItem.create(
+            api_key=requestor.api_key, idempotency_key=idempotency_key,
+            stripe_account=requestor.stripe_account,
+            api_version=requestor.api_version, **params)
         return ii
 
-    def invoices(self, **params):
+    def invoices(self, api_key=None, stripe_account=None,
+                 api_version=None, **params):
+        requestor = self._api_requestor(
+            instance=self, api_key=api_key, stripe_account=stripe_account,
+            api_version=api_version)
         params['customer'] = self.id
-        invoices = Invoice.list(self.api_key, **params)
+        invoices = Invoice.list(
+            api_key=requestor.api_key, stripe_account=requestor.stripe_account,
+            api_version=requestor.api_version, **params)
         return invoices
 
-    def invoice_items(self, **params):
+    def invoice_items(self, api_key=None, stripe_account=None,
+                      api_version=None, **params):
+        requestor = self._api_requestor(
+            instance=self, api_key=api_key, stripe_account=stripe_account,
+            api_version=api_version)
         params['customer'] = self.id
-        iis = InvoiceItem.list(self.api_key, **params)
+        iis = InvoiceItem.list(
+            api_key=requestor.api_key, stripe_account=requestor.stripe_account,
+            api_version=requestor.api_version, **params)
         return iis
 
-    def charges(self, **params):
+    def charges(self, api_key=None, stripe_account=None, api_version=None,
+                **params):
+        requestor = self._api_requestor(
+            instance=self, api_key=api_key, stripe_account=stripe_account,
+            api_version=api_version)
         params['customer'] = self.id
-        charges = Charge.list(self.api_key, **params)
+        charges = Charge.list(
+            api_key=requestor.api_key, stripe_account=requestor.stripe_account,
+            api_version=requestor.api_version, **params)
         return charges
 
-    def update_subscription(self, idempotency_key=None, **params):
+    def update_subscription(self, idempotency_key=None, api_key=None,
+                            stripe_account=None, api_version=None, **params):
         warnings.warn(
             'The `update_subscription` method is deprecated. Instead, use the '
             '`subscriptions` resource on the customer object to update a '
             'subscription',
             DeprecationWarning)
-        requestor = api_requestor.APIRequestor(self.api_key,
-                                               account=self.stripe_account)
+        requestor = self._api_requestor(
+            instance=self, api_key=api_key, stripe_account=stripe_account,
+            api_version=api_version)
         url = self.instance_url() + '/subscription'
         headers = populate_headers(idempotency_key)
         response, api_key = requestor.request('post', url, params, headers)
-        self.refresh_from({'subscription': response}, api_key, True)
+        self.refresh_from({'subscription': response}, api_key=api_key,
+                          api_version=requestor.api_version, partial=True,
+                          stripe_account=requestor.stripe_account)
         return self.subscription
 
-    def cancel_subscription(self, idempotency_key=None, **params):
+    def cancel_subscription(self, idempotency_key=None, api_key=None,
+                            stripe_account=None, api_version=None, **params):
         warnings.warn(
             'The `cancel_subscription` method is deprecated. Instead, use the '
             '`subscriptions` resource on the customer object to cancel a '
             'subscription',
             DeprecationWarning)
-        requestor = api_requestor.APIRequestor(self.api_key,
-                                               account=self.stripe_account)
+        requestor = self._api_requestor(
+            instance=self, api_key=api_key, stripe_account=stripe_account,
+            api_version=api_version)
         url = self.instance_url() + '/subscription'
         headers = populate_headers(idempotency_key)
         response, api_key = requestor.request('delete', url, params, headers)
-        self.refresh_from({'subscription': response}, api_key, True)
+        self.refresh_from({'subscription': response}, api_key=api_key,
+                          api_version=requestor.api_version, partial=True,
+                          stripe_account=requestor.stripe_account)
         return self.subscription
 
     # TODO: Remove arg in next major release.
-    def delete_discount(self, **params):
-        requestor = api_requestor.APIRequestor(self.api_key,
-                                               account=self.stripe_account)
+    def delete_discount(self, api_key=None, stripe_account=None,
+                        api_version=None, **params):
+        requestor = self._api_requestor(
+            instance=self, api_key=api_key, stripe_account=stripe_account,
+            api_version=api_version)
         url = self.instance_url() + '/discount'
         _, api_key = requestor.request('delete', url)
-        self.refresh_from({'discount': None}, api_key, True)
+        self.refresh_from({'discount': None}, api_key=api_key,
+                          api_version=requestor.api_version, partial=True,
+                          stripe_account=requestor.stripe_account)
 
     @classmethod
     def modify_source(cls, sid, source_id, **params):
@@ -827,15 +918,19 @@ class Invoice(CreateableAPIResource, ListableAPIResource,
         return self.request('post', self.instance_url() + '/pay', {}, headers)
 
     @classmethod
-    def upcoming(cls, api_key=None, stripe_account=None, **params):
+    def upcoming(cls, api_key=None, stripe_account=None, api_version=None,
+                 **params):
         if "subscription_items" in params:
             items = convert_array_to_dict(params["subscription_items"])
             params["subscription_items"] = items
-        requestor = api_requestor.APIRequestor(api_key,
-                                               account=stripe_account)
+        requestor = cls._api_requestor(
+            api_key=api_key, stripe_account=stripe_account,
+            api_version=api_version)
         url = cls.class_url() + '/upcoming'
         response, api_key = requestor.request('get', url, params)
-        return convert_to_stripe_object(response, api_key, stripe_account)
+        return convert_to_stripe_object(
+            response, api_key, requestor.stripe_account,
+            api_version=requestor.api_version)
 
 
 class InvoiceItem(CreateableAPIResource, UpdateableAPIResource,
@@ -852,12 +947,16 @@ class Subscription(CreateableAPIResource, DeletableAPIResource,
                    UpdateableAPIResource, ListableAPIResource):
 
     # TODO: Remove arg in next major release.
-    def delete_discount(self, **params):
-        requestor = api_requestor.APIRequestor(self.api_key,
-                                               account=self.stripe_account)
+    def delete_discount(self, api_key=None, stripe_account=None,
+                        api_version=None, **params):
+        requestor = self._api_requestor(
+            instance=self, api_key=api_key, stripe_account=stripe_account,
+            api_version=api_version)
         url = self.instance_url() + '/discount'
         _, api_key = requestor.request('delete', url)
-        self.refresh_from({'discount': None}, api_key, True)
+        self.refresh_from({'discount': None}, api_key=api_key,
+                          api_version=requestor.api_version, partial=True,
+                          stripe_account=requestor.stripe_account)
 
     @classmethod
     def modify(cls, sid, **params):
@@ -930,7 +1029,8 @@ class Reversal(UpdateableAPIResource):
             "ID. Call save on transfer.reversals.retrieve('reversal_id')")
 
     @classmethod
-    def retrieve(cls, id, api_key=None, **params):
+    def retrieve(cls, id, api_key=None, stripe_account=None,
+                 api_version=None, **params):
         raise NotImplementedError(
             "Can't retrieve a reversal without a transfer"
             "ID. Use transfer.reversals.retrieve('reversal_id')")
@@ -939,9 +1039,15 @@ class Reversal(UpdateableAPIResource):
 class Recipient(CreateableAPIResource, UpdateableAPIResource,
                 ListableAPIResource, DeletableAPIResource):
 
-    def transfers(self, **params):
+    def transfers(self, api_key=None, stripe_account=None, api_version=None,
+                  **params):
+        requestor = self._api_requestor(
+            instance=self, api_key=api_key, stripe_account=stripe_account,
+            api_version=api_version)
         params['recipient'] = self.id
-        transfers = Transfer.list(self.api_key, **params)
+        transfers = Transfer.list(
+            api_key=requestor.api_key, stripe_account=requestor.stripe_account,
+            api_version=requestor.api_version, **params)
         return transfers
 
 
@@ -960,16 +1066,20 @@ class FileUpload(ListableAPIResource):
         return 'file'
 
     @classmethod
-    def create(cls, api_key=None, stripe_account=None, **params):
-        requestor = api_requestor.APIRequestor(
-            api_key, api_base=cls.api_base(), account=stripe_account)
+    def create(cls, api_key=None, stripe_account=None, api_version=None,
+               **params):
+        requestor = cls._api_requestor(
+            api_key=api_key, stripe_account=stripe_account,
+            api_version=api_version)
         url = cls.class_url()
         supplied_headers = {
             "Content-Type": "multipart/form-data"
         }
         response, api_key = requestor.request(
             'post', url, params=params, headers=supplied_headers)
-        return convert_to_stripe_object(response, api_key, stripe_account)
+        return convert_to_stripe_object(
+            response, api_key, requestor.stripe_account,
+            api_version=requestor.api_version)
 
 
 class ApplicationFee(ListableAPIResource):
@@ -1004,7 +1114,8 @@ class ApplicationFeeRefund(UpdateableAPIResource):
         return self._build_instance_url(self.fee, self.id)
 
     @classmethod
-    def retrieve(cls, id, api_key=None, **params):
+    def retrieve(cls, id, api_key=None, stripe_account=None,
+                 api_version=None, **params):
         raise NotImplementedError(
             "Can't retrieve a refund without an application fee ID. "
             "Use application_fee.refunds.retrieve('refund_id') instead.")

--- a/stripe/test/resources/test_stripe_object.py
+++ b/stripe/test/resources/test_stripe_object.py
@@ -11,10 +11,12 @@ class StripeObjectTests(StripeUnitTestCase):
 
     def test_initializes_with_parameters(self):
         obj = stripe.resource.StripeObject(
-            'foo', 'bar', myparam=5, yourparam='boo')
+            'foo', 'bar', myparam=5, yourparam='boo',
+            api_version='myversion')
 
         self.assertEqual('foo', obj.id)
         self.assertEqual('bar', obj.api_key)
+        self.assertEqual('myversion', obj.api_version)
 
     def test_access(self):
         obj = stripe.resource.StripeObject('myid', 'mykey', myparam=5)
@@ -48,9 +50,10 @@ class StripeObjectTests(StripeUnitTestCase):
         obj = stripe.resource.StripeObject.construct_from({
             'foo': 'bar',
             'trans': 'me',
-        }, 'mykey')
+        }, 'mykey', api_version='myversion')
 
         self.assertEqual('mykey', obj.api_key)
+        self.assertEqual('myversion', obj.api_version)
         self.assertEqual('bar', obj.foo)
         self.assertEqual('me', obj['trans'])
         self.assertEqual(None, obj.stripe_account)
@@ -82,13 +85,15 @@ class StripeObjectTests(StripeUnitTestCase):
                     {'id': 'nested'}
                 ],
             }
-        }, 'key', stripe_account='acct_foo')
+        }, 'key', stripe_account='acct_foo', api_version='myversion')
 
         nested = obj.foos.data[0]
 
         self.assertEqual('key', obj.api_key)
+        self.assertEqual('myversion', obj.api_version)
         self.assertEqual('nested', nested.id)
         self.assertEqual('key', nested.api_key)
+        self.assertEqual('myversion', nested.api_version)
         self.assertEqual('acct_foo', nested.stripe_account)
 
     def test_refresh_from_nested_object(self):
@@ -140,7 +145,9 @@ class StripeObjectTests(StripeUnitTestCase):
             'foo', 'bar', myparam=5)
 
         obj['object'] = 'boo'
-        obj.refresh_from({'fala': 'lalala'}, api_key='bar', partial=True)
+        obj.refresh_from(
+            {'fala': 'lalala'}, api_key='bar', partial=True,
+            api_version='myversion')
 
         self.assertEqual('lalala', obj.fala)
 
@@ -149,6 +156,7 @@ class StripeObjectTests(StripeUnitTestCase):
 
         self.assertEqual('foo', newobj.id)
         self.assertEqual('bar', newobj.api_key)
+        self.assertEqual('myversion', newobj.api_version)
         self.assertEqual('boo', newobj['object'])
         self.assertEqual('lalala', newobj.fala)
 
@@ -172,7 +180,7 @@ class StripeObjectTests(StripeUnitTestCase):
             'empty': '',
             'value': 'foo',
             'nested': nested,
-        }, 'mykey', stripe_account='myaccount')
+        }, 'mykey', stripe_account='myaccount', api_version='myversion')
 
         copied = copy(obj)
 
@@ -181,6 +189,7 @@ class StripeObjectTests(StripeUnitTestCase):
         self.assertEqual('bar', copied.nested.value)
 
         self.assertEqual('mykey', copied.api_key)
+        self.assertEqual('myversion', copied.api_version)
         self.assertEqual('myaccount', copied.stripe_account)
 
         # Verify that we're not deep copying nested values.
@@ -194,7 +203,7 @@ class StripeObjectTests(StripeUnitTestCase):
             'empty': '',
             'value': 'foo',
             'nested': nested,
-        }, 'mykey', stripe_account='myaccount')
+        }, 'mykey', stripe_account='myaccount', api_version='myversion')
 
         copied = deepcopy(obj)
 
@@ -203,6 +212,7 @@ class StripeObjectTests(StripeUnitTestCase):
         self.assertEqual('bar', copied.nested.value)
 
         self.assertEqual('mykey', copied.api_key)
+        self.assertEqual('myversion', copied.api_version)
         self.assertEqual('myaccount', copied.stripe_account)
 
         # Verify that we're actually deep copying nested values.


### PR DESCRIPTION
Hello!  This is a first contribution to `stripe-python` but we've (my company has) got Stripe integrated into production and I'm a frequent contributor to [dj-stripe](https://github.com/kavdev/dj-stripe), a library for interfacing Django with Stripe via this library. :-)

This is being submitted as a Work In Progress in order to get some initial feedback before proceeding with additional work in getting it landed.  So the disclaimer here is that there are *no* additional test cases added yet (but we'll do that prior to completion), although the full test suite does execute successfully.

The background is that in [dj-stripe](https://github.com/kavdev/dj-stripe) we're processing events using the `api_version` that is indicated in the event messages, which as of the current version means temporarily switching the global `stripe.api_version` to that (via a context manager) and then switching it back again to whatever was previously configured.  As you can [see here](https://github.com/kavdev/dj-stripe/blob/d7c6cc16d74d358a815661b2a413d3f3df169be0/djstripe/stripe_objects.py#L927-L928).

This generally works but we're worried about changing globals in the application state, especially for situations in which  the event webhooks are processed in the same multi-threaded server where other (normal) workload with Stripe happens (e.g. creating customers on user sign-up).

The thought is that in the moments when the context manager has changed the global `api_version`, it will affect any other place utilising Stripe.  This isn't likely to cause a lot of issues, but it certainly doesn't feel right, and obviously with billing related is desired to be as water-tight as possible. ;-)

So, this PR builds on a3373ac and suggests to add `api_version` as a passthrough argument for resources *and* adds additional stickiness for it when resources are constructed.  A contentious point of this PR is the addition of a slightly more uniform approach to arguments that are ultimately passed through to the `APIRequestor` via a factory classmethod that performs the work.

On one hand it greatly tidies up these arguments, and means the logic for `APIRequestor` is contained to one place, and would mean simplify future changes to this area.  On the other hand it removes some of the explicitness of the passthrough arguments, which some will see as bad (and it may break clients that use positional arguments, even though they probably shouldn't).  In saying that, there was some varying consistency on exactly what arguments were supported where, and this does fix that.

Thoughts and feedback greatly welcomed - Thank you in advance!

P.S. I'm not opposed to reversing any part of the changes, but supporting passthrough on some level would be greatly appreciated for the sake of correctness. :-)