### PR TITLE
Add parameters when calling `pay` on an invoice

### DIFF
--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -824,9 +824,10 @@ class Customer(CreateableAPIResource, UpdateableAPIResource,
 class Invoice(CreateableAPIResource, ListableAPIResource,
               UpdateableAPIResource):
 
-    def pay(self, idempotency_key=None):
+    def pay(self, idempotency_key=None, **params):
         headers = populate_headers(idempotency_key)
-        return self.request('post', self.instance_url() + '/pay', {}, headers)
+        return self.request(
+            'post', self.instance_url() + '/pay', params, headers)
 
     @classmethod
     def upcoming(cls, api_key=None, stripe_account=None, **params):

--- a/stripe/test/resources/test_invoices.py
+++ b/stripe/test/resources/test_invoices.py
@@ -66,6 +66,19 @@ class InvoiceTest(StripeResourceTest):
             None
         )
 
+    def test_pay_invoice_params(self):
+        invoice = stripe.Invoice(id="ii_pay")
+        invoice.pay(source="src_foo")
+
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/v1/invoices/ii_pay/pay',
+            {
+                'source': 'src_foo',
+            },
+            None
+        )
+
     def test_upcoming_invoice(self):
         stripe.Invoice.upcoming()
 


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @ark-stripe 

Users can now provide a `source` parameter when paying invoices, but the `pay` method currently does not let users provide any parameters. This PR fixes that.

Thanks to keyword args, this is not a breaking change.