### PR TITLE
Add optional `code` to `InvalidRequestError`.

### DIFF
--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -192,7 +192,7 @@ class APIRequestor(object):
         elif rcode in [400, 404]:
             return error.InvalidRequestError(
                 error_data.get('message'), error_data.get('param'),
-                rbody, rcode, resp, rheaders)
+                error_data.get('code'), rbody, rcode, resp, rheaders)
         elif rcode == 401:
             return error.AuthenticationError(
                 error_data.get('message'), rbody, rcode, resp, rheaders)

--- a/stripe/error.py
+++ b/stripe/error.py
@@ -58,12 +58,13 @@ class CardError(StripeError):
 
 class InvalidRequestError(StripeError):
 
-    def __init__(self, message, param, http_body=None,
+    def __init__(self, message, param, code=None, http_body=None,
                  http_status=None, json_body=None, headers=None):
         super(InvalidRequestError, self).__init__(
             message, http_body, http_status, json_body,
             headers)
         self.param = param
+        self.code = code
 
 
 class AuthenticationError(StripeError):


### PR DESCRIPTION
A POST to `/v1/charges/ch_xxxx/capture` after the auth has released/expired will respond with a 400 error and body of:
```
{
  "error": {
    "type": "invalid_request_error",
    "message": "Charge ch_xxxx cannot be captured because the charge has expired (a charge must be captured within 7 days). You will need to create a new charge to retry the payment.",
    "code": "charge_expired_for_capture"
  }
}
```

This change exposes the `code` value as an attr on the error instance just as `CardError` does.