### PR TITLE
Fix unpickling in Python 3

### DIFF
--- a/stripe/stripe_object.py
+++ b/stripe/stripe_object.py
@@ -115,6 +115,28 @@ class StripeObject(dict):
         if hasattr(self, '_unsaved_values'):
             self._unsaved_values.remove(k)
 
+    # Custom unpickling method that uses `update` to update the dictionary
+    # without calling __setitem__, which would fail if any value is an empty
+    # string
+    def __setstate__(self, state):
+        self.update(state)
+
+    # Custom pickling method to ensure the instance is pickled as a custom
+    # class and not as a dict, otherwise __setstate__ would not be called when
+    # unpickling.
+    def __reduce__(self):
+        reduce_value = (
+            type(self),  # callable
+            (  # args
+                self.get('id', None),
+                self.api_key,
+                self.stripe_version,
+                self.stripe_account
+            ),
+            dict(self),  # state
+        )
+        return reduce_value
+
     @classmethod
     def construct_from(cls, values, key, stripe_version=None,
                        stripe_account=None):

--- a/stripe/test/resources/test_stripe_object.py
+++ b/stripe/test/resources/test_stripe_object.py
@@ -142,7 +142,14 @@ class StripeObjectTests(StripeUnitTestCase):
             'foo', 'bar', myparam=5)
 
         obj['object'] = 'boo'
-        obj.refresh_from({'fala': 'lalala'}, api_key='bar', partial=True)
+        obj.refresh_from(
+            {
+                'fala': 'lalala',
+                # ensures that empty strings are correctly unpickled in Py3
+                'emptystring': '',
+            },
+            api_key='bar', partial=True
+        )
 
         self.assertEqual('lalala', obj.fala)
 
@@ -153,6 +160,7 @@ class StripeObjectTests(StripeUnitTestCase):
         self.assertEqual('bar', newobj.api_key)
         self.assertEqual('boo', newobj['object'])
         self.assertEqual('lalala', newobj.fala)
+        self.assertEqual('', newobj.emptystring)
 
     def test_deletion(self):
         obj = stripe.stripe_object.StripeObject('id', 'key')


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Fixes #352.

This was annoying :/

Basically, the issue is that when unpickling `StripeObject`s, Python 3 calls our custom `__setitem__` method which forbids empty strings.

In order to directly reset the dict values, it is necessary to create a custom `__setstate__` method that will use [`update`](https://docs.python.org/3/library/stdtypes.html#dict.update) instead.

However, because `StripeObject` is a subclass of `dict`, `__setstate__` is not called automatically when unpickling the instance, and I had to define a [`__reduce__`](https://docs.python.org/3/library/pickle.html?highlight=__reduce__#object.__reduce__) method to force the pickler to treat the instance as a custom class and not as a normal dict.

I'm not super happy with this fix as it's relatively brittle (`__reduce__` needs to be consistent with the class constructor) but it's an unfortunate consequence of having `StripeObject` directly subclass `dict`. I wish we had gone with composition over inheritance here, but that's another discussion...
