### PR TITLE
Handle case where payload is a bytearray or bytes

### DIFF
--- a/stripe/test/test_webhook.py
+++ b/stripe/test/test_webhook.py
@@ -1,3 +1,4 @@
+import sys
 import time
 
 import stripe
@@ -25,6 +26,25 @@ class WebhookTests(StripeUnitTestCase):
         with self.assertRaises(stripe.error.SignatureVerificationError):
             stripe.Webhook.construct_event(
                 DUMMY_WEBHOOK_PAYLOAD, header, DUMMY_WEBHOOK_SECRET)
+
+    def test_construct_event_from_bytearray(self):
+        header = WebhookSignatureTests.generate_header()
+        payload = bytearray(DUMMY_WEBHOOK_PAYLOAD, 'utf-8')
+        event = stripe.Webhook.construct_event(
+            payload, header, DUMMY_WEBHOOK_SECRET)
+        self.assertTrue(isinstance(event, stripe.Event))
+
+    def test_construct_event_from_bytes(self):
+        # This test is only applicable to Python 3 as `bytes` is not a symbol
+        # in Python 2.
+        if sys.version_info < (3, 0):
+            return
+
+        header = WebhookSignatureTests.generate_header()
+        payload = bytes(DUMMY_WEBHOOK_PAYLOAD, 'utf-8')
+        event = stripe.Webhook.construct_event(
+            payload, header, DUMMY_WEBHOOK_SECRET)
+        self.assertTrue(isinstance(event, stripe.Event))
 
 
 class WebhookSignatureTests(StripeUnitTestCase):

--- a/stripe/webhook.py
+++ b/stripe/webhook.py
@@ -12,6 +12,8 @@ class Webhook(object):
     @staticmethod
     def construct_event(payload, sig_header, secret,
                         tolerance=DEFAULT_TOLERANCE, api_key=None):
+        if hasattr(payload, 'decode'):
+            payload = payload.decode('utf-8')
         if api_key is None:
             api_key = stripe.api_key
         data = util.json.loads(payload)


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @spastorelli-stripe

This PR fixes the `Webhook.construct_event` method to handle the case where `payload` is a `bytearray` or `bytes`.

In particular, with Python 3, retrieving the request's body in Django via `request.body` will return a `bytes` instance (where as with Python 2, a `str` instance is returned). This fix makes it so users don't have to worry about this and can always pass `request.body` to the method. (It also means that our [sample code](https://stripe.com/docs/webhooks#verify-official-libraries) will work regardless of which Python version is used.)

