### PR TITLE
Try relative Python imports

### DIFF
--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -22,7 +22,7 @@ app_info = None
 log = None
 
 # Resource
-from stripe.resource import (  # noqa
+from .resource import (  # noqa
     Account,
     AlipayAccount,
     ApplePayDomain,
@@ -60,16 +60,16 @@ from stripe.resource import (  # noqa
     Transfer)
 
 # OAuth
-from stripe.oauth import OAuth  # noqa
+from .oauth import OAuth  # noqa
 
 # Webhooks
-from stripe.webhook import Webhook, WebhookSignature  # noqa
+from .webhook import Webhook, WebhookSignature  # noqa
 
 # Error imports.  Note that we may want to move these out of the root
 # namespace in the future and you should prefer to access them via
 # the fully qualified `stripe.error` module.
 
-from stripe.error import (  # noqa
+from .error import (  # noqa
     APIConnectionError,
     APIError,
     AuthenticationError,
@@ -84,9 +84,9 @@ from stripe.error import (  # noqa
 # DEPRECATED: These imports will be moved out of the root stripe namespace
 # in version 2.0
 
-from stripe.version import VERSION  # noqa
-from stripe.api_requestor import APIRequestor  # noqa
-from stripe.resource import (  # noqa
+from .version import VERSION  # noqa
+from .api_requestor import APIRequestor  # noqa
+from .resource import (  # noqa
     APIResource,
     CreateableAPIResource,
     DeletableAPIResource,
@@ -97,7 +97,7 @@ from stripe.resource import (  # noqa
     StripeObjectEncoder,
     UpdateableAPIResource,
     convert_to_stripe_object)
-from stripe.util import json, logger  # noqa
+from .util import json, logger  # noqa
 
 
 # Sets some basic information about the running application that's sent along

--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -7,8 +7,8 @@ import urlparse
 import warnings
 
 import stripe
-from stripe import error, http_client, version, util
-from stripe.multipart_data_generator import MultipartDataGenerator
+from . import error, http_client, version, util
+from .multipart_data_generator import MultipartDataGenerator
 
 
 def _encode_datetime(dttime):
@@ -70,8 +70,8 @@ class APIRequestor(object):
         self.api_version = api_version or stripe.api_version
         self.stripe_account = account
 
-        from stripe import verify_ssl_certs as verify
-        from stripe import proxy
+        from . import verify_ssl_certs as verify
+        from . import proxy
 
         self._client = client or stripe.default_http_client or \
             http_client.new_default_http_client(
@@ -231,7 +231,7 @@ class APIRequestor(object):
         if self.api_key:
             my_api_key = self.api_key
         else:
-            from stripe import api_key
+            from . import api_key
             my_api_key = api_key
 
         if my_api_key is None:
@@ -345,39 +345,39 @@ class APIRequestor(object):
         return client._handle_request_error(*args)
 
     def requests_request(self, meth, abs_url, headers, params):
-        from stripe.http_client import RequestsClient
+        from .http_client import RequestsClient
         return self._deprecated_request(RequestsClient, meth, abs_url,
                                         headers, params)
 
     def handle_requests_error(self, err):
-        from stripe.http_client import RequestsClient
+        from .http_client import RequestsClient
         return self._deprecated_handle_error(RequestsClient, err)
 
     def pycurl_request(self, meth, abs_url, headers, params):
-        from stripe.http_client import PycurlClient
+        from .http_client import PycurlClient
         return self._deprecated_request(PycurlClient, meth, abs_url,
                                         headers, params)
 
     def handle_pycurl_error(self, err):
-        from stripe.http_client import PycurlClient
+        from .http_client import PycurlClient
         return self._deprecated_handle_error(PycurlClient, err)
 
     def urlfetch_request(self, meth, abs_url, headers, params):
-        from stripe.http_client import UrlFetchClient
+        from .http_client import UrlFetchClient
         return self._deprecated_request(UrlFetchClient, meth, abs_url,
                                         headers, params)
 
     def handle_urlfetch_error(self, err, abs_url):
-        from stripe.http_client import UrlFetchClient
+        from .http_client import UrlFetchClient
         return self._deprecated_handle_error(UrlFetchClient, err, abs_url)
 
     def urllib2_request(self, meth, abs_url, headers, params):
-        from stripe.http_client import Urllib2Client
+        from .http_client import Urllib2Client
         return self._deprecated_request(Urllib2Client, meth, abs_url,
                                         headers, params)
 
     def handle_urllib2_error(self, err, abs_url):
-        from stripe.http_client import Urllib2Client
+        from .http_client import Urllib2Client
         return self._deprecated_handle_error(Urllib2Client, err, abs_url)
 
 

--- a/stripe/http_client.py
+++ b/stripe/http_client.py
@@ -223,6 +223,12 @@ class PycurlClient(HTTPClient):
     def __init__(self, verify_ssl_certs=True, proxy=None):
         super(PycurlClient, self).__init__(
             verify_ssl_certs=verify_ssl_certs, proxy=proxy)
+
+        if pycurl is None:
+            raise ImportError(
+                "It doesn't appear that pycurl could be imported. Is it "
+                "installed?")
+
         # need to urlparse the proxy, since PyCurl
         # consumes the proxy url in small pieces
         if self._proxy:

--- a/stripe/importer.py
+++ b/stripe/importer.py
@@ -12,5 +12,5 @@ def import_json():
         "`from importer import json` instead'",
         DeprecationWarning)
 
-    from stripe.util import json
+    from .util import json
     return json


### PR DESCRIPTION
Moves from absolute imports to relative imports (i.e. prefix with a `.`
instead of a fully qualified `stripe.`).

I didn't change the test suite because it's not necessary and we might
want to move that out of the `stripe` module and into a `tests`
directory eventually anyway.