### PR TITLE
Use `-W all` instead of `-W always`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - python setup.py install
 script:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then flake8 stripe; fi
-  - python -W always setup.py test
+  - python -W all setup.py test
 matrix:
   allow_failures:
     - python: 3.7-dev

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     mock
 commands =
     python setup.py clean --all
-    python -W always setup.py test {posargs}
+    python -W all setup.py test {posargs}
 setenv =
     STRIPE_TEST_PYCURL = true
 
@@ -28,4 +28,4 @@ deps =
 commands =
     flake8 stripe
     python setup.py clean --all
-    python -W always setup.py test {posargs}
+    python -W all setup.py test {posargs}


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

This was reported by @jleclanche in #329. `always` is not a a valid value for the `-W` flag. The correct value is `all`. From the man page:

> **all** to print a warning
> each time it occurs (this may generate many messages if a  warn-
> ing  is  triggered  repeatedly for the same source line, such as
> inside a loop)
