### PR TITLE
Add missing invalid_client OAuth error

### DIFF
--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -225,7 +225,9 @@ class APIRequestor(object):
             rheaders
         ]
 
-        if error_code == 'invalid_grant':
+        if error_code == 'invalid_client':
+            return oauth_error.InvalidClientError(*args)
+        elif error_code == 'invalid_grant':
             return oauth_error.InvalidGrantError(*args)
         elif error_code == 'invalid_request':
             return oauth_error.InvalidRequestError(*args)

--- a/stripe/oauth_error.py
+++ b/stripe/oauth_error.py
@@ -9,6 +9,10 @@ class OAuthError(StripeError):
         self.code = code
 
 
+class InvalidClientError(OAuthError):
+    pass
+
+
 class InvalidGrantError(OAuthError):
     pass
 

--- a/stripe/test/test_requestor.py
+++ b/stripe/test/test_requestor.py
@@ -457,6 +457,13 @@ class APIRequestorRequestTests(StripeUnitTestCase):
                           self.requestor.request,
                           'get', self.valid_path, {})
 
+    def test_invalid_client_error(self):
+        self.mock_response('{"error": "invalid_client"}', 401)
+
+        self.assertRaises(stripe.oauth_error.InvalidClientError,
+                          self.requestor.request,
+                          'get', self.valid_path, {})
+
     def test_invalid_grant_error(self):
         self.mock_response('{"error": "invalid_grant"}', 400)
 


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Adds support for the `invalid_client` OAuth error.

Cf. https://github.com/stripe/stripe-ruby/pull/562
