### PR TITLE
Fix pycurl client with Python 3

### DIFF
--- a/stripe/test/test_http_client.py
+++ b/stripe/test/test_http_client.py
@@ -274,27 +274,27 @@ class PycurlClientTests(StripeUnitTestCase, ClientTestBase):
     def setUp(self):
         super(PycurlClientTests, self).setUp()
 
-        self.sio_patcher = patch('stripe.util.StringIO.StringIO')
+        self.bio_patcher = patch('stripe.util.io.BytesIO')
 
-        sio_mock = Mock()
-        self.sio_patcher.start().return_value = sio_mock
-        self.sio_getvalue = sio_mock.getvalue
+        bio_mock = Mock()
+        self.bio_patcher.start().return_value = bio_mock
+        self.bio_getvalue = bio_mock.getvalue
 
     def tearDown(self):
         super(PycurlClientTests, self).tearDown()
 
-        self.sio_patcher.stop()
+        self.bio_patcher.stop()
 
     def mock_response(self, mock, body, code):
-        self.sio_getvalue.return_value = body
+        self.bio_getvalue.return_value = body.encode('utf-8')
 
         mock.getinfo.return_value = code
 
     def mock_error(self, mock):
         class FakeException(BaseException):
-
-            def __getitem__(self, i):
-                return 'foo'
+            @property
+            def args(self):
+                return ('foo', 'bar')
 
         stripe.http_client.pycurl.error = FakeException
         mock.perform.side_effect = stripe.http_client.pycurl.error

--- a/stripe/util.py
+++ b/stripe/util.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import hmac
+import io
 import logging
 import sys
 import os
@@ -14,7 +15,7 @@ STRIPE_LOG = os.environ.get('STRIPE_LOG')
 logger = logging.getLogger('stripe')
 
 __all__ = [
-    'StringIO',
+    'io',
     'parse_qsl',
     'json',
     'utf8',
@@ -23,12 +24,6 @@ __all__ = [
     'dashboard_link',
     'logfmt',
 ]
-
-try:
-    # When cStringIO is available
-    import cStringIO as StringIO
-except ImportError:
-    import StringIO
 
 try:
     from urlparse import parse_qsl


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Fixes #317.

There are two issues preventing the pycurl client from working with Python 3:

- we use `StringIO` when we should be using `BytesIO`

- we don't access the `pycurl.error` parameters correctly

This PR fixes both issues.
