### PR TITLE
Re-use `pycurl.Curl` objects between requests

### DIFF
--- a/stripe/http_client.py
+++ b/stripe/http_client.py
@@ -223,6 +223,10 @@ class PycurlClient(HTTPClient):
     def __init__(self, verify_ssl_certs=True, proxy=None):
         super(PycurlClient, self).__init__(
             verify_ssl_certs=verify_ssl_certs, proxy=proxy)
+
+        # Initialize this within the object so that we can reuse connections.
+        self._curl = pycurl.Curl()
+
         # need to urlparse the proxy, since PyCurl
         # consumes the proxy url in small pieces
         if self._proxy:
@@ -241,49 +245,56 @@ class PycurlClient(HTTPClient):
     def request(self, method, url, headers, post_data=None):
         b = util.io.BytesIO()
         rheaders = util.io.BytesIO()
-        curl = pycurl.Curl()
+
+        # Pycurl's design is a little weird: although we set per-request
+        # options on this object, it's also capable of maintaining established
+        # connections. Here we call reset() between uses to make sure it's in a
+        # pristine state, but notably reset() doesn't reset connections, so we
+        # still get to take advantage of those by virtue of re-using the same
+        # object.
+        self._curl.reset()
 
         proxy = self._get_proxy(url)
         if proxy:
             if proxy.hostname:
-                curl.setopt(pycurl.PROXY, proxy.hostname)
+                self._curl.setopt(pycurl.PROXY, proxy.hostname)
             if proxy.port:
-                curl.setopt(pycurl.PROXYPORT, proxy.port)
+                self._curl.setopt(pycurl.PROXYPORT, proxy.port)
             if proxy.username or proxy.password:
-                curl.setopt(
+                self._curl.setopt(
                     pycurl.PROXYUSERPWD,
                     "%s:%s" % (proxy.username, proxy.password))
 
         if method == 'get':
-            curl.setopt(pycurl.HTTPGET, 1)
+            self._curl.setopt(pycurl.HTTPGET, 1)
         elif method == 'post':
-            curl.setopt(pycurl.POST, 1)
-            curl.setopt(pycurl.POSTFIELDS, post_data)
+            self._curl.setopt(pycurl.POST, 1)
+            self._curl.setopt(pycurl.POSTFIELDS, post_data)
         else:
-            curl.setopt(pycurl.CUSTOMREQUEST, method.upper())
+            self._curl.setopt(pycurl.CUSTOMREQUEST, method.upper())
 
         # pycurl doesn't like unicode URLs
-        curl.setopt(pycurl.URL, util.utf8(url))
+        self._curl.setopt(pycurl.URL, util.utf8(url))
 
-        curl.setopt(pycurl.WRITEFUNCTION, b.write)
-        curl.setopt(pycurl.HEADERFUNCTION, rheaders.write)
-        curl.setopt(pycurl.NOSIGNAL, 1)
-        curl.setopt(pycurl.CONNECTTIMEOUT, 30)
-        curl.setopt(pycurl.TIMEOUT, 80)
-        curl.setopt(pycurl.HTTPHEADER, ['%s: %s' % (k, v)
-                                        for k, v in headers.iteritems()])
+        self._curl.setopt(pycurl.WRITEFUNCTION, b.write)
+        self._curl.setopt(pycurl.HEADERFUNCTION, rheaders.write)
+        self._curl.setopt(pycurl.NOSIGNAL, 1)
+        self._curl.setopt(pycurl.CONNECTTIMEOUT, 30)
+        self._curl.setopt(pycurl.TIMEOUT, 80)
+        self._curl.setopt(pycurl.HTTPHEADER, ['%s: %s' % (k, v)
+                                              for k, v in headers.iteritems()])
         if self._verify_ssl_certs:
-            curl.setopt(pycurl.CAINFO, os.path.join(
+            self._curl.setopt(pycurl.CAINFO, os.path.join(
                 os.path.dirname(__file__), 'data/ca-certificates.crt'))
         else:
-            curl.setopt(pycurl.SSL_VERIFYHOST, False)
+            self._curl.setopt(pycurl.SSL_VERIFYHOST, False)
 
         try:
-            curl.perform()
+            self._curl.perform()
         except pycurl.error as e:
             self._handle_request_error(e)
         rbody = b.getvalue().decode('utf-8')
-        rcode = curl.getinfo(pycurl.RESPONSE_CODE)
+        rcode = self._curl.getinfo(pycurl.RESPONSE_CODE)
         headers = self.parse_headers(rheaders.getvalue().decode('utf-8'))
 
         return rbody, rcode, headers


### PR DESCRIPTION
This is poorly documented, but it seems that Pycurl will maintain
established connections between requests [1]. Here we move the
initialization of the `Curl` object to the constructor and keep almsot
everything else the same, with the exception of the addition of a
`self._curl.reset()` call before any request to make sure that our
options are zeroed (`reset` doesn't reset open connections).

Fixes #324.

r? @ob-stripe 

[1] http://pycurl.io/docs/latest/curlobject.html#pycurl.Curl.reset