### PR TITLE
Fix example for Python 3 compatibility

### DIFF
--- a/examples/webhooks.py
+++ b/examples/webhooks.py
@@ -13,7 +13,7 @@ app = Flask(__name__)
 
 @app.route('/webhooks', methods=['POST'])
 def webhooks():
-    payload = request.data
+    payload = request.data.decode('utf-8')
     received_sig = request.headers.get('Stripe-Signature', None)
 
     try:


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @revmischa

Fix the webhooks example to make it work with Python 3 as well as 2. This was pointed out by @revmischa a couple of weeks back [here](https://github.com/stripe/stripe-python/commit/59078610ff7dfc67c7adb63c8977f6309ae88885#commitcomment-22550934).
