### PR TITLE
Constrain Requests to < 2.13.0 if on setuptools < 18.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,23 @@ try:
 except ImportError:
     from distutils.core import setup
 
+# The Requests package added a release in 2.14.0 that broke a whole bunch of
+# people on old versions of pip and setuptools (< 18.0.0). Here we check to see
+# whether we have a version that might be affected so that we can add a maximum
+# version for Requests.
+#
+# This can probably removed after most people have moved to setuptools 18.0.0+.
+#
+# More context here: https://github.com/stripe/stripe-python/pull/311
+old_setuptools_version = False
+try:
+    from distutils.version import StrictVersion
+    import setuptools
+    if StrictVersion(setuptools.__version__) < StrictVersion("18.0.0"):
+        old_setuptools_version = True
+except ImportError:
+    pass
+
 try:
     from distutils.command.build_py import build_py_2to3 as build_py
 except ImportError:
@@ -25,6 +42,8 @@ if sys.version_info < (2, 6):
         DeprecationWarning)
     install_requires.append('requests >= 0.8.8, < 0.10.1')
     install_requires.append('ssl')
+elif old_setuptools_version:
+    install_requires.append('requests >= 0.8.8, < 2.14.0')
 else:
     install_requires.append('requests >= 0.8.8')
 


### PR DESCRIPTION
See #307 for context, but the Requests packaged added a release that broke a lot of people on old versions of pip/setuptools. Here we constrain the library to < 2.13.0 if we detect setuptools < 18.0.0.

Fixes #307.