### PR TITLE
Fix BytesWarning with Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - python setup.py install
 script:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then flake8 stripe; fi
-  - python -W all setup.py test
+  - python -W all -bb -W error::BytesWarning setup.py test
 matrix:
   allow_failures:
     - python: 3.7-dev

--- a/stripe/util.py
+++ b/stripe/util.py
@@ -114,6 +114,9 @@ def dashboard_link(request_id):
 
 def logfmt(props):
     def fmt(key, val):
+        # Handle case where val is a bytes or bytesarray
+        if sys.version_info[0] == 3 and hasattr(val, 'decode'):
+            val = val.decode('utf-8')
         # Check if val is already a string to avoid re-encoding into
         # ascii. Since the code is sent through 2to3, we can't just
         # use unicode(val, encoding='utf8') since it will be

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     mock
 commands =
     python setup.py clean --all
-    python -W all setup.py test {posargs}
+    python -W all -bb -W error::BytesWarning setup.py test {posargs}
 setenv =
     STRIPE_TEST_PYCURL = true
 
@@ -28,4 +28,4 @@ deps =
 commands =
     flake8 stripe
     python setup.py clean --all
-    python -W all setup.py test {posargs}
+    python -W all -bb -W error::BytesWarning setup.py test {posargs}


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Fixes #329.

As far as I can tell, it's not possible to enable `BytesWarning` programmatically. I had to add `-bb -W error::BytesWarning` directly to the command line invocations. This is what [Python itself](https://github.com/python/cpython/blob/d39dbf4cf18488beb190ab358b7ab38792cd5043/Tools/scripts/run_tests.py#L33-L34) does for its own test suite because of [this open issue](https://bugs.python.org/issue20361).