### PR TITLE
ListObject: proxy __len__ to data list

### DIFF
--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -427,6 +427,9 @@ class ListObject(StripeObject):
     def __iter__(self):
         return getattr(self, 'data', []).__iter__()
 
+    def __len__(self):
+        return getattr(self, 'data', []).__len__()
+
 
 class SingletonAPIResource(APIResource):
 

--- a/stripe/test/resources/test_list_object.py
+++ b/stripe/test/resources/test_list_object.py
@@ -54,6 +54,19 @@ class ListObjectTests(StripeApiTestCase):
 
         self.assertResponse(res)
 
+    def test_len(self):
+        self.assertEqual(len(self.lo), 1)
+
+    def test_bool(self):
+        self.assertTrue(self.lo)
+
+        empty = stripe.resource.ListObject.construct_from({
+            'id': 'me',
+            'url': '/my/path',
+            'data': [],
+        }, 'mykey')
+        self.assertFalse(empty)
+
 
 class AutoPagingTests(StripeApiTestCase):
 


### PR DESCRIPTION
Otherwise it will use the one from the underlying dict it seems, and
empty ListObjects (without data) are trueish then.