### PR TITLE
Fix serialization of items when saving subscriptions

### DIFF
--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -874,6 +874,13 @@ class Subscription(CreateableAPIResource, DeletableAPIResource,
             params["items"] = convert_array_to_dict(params["items"])
         return super(Subscription, cls).create(**params)
 
+    def serialize(self, previous):
+        updated_params = super(UpdateableAPIResource, self).serialize(previous)
+        if "items" in updated_params:
+            updated_params["items"] = convert_array_to_dict(
+                updated_params["items"])
+        return updated_params
+
 
 class SubscriptionItem(CreateableAPIResource, DeletableAPIResource,
                        UpdateableAPIResource, ListableAPIResource):

--- a/stripe/test/resources/test_subscriptions.py
+++ b/stripe/test/resources/test_subscriptions.py
@@ -56,6 +56,7 @@ class SubscriptionTest(StripeResourceTest):
         trial_end_dttm = datetime.datetime.now() + datetime.timedelta(days=15)
         trial_end_int = int(time.mktime(trial_end_dttm.timetuple()))
 
+        subscription.items = [{"id": "si", "plan": "foo"}]
         subscription.plan = DUMMY_PLAN['id']
         subscription.trial_end = trial_end_int
         subscription.save()
@@ -64,6 +65,12 @@ class SubscriptionTest(StripeResourceTest):
             'post',
             '/v1/subscriptions/test_sub',
             {
+                'items': {
+                    "0": {
+                        "plan": "foo",
+                        "id": "si",
+                    },
+                },
                 'plan': DUMMY_PLAN['id'],
                 'trial_end': trial_end_int
             },


### PR DESCRIPTION
Code had been added to the class methods to properly handle serializing
subscription items to an integer-indexed hash, but the same wasn't
happening for the instance-level `save` method. This patch adds that and
a test to make sure it's happening as expected.

Fixes #336.

r? @ob-stripe
cc @kjc-stripe If you wouldn't mind also taking a look at this ...
cc @stripe/api-libraries 