### PR TITLE
Add support for stripe_version argument in requests

### DIFF
--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -947,10 +947,18 @@ class EphemeralKey(DeletableAPIResource):
     @classmethod
     def create(cls, api_key=None, idempotency_key=None,
                stripe_version=None, stripe_account=None,
-               **params):
+               api_version=None, **params):
         if stripe_version is None:
-            raise ValueError(
-                "stripe_version must be specified to create an ephemeral key")
+            if api_version is not None:
+                stripe_version = api_version
+                warnings.warn(
+                    "The `api_version` parameter when creating an ephemeral "
+                    "key is deprecated. Please use `stripe_version` instead.",
+                    DeprecationWarning)
+            else:
+                raise ValueError(
+                    "stripe_version must be specified to create an ephemeral "
+                    "key")
 
         requestor = api_requestor.APIRequestor(
             api_key,

--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -6,7 +6,8 @@ from copy import deepcopy
 from stripe import api_requestor, error, oauth, util, upload_api_base
 
 
-def convert_to_stripe_object(resp, api_key, version, account):
+def convert_to_stripe_object(resp, api_key=None, stripe_version=None,
+                             stripe_account=None):
     types = {
         'account': Account,
         'alipay_account': AlipayAccount,
@@ -48,8 +49,8 @@ def convert_to_stripe_object(resp, api_key, version, account):
     }
 
     if isinstance(resp, list):
-        return [convert_to_stripe_object(i, api_key, version, account)
-                for i in resp]
+        return [convert_to_stripe_object(i, api_key, stripe_version,
+                                         stripe_account) for i in resp]
     elif isinstance(resp, dict) and not isinstance(resp, StripeObject):
         resp = resp.copy()
         klass_name = resp.get('object')
@@ -57,8 +58,9 @@ def convert_to_stripe_object(resp, api_key, version, account):
             klass = types.get(klass_name, StripeObject)
         else:
             klass = StripeObject
-        return klass.construct_from(resp, api_key, stripe_version=version,
-                                    stripe_account=account)
+        return klass.construct_from(resp, api_key,
+                                    stripe_version=stripe_version,
+                                    stripe_account=stripe_account)
     else:
         return resp
 

--- a/stripe/test/resources/test_api_resource.py
+++ b/stripe/test/resources/test_api_resource.py
@@ -1,6 +1,6 @@
 import stripe
 from stripe.test.helper import (
-    StripeApiTestCase, MyResource, MySingleton
+    StripeApiTestCase, MyResource, MyUpdateable, MySingleton
 )
 
 
@@ -54,7 +54,7 @@ class APIResourceTests(StripeApiTestCase):
         }
 
         converted = stripe.resource.convert_to_stripe_object(
-            sample, 'akey', None)
+            sample, 'akey', None, None)
 
         # Types
         self.assertTrue(isinstance(converted, stripe.resource.StripeObject))
@@ -81,6 +81,27 @@ class APIResourceTests(StripeApiTestCase):
         for obj in [None, 1, 3.14, dict(), list(), set(), tuple(), object()]:
             self.assertRaises(stripe.error.InvalidRequestError,
                               MyResource.retrieve, obj)
+
+    def test_retrieve_and_update_with_stripe_version(self):
+        self.mock_response({
+            'id': 'foo',
+            'bobble': 'scrobble',
+        })
+
+        res = MyUpdateable.retrieve('foo', stripe_version='2017-08-15')
+
+        self.requestor_class_mock.assert_called_with(
+            account=None, api_base=None, key=None,
+            api_version='2017-08-15'
+        )
+
+        res.bobble = 'new_scrobble'
+        res.save()
+
+        self.requestor_class_mock.assert_called_with(
+            account=None, api_base=None, key='reskey',
+            api_version='2017-08-15'
+        )
 
 
 class SingletonAPIResourceTests(StripeApiTestCase):

--- a/stripe/test/resources/test_ephemeral_keys.py
+++ b/stripe/test/resources/test_ephemeral_keys.py
@@ -1,3 +1,5 @@
+import warnings
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 
@@ -7,6 +9,29 @@ class EphemeralKeyTest(StripeResourceTest):
     def test_create(self):
         stripe.EphemeralKey.create(customer='cus_123',
                                    stripe_version='2017-05-25')
