### PR TITLE
Add support for exchange_rates requests

### DIFF
--- a/stripe/api_resources/__init__.py
+++ b/stripe/api_resources/__init__.py
@@ -20,6 +20,7 @@ from stripe.api_resources.customer import Customer
 from stripe.api_resources.dispute import Dispute
 from stripe.api_resources.ephemeral_key import EphemeralKey
 from stripe.api_resources.event import Event
+from stripe.api_resources.exchange_rate import ExchangeRate
 from stripe.api_resources.file_upload import FileUpload
 from stripe.api_resources.invoice import Invoice
 from stripe.api_resources.invoice_item import InvoiceItem

--- a/stripe/api_resources/exchange_rate.py
+++ b/stripe/api_resources/exchange_rate.py
@@ -1,0 +1,9 @@
+from stripe.api_resources.abstract import ListableAPIResource
+
+
+class ExchangeRate(ListableAPIResource):
+    OBJECT_NAME = 'exchange_rate'
+
+    @classmethod
+    def class_name(cls):
+        return 'exchange_rate'

--- a/stripe/test/api_resources/test_exchange_rate.py
+++ b/stripe/test/api_resources/test_exchange_rate.py
@@ -1,0 +1,24 @@
+import stripe
+from stripe.test.helper import StripeResourceTest
+
+
+class ExchangeRateTest(StripeResourceTest):
+
+    def test_is_listable(self):
+        stripe.ExchangeRate.list()
+
+        self.requestor_mock.request.assert_called_with(
+            'get',
+            '/v1/exchange_rates',
+            {}
+        )
+
+    def test_is_retrievable(self):
+        stripe.ExchangeRate.retrieve('usd')
+
+        self.requestor_mock.request.assert_called_with(
+            'get',
+            '/v1/exchange_rates/usd',
+            {},
+            None
+        )

--- a/stripe/util.py
+++ b/stripe/util.py
@@ -194,6 +194,7 @@ def load_object_classes():
         api_resources.Dispute.OBJECT_NAME: api_resources.Dispute,
         api_resources.EphemeralKey.OBJECT_NAME: api_resources.EphemeralKey,
         api_resources.Event.OBJECT_NAME: api_resources.Event,
+        api_resources.ExchangeRate.OBJECT_NAME: api_resources.ExchangeRate,
         api_resources.FileUpload.OBJECT_NAME: api_resources.FileUpload,
         api_resources.Invoice.OBJECT_NAME: api_resources.Invoice,
         api_resources.InvoiceItem.OBJECT_NAME: api_resources.InvoiceItem,


### PR DESCRIPTION
r? @brandur-stripe
cc @stripe/api-libraries @alixander-stripe

Adds support for the new `/v1/exchange_rates` endpoints.