### PR TITLE
Update OAuth implementation

### DIFF
--- a/examples/oauth.py
+++ b/examples/oauth.py
@@ -26,7 +26,7 @@ def callback():
     code = request.args.get('code')
     try:
         resp = stripe.OAuth.token(grant_type='authorization_code', code=code)
-    except stripe.error.OAuthError as e:
+    except stripe.oauth_error.OAuthError as e:
         return 'Error: ' + str(e)
 
     return '''
@@ -41,7 +41,7 @@ def deauthorize():
     stripe_user_id = request.args.get('stripe_user_id')
     try:
         stripe.OAuth.deauthorize(stripe_user_id=stripe_user_id)
-    except stripe.error.OAuthError as e:
+    except stripe.oauth_error.OAuthError as e:
         return 'Error: ' + str(e)
 
     return '''

--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -77,9 +77,12 @@ from stripe.error import (  # noqa
     RateLimitError,
     CardError,
     InvalidRequestError,
-    OAuthError,
     SignatureVerificationError,
     StripeError)
+
+# OAuth error classes are not imported into the root namespace and must be
+# accessed via stripe.oauth_error.<Exception>
+from stripe import oauth_error  # noqa
 
 # DEPRECATED: These imports will be moved out of the root stripe namespace
 # in version 2.0

--- a/stripe/oauth.py
+++ b/stripe/oauth.py
@@ -36,14 +36,14 @@ class OAuth(object):
 
     @staticmethod
     def token(**params):
-        requestor = api_requestor.OAuthRequestor(api_base=connect_api_base)
+        requestor = api_requestor.APIRequestor(api_base=connect_api_base)
         response, api_key = requestor.request(
             'post', '/oauth/token', params, None)
         return response
 
     @staticmethod
     def deauthorize(**params):
-        requestor = api_requestor.OAuthRequestor(api_base=connect_api_base)
+        requestor = api_requestor.APIRequestor(api_base=connect_api_base)
         OAuth._set_client_id(params)
         response, api_key = requestor.request(
             'post', '/oauth/deauthorize', params, None)

--- a/stripe/oauth_error.py
+++ b/stripe/oauth_error.py
@@ -1,0 +1,29 @@
+from stripe.error import StripeError
+
+
+class OAuthError(StripeError):
+    def __init__(self, code, description, http_body=None,
+                 http_status=None, json_body=None, headers=None):
+        super(OAuthError, self).__init__(
+            description, http_body, http_status, json_body, headers)
+        self.code = code
+
+
+class InvalidGrantError(OAuthError):
+    pass
+
+
+class InvalidRequestError(OAuthError):
+    pass
+
+
+class InvalidScopeError(OAuthError):
+    pass
+
+
+class UnsupportedGrantTypeError(OAuthError):
+    pass
+
+
+class UnsupportedResponseTypeError(OAuthError):
+    pass

--- a/stripe/test/helper.py
+++ b/stripe/test/helper.py
@@ -167,38 +167,12 @@ class StripeUnitTestCase(StripeTestCase):
             patcher.stop()
 
 
-class StripeAPIRequestorTestCase(StripeUnitTestCase):
-    REQUESTOR_CLS = stripe.api_requestor.APIRequestor
-
-    def setUp(self):
-        super(StripeAPIRequestorTestCase, self).setUp()
-
-        self.http_client = Mock(stripe.http_client.HTTPClient)
-        self.http_client._verify_ssl_certs = True
-        self.http_client.name = 'mockclient'
-
-        self.requestor = self.REQUESTOR_CLS(client=self.http_client)
-
-    def mock_response(self, return_body, return_code, requestor=None,
-                      headers=None):
-        if not requestor:
-            requestor = self.requestor
-
-        self.http_client.request = Mock(
-            return_value=(return_body, return_code, headers or {}))
-
-
-class StripeOAuthRequestorTestCase(StripeAPIRequestorTestCase):
-    REQUESTOR_CLS = stripe.api_requestor.OAuthRequestor
-
-
 class StripeApiTestCase(StripeTestCase):
-    REQUESTOR_CLS_NAME = 'stripe.api_requestor.APIRequestor'
 
     def setUp(self):
         super(StripeApiTestCase, self).setUp()
 
-        self.requestor_patcher = patch(self.REQUESTOR_CLS_NAME)
+        self.requestor_patcher = patch('stripe.api_requestor.APIRequestor')
         requestor_class_mock = self.requestor_patcher.start()
         self.requestor_mock = requestor_class_mock.return_value
 
@@ -209,14 +183,6 @@ class StripeApiTestCase(StripeTestCase):
 
     def mock_response(self, res):
         self.requestor_mock.request = Mock(return_value=(res, 'reskey'))
-
-
-class StripeOAuthTestCase(StripeApiTestCase):
-    REQUESTOR_CLS_NAME = 'stripe.api_requestor.OAuthRequestor'
-
-    def setUp(self):
-        super(StripeOAuthTestCase, self).setUp()
-        self.mock_response({})
 
 
 class StripeResourceTest(StripeApiTestCase):

--- a/stripe/test/test_oauth.py
+++ b/stripe/test/test_oauth.py
@@ -1,12 +1,13 @@
 import urlparse
 
 import stripe
-from stripe.test.helper import StripeOAuthTestCase
+from stripe.test.helper import StripeApiTestCase
 
 
-class OAuthTests(StripeOAuthTestCase):
+class OAuthTests(StripeApiTestCase):
     def setUp(self):
         super(OAuthTests, self).setUp()
+        self.mock_response({})
 
         stripe.client_id = 'ca_test'
 


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

This PR updates the OAuth implementation to be much closer to the [stripe-ruby implementation](https://github.com/stripe/stripe-ruby/pull/523/files):

- no more dedicated `OAuthRequestor` class. The `APIRequestor` class can now interpret both API and OAuth errors

- dedicated exception classes for each OAuth error type

This is technically a breaking change, but we never documented this feature (and won't until ~all libraries support it) so I don't think this necessarily warrants a major version bump.

The one thing I'm not happy about is the `OAuthInvalidRequestError` class name, to differentiate it from the existing `InvalidRequestError` class. I think it might be worth it moving all the OAuth errors in a different module, e.g. `oauth_error`, so they have their own namespace and we can reuse the `InvalidRequestError` class name.

wdyt?
