### PR TITLE
Add type-checking for `id` in APIResource.retrieve

### DIFF
--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -357,10 +357,13 @@ class APIResource(StripeObject):
 
     def instance_url(self):
         id = self.get('id')
-        if not id:
+
+        if not isinstance(id, basestring):
             raise error.InvalidRequestError(
                 'Could not determine which URL to request: %s instance '
-                'has invalid ID: %r' % (type(self).__name__, id), 'id')
+                'has invalid ID: %r, %s. ID should be of type `str` (or'
+                ' `unicode`)' % (type(self).__name__, id, type(id)), 'id')
+
         id = util.utf8(id)
         base = self.class_url()
         extn = urllib.quote_plus(id)

--- a/stripe/test/resources/test_api_resource.py
+++ b/stripe/test/resources/test_api_resource.py
@@ -77,6 +77,11 @@ class APIResourceTests(StripeApiTestCase):
         self.assertEqual({"f": "b"},
                          stripe.resource.convert_array_to_dict({"f": "b"}))
 
+    def test_raise_on_incorrect_id_type(self):
+        for obj in [None, 1, 3.14, dict(), list(), set(), tuple(), object()]:
+            self.assertRaises(stripe.error.InvalidRequestError,
+                              MyResource.retrieve, obj)
+
 
 class SingletonAPIResourceTests(StripeApiTestCase):
 


### PR DESCRIPTION
My original, and incorrect, invocation was:

`subscription = stripe.Subscription.retrieve({g.user.stripe_sub_id})`

`stripe.Subscription.retrieve` is defined by `APIResource.retrieve`, and it
expects its first parameter `id` to be of type `str`. When an non-`str` type,
and more importantly an un-`urllib.quote_plus`-able type, is provided, the
following stacktrace results:

```
File "/var/task/delete_users.py", line 19, in delete_users
subscription = stripe.Subscription.retrieve({g.user.stripe_sub_id})
File "/var/task/stripe/resource.py", line 338, in retrieve
instance.refresh()
File "/var/task/stripe/resource.py", line 342, in refresh
self.refresh_from(self.request('get', self.instance_url()))
File "/var/task/stripe/resource.py", line 367, in instance_url
extn = urllib.parse.quote_plus(id)
File "/var/lang/lib/python3.6/urllib/parse.py", line 791, in quote_plus
string = quote(string, safe + space, encoding, errors)
File "/var/lang/lib/python3.6/urllib/parse.py", line 775, in quote
return quote_from_bytes(string, safe)
File "/var/lang/lib/python3.6/urllib/parse.py", line 800, in quote_from_bytes
raise TypeError("quote_from_bytes() expected bytes")
TypeError: quote_from_bytes() expected bytes
```

This is due to `urllib.quote_plus` making use of `urllib.quote`, which performs
type-checking to ensure that the argument provided for the parameter `string`
is of type `str`. `urllib.quote_from_bytes` is then invoked, but that expects
an encoded `str`. This causes an exception to be raised related to incorrect
invocation of `urllib.quote_from_bytes` rather than a semantically-incorrect
invocation of `APIResource.retrieve`.

The following error handling would raise a more useful exception to the developer
when the argument for an `id` to `APIResource.retrieve` is not of type `str`.