### PR TITLE
Fix encoding for order items

### DIFF
--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -1086,12 +1086,20 @@ class SKU(CreateableAPIResource, UpdateableAPIResource,
 
 class Order(CreateableAPIResource, UpdateableAPIResource,
             ListableAPIResource):
+    @classmethod
+    def create(cls, **params):
+        if "items" in params:
+            params["items"] = convert_array_to_dict(params["items"])
+        return super(Order, cls).create(**params)
+
     def pay(self, idempotency_key=None, **params):
         headers = populate_headers(idempotency_key)
         return self.request(
             'post', self.instance_url() + '/pay', params, headers)
 
     def return_order(self, idempotency_key=None, **params):
+        if "items" in params:
+            params["items"] = convert_array_to_dict(params["items"])
         headers = populate_headers(idempotency_key)
         return self.request(
             'post', self.instance_url() + '/returns', params, headers)


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Fixes encoding of order items.

This issue is related to #273 and #336. The `items` attribute in [order creation requests](https://stripe.com/docs/api#create_order) and [order return requests](https://stripe.com/docs/api#return_order) is a list of dicts. Since Python dicts are not ordered, this can produce inconsistent results.

E.g. with the following request:

```python
order = stripe.Order.create(items=[
  {'type': 'sku', 'parent': 'sku_...'},
  {'type': 'discount', 'amount': -500, 'currency': 'usd'},
], ...)
```

the `items` attribute may be encoded as:

```
items[][type]=sku&items[][parent]=sku_...&items[][type]=discount&items[][amount]=-500&items[][currency]=usd
```

which would be correctly decoded on the API's end (because the common `type` key is used to detect the multiple list elements) and produce the expected result. But because the dicts are not ordered, the `items` attribute could (among other possibilities) also be encoded as:

```
items[][type]=sku&items[][parent]=sku_...&items[][amount]=-500&items[][currency]=usd&items[][type]=discount
```

which would cause the list to be incorrectly decoded and the request to fail.

The API accepts an integer-indexed hash of hashes in place of a list of hashes for this parameter, so we can use the same fix as we did for subscription items, i.e. transparently convert the parameter into an integer-indexed hash of hashes if it's a list of hashes.
