### PR TITLE
detach method for detaching sources from customers

### DIFF
--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -1184,7 +1184,7 @@ class ApplePayDomain(CreateableAPIResource, ListableAPIResource,
 
 
 class Source(CreateableAPIResource, UpdateableAPIResource, VerifyMixin):
-    def delete(self, **params):
+    def detach(self, **params):
         if hasattr(self, 'customer') and self.customer:
             extn = urllib.quote_plus(util.utf8(self.id))
             customer = util.utf8(self.customer)
@@ -1197,6 +1197,12 @@ class Source(CreateableAPIResource, UpdateableAPIResource, VerifyMixin):
 
         else:
             raise NotImplementedError(
-                'Source objects cannot be deleted, they can only be detached '
-                'from customer objects. This source object does not appear to '
-                'be currently attached to a customer object.')
+                "This source object does not appear to be currently attached "
+                "to a customer object.")
+
+    def delete(self, **params):
+        warnings.warn("The `Source.delete` method is deprecated and will "
+                      "be removed in future versions. Please use the "
+                      "`Source.detach` method instead",
+                      DeprecationWarning)
+        self.detach(**params)

--- a/stripe/test/resources/test_sources.py
+++ b/stripe/test/resources/test_sources.py
@@ -1,3 +1,5 @@
+import warnings
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 
@@ -46,18 +48,18 @@ class SourceTest(StripeResourceTest):
             None
         )
 
-    def test_delete_source_unattached(self):
+    def test_detach_source_unattached(self):
         source = stripe.Source.construct_from({
             'id': 'src_foo',
         }, 'api_key')
-        self.assertRaises(NotImplementedError, source.delete)
+        self.assertRaises(NotImplementedError, source.detach)
 
-    def test_delete_source_attached(self):
+    def test_detach_source_attached(self):
         source = stripe.Source.construct_from({
             'id': 'src_foo',
             'customer': 'cus_bar',
         }, 'api_key')
-        source.delete()
+        source.detach()
 
         self.requestor_mock.request.assert_called_with(
             'delete',
@@ -65,6 +67,19 @@ class SourceTest(StripeResourceTest):
             {},
             None
         )
+
+    def test_delete_source(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+
+            source = stripe.Source.construct_from({
+                'id': 'src_foo',
+                'customer': 'cus_bar',
+            }, 'api_key')
+            source.delete()
+
+            self.assertEqual(1, len(w))
+            self.assertEqual(w[0].category, DeprecationWarning)
 
     def test_verify_source(self):
         source = stripe.Source.construct_from({


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @stan-stripe @will-stripe

- Renames the `Source.delete` method to `Source.detach`. `detach` is more descriptive of what the method actually does (i.e. detaching the source object from its customer object, not actually deleting the source object).

- Alias `detach` to `delete` with a deprecation warning to avoid a breaking change. We should remove the `delete` method in next major version.
