### PR TITLE
Allow uploading in-memory files

### DIFF
--- a/stripe/api_resources/file_upload.py
+++ b/stripe/api_resources/file_upload.py
@@ -1,4 +1,5 @@
-from stripe import api_requestor, upload_api_base, util
+import stripe
+from stripe import api_requestor, util
 from stripe.api_resources.abstract import ListableAPIResource
 
 
@@ -7,7 +8,7 @@ class FileUpload(ListableAPIResource):
 
     @classmethod
     def api_base(cls):
-        return upload_api_base
+        return stripe.upload_api_base
 
     @classmethod
     def class_name(cls):

--- a/stripe/multipart_data_generator.py
+++ b/stripe/multipart_data_generator.py
@@ -18,10 +18,12 @@ class MultipartDataGenerator(object):
             self._write(self.param_header())
             self._write(self.line_break)
             if hasattr(value, 'read'):
+                filename = value.name if hasattr(value, 'name') else "blob"
+
                 self._write("Content-Disposition: form-data; name=\"")
                 self._write(key)
                 self._write("\"; filename=\"")
-                self._write(value.name)
+                self._write(filename)
                 self._write("\"")
                 self._write(self.line_break)
                 self._write("Content-Type: application/octet-stream")

--- a/stripe/test/test_multipart_data_generator.py
+++ b/stripe/test/test_multipart_data_generator.py
@@ -2,6 +2,7 @@
 
 import re
 import sys
+import StringIO
 
 from stripe.multipart_data_generator import MultipartDataGenerator
 from stripe.test.helper import StripeTestCase
@@ -50,3 +51,7 @@ class MultipartDataGeneratorTests(StripeTestCase):
     def test_multipart_data_file_binary(self):
         with open(__file__, mode='rb') as test_file:
             self.run_test_multipart_data_with_file(test_file)
+
+    def test_multipart_data_stringio(self):
+        string = StringIO.StringIO("foo")
+        self.run_test_multipart_data_with_file(string)


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @praboud-stripe

Fixes #227.

I spent some time investigating this and I agree with @praboud-stripe's analysis in #227. Rack returns multipart blocks with no filenames directly as `String`s rather than as `Hash`es -- they explicitly test for this behavior (cf. [here](https://github.com/rack/rack/blob/d4793a0707efa9011ded6ebc88154ac9d7f98c8a/test/spec_multipart.rb#L36)).

Fixing the backend to handle either a string or a hash might be possible, but sending a dummy filename in the client libraries is definitely the path of least resistance. We actually already do this in stripe-node (cf. [here](https://github.com/stripe/stripe-node/blob/a7382226965ee399ce6b5b9fd162c5af74c8131d/lib/MultipartDataGenerator.js#L30)).
