### PR TITLE
Catch `Exception` instead of using bare `except`

### DIFF
--- a/stripe/webhook.py
+++ b/stripe/webhook.py
@@ -45,7 +45,7 @@ class WebhookSignature(object):
         try:
             timestamp, signatures = cls._get_timestamp_and_signatures(
                 header, cls.EXPECTED_SCHEME)
-        except:
+        except Exception:
             raise error.SignatureVerificationError(
                 "Unable to extract timestamp and signatures from header",
                 header, payload)


### PR DESCRIPTION
This seems to be new, but flake8 is complaining that we're using a bare
except and it's breaking the build:

    flake8 stripe
    stripe/webhook.py:48:9: E722 do not use bare except'

Here we change over to catch the parent `Exception` class instead.

r? @ob-stripe