+
+        self.requestor_class_mock.assert_called_with(
+            None,
+            api_version='2017-05-25',
+            account=None
+        )
+
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/v1/ephemeral_keys',
+            {'customer': 'cus_123'},
+            None
+        )
+
+    def test_create_legacy_parameter_api_version(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+
+            stripe.EphemeralKey.create(customer='cus_123',
+                                       api_version='2017-05-25')
+
+            self.assertEqual(1, len(w))
+            self.assertEqual(w[0].category, DeprecationWarning)
 
         self.requestor_class_mock.assert_called_with(
             None,

--- a/stripe/test/resources/test_ephemeral_keys.py
+++ b/stripe/test/resources/test_ephemeral_keys.py
@@ -6,7 +6,7 @@ class EphemeralKeyTest(StripeResourceTest):
 
     def test_create(self):
         stripe.EphemeralKey.create(customer='cus_123',
-                                   api_version='2017-05-25')
+                                   stripe_version='2017-05-25')
 
         self.requestor_class_mock.assert_called_with(
             None,
@@ -42,11 +42,11 @@ class EphemeralKeyTest(StripeResourceTest):
 
         try:
             with self.assertRaisesRegex(ValueError,
-                                        'api_version must be specified'):
+                                        'stripe_version must be specified'):
                 stripe.EphemeralKey.create(customer='cus_123')
 
             stripe.EphemeralKey.create(customer='cus_123',
-                                       api_version='2017-06-05')
+                                       stripe_version='2017-06-05')
 
             self.requestor_class_mock.assert_called_with(
                 None,

--- a/stripe/test/resources/test_stripe_object.py
+++ b/stripe/test/resources/test_stripe_object.py
@@ -53,17 +53,19 @@ class StripeObjectTests(StripeUnitTestCase):
         self.assertEqual('mykey', obj.api_key)
         self.assertEqual('bar', obj.foo)
         self.assertEqual('me', obj['trans'])
+        self.assertEqual(None, obj.stripe_version)
         self.assertEqual(None, obj.stripe_account)
 
         obj.refresh_from({
             'foo': 'baz',
             'johnny': 5,
-        }, 'key2', stripe_account='acct_foo')
+        }, 'key2', stripe_version='2017-08-15', stripe_account='acct_foo')
 
         self.assertEqual(5, obj.johnny)
         self.assertEqual('baz', obj.foo)
         self.assertRaises(AttributeError, getattr, obj, 'trans')
         self.assertEqual('key2', obj.api_key)
+        self.assertEqual('2017-08-15', obj.stripe_version)
         self.assertEqual('acct_foo', obj.stripe_account)
 
         obj.refresh_from({


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @remi-stripe 

Fixes #343. Basically, it turns out we never supported specifying a custom API version on a per-request basis in the Python library (except for ephemeral keys, which _require_ an explicit API version).

This PR adds supports for a `stripe_version` named parameter in all request methods. The parameter is handled like `stripe_account`, i.e. it is persistently maintained on instances.

E.g. when doing the following:
```python
c = stripe.Customer.create(stripe_version='2015-02-18')
c.description = "foo"
c.save()
```

the update request sent by `save()` will also include the `Stripe-Version: 2015-02-18` header. This behavior is consistent with the Ruby and PHP libraries.

In order to be consistent with the other libraries, the parameter is named `stripe_version`, not `api_version` (cf. [Ruby](https://github.com/stripe/stripe-ruby/blob/855ce0c7d45e7a096ae404c1790c8c9223ffefd9/lib/stripe/api_operations/request.rb#L38) and [PHP](https://github.com/stripe/stripe-php/blob/c8c8d384636b6b78c4c17e2b00102e914f0b7cc5/lib/Util/RequestOptions.php#L67-L69)).

Potential breaking changes in this PR:

- I renamed the existing `api_version` parameter in `EphemeralKey` methods to `stripe_version`. This obviously isn't great. Maybe we could alias `api_version` to `stripe_version` and issue a deprecation warning so that users update their code to use the latter?

- The `convert_to_stripe_object` method now has 4 arguments instead of 3. While the method is [publicly exposed](https://github.com/stripe/stripe-python/blob/ef50aa5e96b05a47f4b277ac6eab76e336860b99/stripe/__init__.py#L103), I think it's fair to say that this is an internal method that shouldn't be called directly by users so modifying the signature isn't a breaking change, but that's definitely debatable.

I don't think this PR should be merged until the above two points have been addressed. Let me know what you think!
