### PR TITLE
Minor fixes

### DIFF
--- a/stripe/api_resources/account.py
+++ b/stripe/api_resources/account.py
@@ -54,10 +54,3 @@ class Account(CreateableAPIResource, ListableAPIResource,
     def deauthorize(self, **params):
         params['stripe_user_id'] = self.id
         return oauth.OAuth.deauthorize(**params)
-
-    @classmethod
-    def modify_external_account(cls, sid, external_account_id, **params):
-        url = "%s/%s/external_accounts/%s" % (
-            cls.class_url(), urllib.quote_plus(util.utf8(sid)),
-            urllib.quote_plus(util.utf8(external_account_id)))
-        return cls._modify(url, **params)

--- a/stripe/api_resources/customer.py
+++ b/stripe/api_resources/customer.py
@@ -1,4 +1,3 @@
-import urllib
 import warnings
 
 from stripe import api_requestor, util
@@ -79,10 +78,3 @@ class Customer(CreateableAPIResource, UpdateableAPIResource,
         url = self.instance_url() + '/discount'
         _, api_key = requestor.request('delete', url)
         self.refresh_from({'discount': None}, api_key, True)
-
-    @classmethod
-    def modify_source(cls, sid, source_id, **params):
-        url = "%s/%s/sources/%s" % (
-            cls.class_url(), urllib.quote_plus(util.utf8(sid)),
-            urllib.quote_plus(util.utf8(source_id)))
-        return cls._modify(url, **params)

--- a/stripe/api_resources/invoice_item.py
+++ b/stripe/api_resources/invoice_item.py
@@ -6,4 +6,4 @@ from stripe.api_resources.abstract import ListableAPIResource
 
 class InvoiceItem(CreateableAPIResource, UpdateableAPIResource,
                   ListableAPIResource, DeletableAPIResource):
-    OBJECT_NAME = 'invoice_item'
+    OBJECT_NAME = 'invoiceitem'

--- a/stripe/test/api_resources/test_balance.py
+++ b/stripe/test/api_resources/test_balance.py
@@ -24,3 +24,10 @@ class BalanceTransactionTest(StripeResourceTest):
             '/v1/balance/history',
             {}
         )
+
+    def test_convert_to_stripe_object(self):
+        transaction = stripe.util.convert_to_stripe_object({
+            'id': 'txn_foo',
+            'object': 'balance_transaction',
+        })
+        self.assertIsInstance(transaction, stripe.BalanceTransaction)

--- a/stripe/test/api_resources/test_invoice.py
+++ b/stripe/test/api_resources/test_invoice.py
@@ -30,6 +30,13 @@ class InvoiceTest(StripeResourceTest):
             {'customer': 'cus_get_invoice_items'},
         )
 
+    def test_convert_to_stripe_object(self):
+        item = stripe.util.convert_to_stripe_object({
+            'id': 'ii_foo',
+            'object': 'invoiceitem',
+        })
+        self.assertIsInstance(item, stripe.InvoiceItem)
+
     def test_invoice_create(self):
         customer = stripe.Customer(id="cus_invoice")
         stripe.Invoice.create(customer=customer.id)

--- a/stripe/util.py
+++ b/stripe/util.py
@@ -181,6 +181,8 @@ def load_object_classes():
         api_resources.ApplicationFeeRefund.OBJECT_NAME:
             api_resources.ApplicationFeeRefund,
         api_resources.Balance.OBJECT_NAME: api_resources.Balance,
+        api_resources.BalanceTransaction.OBJECT_NAME:
+            api_resources.BalanceTransaction,
         api_resources.BankAccount.OBJECT_NAME: api_resources.BankAccount,
         api_resources.BitcoinReceiver.OBJECT_NAME:
             api_resources.BitcoinReceiver,


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

A few random fixes:

- removed the existing `modify_external_account` and `modify_source` class methods on `Account` and `Customer` resp. since those methods are now created by the `@nested_resource_class_methods` decorator (#350)

- fixed the object name for `InvoiceItem` and added `BalanceTransaction` in `util.convert_to_stripe_object`. I think I broke both of these in #351 :/

The existing `@nested_resource_class_methods` tests ensure the removed methods still actually exist. Added a very basic test to avoid regression for the other fixes.
