### PR TITLE
Replace 2to3 with six

### DIFF
--- a/examples/charge.py
+++ b/examples/charge.py
@@ -1,8 +1,13 @@
+from __future__ import absolute_import, division, print_function
+
+import os
+
 import stripe
 
-stripe.api_key = 'tGN0bIwXnHdwOa85VABjPdSn8nWY7G7I'
 
-print "Attempting charge..."
+stripe.api_key = os.environ.get('STRIPE_SECRET_KEY')
+
+print("Attempting charge...")
 
 resp = stripe.Charge.create(
     amount=200,
@@ -11,4 +16,4 @@ resp = stripe.Charge.create(
     description='customer@gmail.com'
 )
 
-print 'Success: %r' % (resp, )
+print('Success: %r' % (resp))

--- a/examples/oauth.py
+++ b/examples/oauth.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import os
 
 import stripe

--- a/examples/proxy.py
+++ b/examples/proxy.py
@@ -1,26 +1,30 @@
+from __future__ import absolute_import, division, print_function
+
+import os
+
 import stripe
 
 
-stripe.api_key = 'tGN0bIwXnHdwOa85VABjPdSn8nWY7G7I'
+stripe.api_key = os.environ.get('STRIPE_SECRET_KEY')
 
-print( "Attempting charge..." )
+print("Attempting charge...")
 
 stripe.proxy = {
     "http": "http://<user>:<pass>@<proxy>:<port>",
-    "https": "http://<user>:<pass>@<proxy>:<port>" }
+    "https": "http://<user>:<pass>@<proxy>:<port>",
+}
 
-clients = ( 
-    stripe.http_client.RequestsClient( 
-        verify_ssl_certs= stripe.verify_ssl_certs,
-        proxy= stripe.proxy )
-    ,
-    stripe.http_client.PycurlClient( 
-        verify_ssl_certs= stripe.verify_ssl_certs,
-        proxy= stripe.proxy )
-    ,
-    stripe.http_client.Urllib2Client( 
-        verify_ssl_certs= stripe.verify_ssl_certs,
-        proxy= stripe.proxy ) )
+clients = (
+    stripe.http_client.RequestsClient(
+        verify_ssl_certs=stripe.verify_ssl_certs,
+        proxy=stripe.proxy),
+    stripe.http_client.PycurlClient(
+        verify_ssl_certs=stripe.verify_ssl_certs,
+        proxy=stripe.proxy),
+    stripe.http_client.Urllib2Client(
+        verify_ssl_certs=stripe.verify_ssl_certs,
+        proxy=stripe.proxy),
+)
 
 for c in clients:
     stripe.default_http_client = c
@@ -30,4 +34,4 @@ for c in clients:
         card='tok_visa',
         description='customer@gmail.com'
     )
-    print( 'Success: %s, %r' % ( c.name, resp, ) )
+    print('Success: %s, %r' % (c.name, resp))

--- a/examples/webhooks.py
+++ b/examples/webhooks.py
@@ -1,9 +1,10 @@
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import os
 
 import stripe
 from flask import Flask, request
+
 
 stripe.api_key = os.environ.get('STRIPE_SECRET_KEY')
 webhook_secret = os.environ.get('WEBHOOK_SECRET')

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ setup(
     install_requires=install_requires,
     test_suite='stripe.test.all',
     tests_require=['unittest2', 'mock'],
-    use_2to3=True,
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 # Stripe Python bindings
 # API docs at http://stripe.com/docs/api
 # Authors:

--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import calendar
 import datetime
 import platform

--- a/stripe/api_resources/__init__.py
+++ b/stripe/api_resources/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 # flake8: noqa
 
 from stripe.api_resources.list_object import ListObject

--- a/stripe/api_resources/abstract/__init__.py
+++ b/stripe/api_resources/abstract/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 # flake8: noqa
 
 from stripe.api_resources.abstract.api_resource import APIResource

--- a/stripe/api_resources/abstract/api_resource.py
+++ b/stripe/api_resources/abstract/api_resource.py
@@ -1,7 +1,6 @@
-import urllib
-
-from stripe import error, util
+from stripe import error, util, six
 from stripe.stripe_object import StripeObject
+from stripe.six.moves.urllib.parse import quote_plus
 
 
 class APIResource(StripeObject):
@@ -22,7 +21,7 @@ class APIResource(StripeObject):
             raise NotImplementedError(
                 'APIResource is an abstract class.  You should perform '
                 'actions on its subclasses (e.g. Charge, Customer)')
-        return str(urllib.quote_plus(cls.__name__.lower()))
+        return str(quote_plus(cls.__name__.lower()))
 
     @classmethod
     def class_url(cls):
@@ -32,7 +31,7 @@ class APIResource(StripeObject):
     def instance_url(self):
         id = self.get('id')
 
-        if not isinstance(id, basestring):
+        if not isinstance(id, six.string_types):
             raise error.InvalidRequestError(
                 'Could not determine which URL to request: %s instance '
                 'has invalid ID: %r, %s. ID should be of type `str` (or'
@@ -40,5 +39,5 @@ class APIResource(StripeObject):
 
         id = util.utf8(id)
         base = self.class_url()
-        extn = urllib.quote_plus(id)
+        extn = quote_plus(id)
         return "%s/%s" % (base, extn)

--- a/stripe/api_resources/abstract/api_resource.py
+++ b/stripe/api_resources/abstract/api_resource.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe import error, util, six
 from stripe.stripe_object import StripeObject
 from stripe.six.moves.urllib.parse import quote_plus

--- a/stripe/api_resources/abstract/createable_api_resource.py
+++ b/stripe/api_resources/abstract/createable_api_resource.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.api_resources.abstract.api_resource import APIResource
 from stripe import api_requestor, util
 

--- a/stripe/api_resources/abstract/deletable_api_resource.py
+++ b/stripe/api_resources/abstract/deletable_api_resource.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.api_resources.abstract.api_resource import APIResource
 
 

--- a/stripe/api_resources/abstract/listable_api_resource.py
+++ b/stripe/api_resources/abstract/listable_api_resource.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import warnings
 
 from stripe import api_requestor, util

--- a/stripe/api_resources/abstract/nested_resource_class_methods.py
+++ b/stripe/api_resources/abstract/nested_resource_class_methods.py
@@ -1,6 +1,5 @@
-import urllib
-
 from stripe import api_requestor, util
+from stripe.six.moves.urllib.parse import quote_plus
 
 
 def nested_resource_class_methods(resource, path=None, operations=None):
@@ -11,10 +10,10 @@ def nested_resource_class_methods(resource, path=None, operations=None):
 
     def wrapper(cls):
         def nested_resource_url(cls, id, nested_id=None):
-            url = "%s/%s/%s" % (cls.class_url(), urllib.quote_plus(id),
-                                urllib.quote_plus(path))
+            url = "%s/%s/%s" % (cls.class_url(), quote_plus(id),
+                                quote_plus(path))
             if nested_id is not None:
-                url += "/%s" % urllib.quote_plus(nested_id)
+                url += "/%s" % quote_plus(nested_id)
             return url
         resource_url_method = "%ss_url" % resource
         setattr(cls, resource_url_method, classmethod(nested_resource_url))

--- a/stripe/api_resources/abstract/nested_resource_class_methods.py
+++ b/stripe/api_resources/abstract/nested_resource_class_methods.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe import api_requestor, util
 from stripe.six.moves.urllib.parse import quote_plus
 

--- a/stripe/api_resources/abstract/singleton_api_resource.py
+++ b/stripe/api_resources/abstract/singleton_api_resource.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.api_resources.abstract.api_resource import APIResource
 
 

--- a/stripe/api_resources/abstract/updateable_api_resource.py
+++ b/stripe/api_resources/abstract/updateable_api_resource.py
@@ -1,7 +1,6 @@
-import urllib
-
 from stripe import api_requestor, util
 from stripe.api_resources.abstract.api_resource import APIResource
+from stripe.six.moves.urllib.parse import quote_plus
 
 
 class UpdateableAPIResource(APIResource):
@@ -19,7 +18,7 @@ class UpdateableAPIResource(APIResource):
 
     @classmethod
     def modify(cls, sid, **params):
-        url = "%s/%s" % (cls.class_url(), urllib.quote_plus(util.utf8(sid)))
+        url = "%s/%s" % (cls.class_url(), quote_plus(util.utf8(sid)))
         return cls._modify(url, **params)
 
     def save(self, idempotency_key=None):

--- a/stripe/api_resources/abstract/updateable_api_resource.py
+++ b/stripe/api_resources/abstract/updateable_api_resource.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe import api_requestor, util
 from stripe.api_resources.abstract.api_resource import APIResource
 from stripe.six.moves.urllib.parse import quote_plus

--- a/stripe/api_resources/abstract/verify_mixin.py
+++ b/stripe/api_resources/abstract/verify_mixin.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe import util
 
 

--- a/stripe/api_resources/account.py
+++ b/stripe/api_resources/account.py
@@ -1,11 +1,11 @@
-import urllib
-
 from stripe import oauth, util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import nested_resource_class_methods
+
+from stripe.six.moves.urllib.parse import quote_plus
 
 
 @nested_resource_class_methods(
@@ -33,7 +33,7 @@ class Account(CreateableAPIResource, ListableAPIResource,
             return "/v1/account"
         sid = util.utf8(sid)
         base = cls.class_url()
-        extn = urllib.quote_plus(sid)
+        extn = quote_plus(sid)
         return "%s/%s" % (base, extn)
 
     def instance_url(self):

--- a/stripe/api_resources/account.py
+++ b/stripe/api_resources/account.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe import oauth, util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import DeletableAPIResource

--- a/stripe/api_resources/alipay_account.py
+++ b/stripe/api_resources/alipay_account.py
@@ -1,9 +1,9 @@
-import urllib
-
 from stripe import util
 from stripe.api_resources.customer import Customer
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+
+from stripe.six.moves.urllib.parse import quote_plus
 
 
 class AlipayAccount(UpdateableAPIResource, DeletableAPIResource):
@@ -12,11 +12,11 @@ class AlipayAccount(UpdateableAPIResource, DeletableAPIResource):
     @classmethod
     def _build_instance_url(cls, customer, sid):
         token = util.utf8(sid)
-        extn = urllib.quote_plus(token)
+        extn = quote_plus(token)
         customer = util.utf8(customer)
 
         base = Customer.class_url()
-        owner_extn = urllib.quote_plus(customer)
+        owner_extn = quote_plus(customer)
 
         return "%s/%s/sources/%s" % (base, owner_extn, extn)
 

--- a/stripe/api_resources/alipay_account.py
+++ b/stripe/api_resources/alipay_account.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe import util
 from stripe.api_resources.customer import Customer
 from stripe.api_resources.abstract import DeletableAPIResource

--- a/stripe/api_resources/apple_pay_domain.py
+++ b/stripe/api_resources/apple_pay_domain.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource

--- a/stripe/api_resources/application_fee.py
+++ b/stripe/api_resources/application_fee.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe import util
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import nested_resource_class_methods

--- a/stripe/api_resources/application_fee_refund.py
+++ b/stripe/api_resources/application_fee_refund.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe import util
 from stripe.api_resources import ApplicationFee
 from stripe.api_resources.abstract import UpdateableAPIResource

--- a/stripe/api_resources/application_fee_refund.py
+++ b/stripe/api_resources/application_fee_refund.py
@@ -1,8 +1,8 @@
-import urllib
-
 from stripe import util
 from stripe.api_resources import ApplicationFee
 from stripe.api_resources.abstract import UpdateableAPIResource
+
+from stripe.six.moves.urllib.parse import quote_plus
 
 
 class ApplicationFeeRefund(UpdateableAPIResource):
@@ -13,8 +13,8 @@ class ApplicationFeeRefund(UpdateableAPIResource):
         fee = util.utf8(fee)
         sid = util.utf8(sid)
         base = ApplicationFee.class_url()
-        cust_extn = urllib.quote_plus(fee)
-        extn = urllib.quote_plus(sid)
+        cust_extn = quote_plus(fee)
+        extn = quote_plus(sid)
         return "%s/%s/refunds/%s" % (base, cust_extn, extn)
 
     @classmethod

--- a/stripe/api_resources/balance.py
+++ b/stripe/api_resources/balance.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.api_resources.abstract import SingletonAPIResource
 
 

--- a/stripe/api_resources/balance_transaction.py
+++ b/stripe/api_resources/balance_transaction.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.api_resources.abstract import ListableAPIResource
 
 

--- a/stripe/api_resources/bank_account.py
+++ b/stripe/api_resources/bank_account.py
@@ -1,11 +1,10 @@
-import urllib
-
 from stripe import error, util
 from stripe.api_resources.account import Account
 from stripe.api_resources.customer import Customer
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import VerifyMixin
+from stripe.six.moves.urllib.parse import quote_plus
 
 
 class BankAccount(UpdateableAPIResource, DeletableAPIResource, VerifyMixin):
@@ -13,19 +12,19 @@ class BankAccount(UpdateableAPIResource, DeletableAPIResource, VerifyMixin):
 
     def instance_url(self):
         token = util.utf8(self.id)
-        extn = urllib.quote_plus(token)
+        extn = quote_plus(token)
         if hasattr(self, 'customer'):
             customer = util.utf8(self.customer)
 
             base = Customer.class_url()
-            owner_extn = urllib.quote_plus(customer)
+            owner_extn = quote_plus(customer)
             class_base = "sources"
 
         elif hasattr(self, 'account'):
             account = util.utf8(self.account)
 
             base = Account.class_url()
-            owner_extn = urllib.quote_plus(account)
+            owner_extn = quote_plus(account)
             class_base = "external_accounts"
 
         else:

--- a/stripe/api_resources/bank_account.py
+++ b/stripe/api_resources/bank_account.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe import error, util
 from stripe.api_resources.account import Account
 from stripe.api_resources.customer import Customer

--- a/stripe/api_resources/bitcoin_receiver.py
+++ b/stripe/api_resources/bitcoin_receiver.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe import util
 from stripe.api_resources.customer import Customer
 from stripe.api_resources.abstract import CreateableAPIResource

--- a/stripe/api_resources/bitcoin_receiver.py
+++ b/stripe/api_resources/bitcoin_receiver.py
@@ -1,11 +1,10 @@
-import urllib
-
 from stripe import util
 from stripe.api_resources.customer import Customer
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.six.moves.urllib.parse import quote_plus
 
 
 class BitcoinReceiver(CreateableAPIResource, UpdateableAPIResource,
@@ -14,12 +13,12 @@ class BitcoinReceiver(CreateableAPIResource, UpdateableAPIResource,
 
     def instance_url(self):
         token = util.utf8(self.id)
-        extn = urllib.quote_plus(token)
+        extn = quote_plus(token)
 
         if hasattr(self, 'customer'):
             customer = util.utf8(self.customer)
             base = Customer.class_url()
-            cust_extn = urllib.quote_plus(customer)
+            cust_extn = quote_plus(customer)
             return "%s/%s/sources/%s" % (base, cust_extn, extn)
         else:
             base = BitcoinReceiver.class_url()

--- a/stripe/api_resources/bitcoin_transaction.py
+++ b/stripe/api_resources/bitcoin_transaction.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.stripe_object import StripeObject
 
 

--- a/stripe/api_resources/card.py
+++ b/stripe/api_resources/card.py
@@ -1,11 +1,10 @@
-import urllib
-
 from stripe import error, util
 from stripe.api_resources.account import Account
 from stripe.api_resources.customer import Customer
 from stripe.api_resources.recipient import Recipient
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import DeletableAPIResource
+from stripe.six.moves.urllib.parse import quote_plus
 
 
 class Card(UpdateableAPIResource, DeletableAPIResource):
@@ -13,26 +12,26 @@ class Card(UpdateableAPIResource, DeletableAPIResource):
 
     def instance_url(self):
         token = util.utf8(self.id)
-        extn = urllib.quote_plus(token)
+        extn = quote_plus(token)
         if hasattr(self, 'customer'):
             customer = util.utf8(self.customer)
 
             base = Customer.class_url()
-            owner_extn = urllib.quote_plus(customer)
+            owner_extn = quote_plus(customer)
             class_base = "sources"
 
         elif hasattr(self, 'recipient'):
             recipient = util.utf8(self.recipient)
 
             base = Recipient.class_url()
-            owner_extn = urllib.quote_plus(recipient)
+            owner_extn = quote_plus(recipient)
             class_base = "cards"
 
         elif hasattr(self, 'account'):
             account = util.utf8(self.account)
 
             base = Account.class_url()
-            owner_extn = urllib.quote_plus(account)
+            owner_extn = quote_plus(account)
             class_base = "external_accounts"
 
         else:

--- a/stripe/api_resources/card.py
+++ b/stripe/api_resources/card.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe import error, util
 from stripe.api_resources.account import Account
 from stripe.api_resources.customer import Customer

--- a/stripe/api_resources/charge.py
+++ b/stripe/api_resources/charge.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe import api_requestor, util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource

--- a/stripe/api_resources/country_spec.py
+++ b/stripe/api_resources/country_spec.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.api_resources import abstract
 
 

--- a/stripe/api_resources/coupon.py
+++ b/stripe/api_resources/coupon.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource

--- a/stripe/api_resources/customer.py
+++ b/stripe/api_resources/customer.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import warnings
 
 from stripe import api_requestor, util

--- a/stripe/api_resources/dispute.py
+++ b/stripe/api_resources/dispute.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe import util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource

--- a/stripe/api_resources/ephemeral_key.py
+++ b/stripe/api_resources/ephemeral_key.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import warnings
 
 from stripe import api_requestor, util

--- a/stripe/api_resources/event.py
+++ b/stripe/api_resources/event.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.api_resources import abstract
 
 

--- a/stripe/api_resources/exchange_rate.py
+++ b/stripe/api_resources/exchange_rate.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.api_resources.abstract import ListableAPIResource
 
 

--- a/stripe/api_resources/file_upload.py
+++ b/stripe/api_resources/file_upload.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe import api_requestor, util
 from stripe.api_resources.abstract import ListableAPIResource

--- a/stripe/api_resources/invoice.py
+++ b/stripe/api_resources/invoice.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe import api_requestor, util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource

--- a/stripe/api_resources/invoice_item.py
+++ b/stripe/api_resources/invoice_item.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource

--- a/stripe/api_resources/list_object.py
+++ b/stripe/api_resources/list_object.py
@@ -1,8 +1,9 @@
-import urllib
 import warnings
 
 from stripe import util
 from stripe.stripe_object import StripeObject
+
+from stripe.six.moves.urllib.parse import quote_plus
 
 
 class ListObject(StripeObject):
@@ -41,7 +42,7 @@ class ListObject(StripeObject):
     def retrieve(self, id, **params):
         base = self.get('url')
         id = util.utf8(id)
-        extn = urllib.quote_plus(id)
+        extn = quote_plus(id)
         url = "%s/%s" % (base, extn)
 
         return self.request('get', url, params)

--- a/stripe/api_resources/list_object.py
+++ b/stripe/api_resources/list_object.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import warnings
 
 from stripe import util

--- a/stripe/api_resources/login_link.py
+++ b/stripe/api_resources/login_link.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.stripe_object import StripeObject
 
 

--- a/stripe/api_resources/order.py
+++ b/stripe/api_resources/order.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe import util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource

--- a/stripe/api_resources/order_return.py
+++ b/stripe/api_resources/order_return.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.api_resources.abstract import ListableAPIResource
 
 

--- a/stripe/api_resources/payout.py
+++ b/stripe/api_resources/payout.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource

--- a/stripe/api_resources/plan.py
+++ b/stripe/api_resources/plan.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource

--- a/stripe/api_resources/product.py
+++ b/stripe/api_resources/product.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource

--- a/stripe/api_resources/recipient.py
+++ b/stripe/api_resources/recipient.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.api_resources.transfer import Transfer
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import DeletableAPIResource

--- a/stripe/api_resources/recipient_transfer.py
+++ b/stripe/api_resources/recipient_transfer.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.stripe_object import StripeObject
 
 

--- a/stripe/api_resources/refund.py
+++ b/stripe/api_resources/refund.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource

--- a/stripe/api_resources/reversal.py
+++ b/stripe/api_resources/reversal.py
@@ -1,8 +1,7 @@
-import urllib
-
 from stripe import util
 from stripe.api_resources.transfer import Transfer
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.six.moves.urllib.parse import quote_plus
 
 
 class Reversal(UpdateableAPIResource):
@@ -12,8 +11,8 @@ class Reversal(UpdateableAPIResource):
         token = util.utf8(self.id)
         transfer = util.utf8(self.transfer)
         base = Transfer.class_url()
-        cust_extn = urllib.quote_plus(transfer)
-        extn = urllib.quote_plus(token)
+        cust_extn = quote_plus(transfer)
+        extn = quote_plus(token)
         return "%s/%s/reversals/%s" % (base, cust_extn, extn)
 
     @classmethod

--- a/stripe/api_resources/reversal.py
+++ b/stripe/api_resources/reversal.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe import util
 from stripe.api_resources.transfer import Transfer
 from stripe.api_resources.abstract import UpdateableAPIResource

--- a/stripe/api_resources/sku.py
+++ b/stripe/api_resources/sku.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource

--- a/stripe/api_resources/source.py
+++ b/stripe/api_resources/source.py
@@ -1,4 +1,3 @@
-import urllib
 import warnings
 
 from stripe import util
@@ -6,6 +5,7 @@ from stripe.api_resources import Customer
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import VerifyMixin
+from stripe.six.moves.urllib.parse import quote_plus
 
 
 class Source(CreateableAPIResource, UpdateableAPIResource, VerifyMixin):
@@ -13,10 +13,10 @@ class Source(CreateableAPIResource, UpdateableAPIResource, VerifyMixin):
 
     def detach(self, **params):
         if hasattr(self, 'customer') and self.customer:
-            extn = urllib.quote_plus(util.utf8(self.id))
+            extn = quote_plus(util.utf8(self.id))
             customer = util.utf8(self.customer)
             base = Customer.class_url()
-            owner_extn = urllib.quote_plus(customer)
+            owner_extn = quote_plus(customer)
             url = "%s/%s/sources/%s" % (base, owner_extn, extn)
 
             self.refresh_from(self.request('delete', url, params))

--- a/stripe/api_resources/source.py
+++ b/stripe/api_resources/source.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import warnings
 
 from stripe import util

--- a/stripe/api_resources/source_transaction.py
+++ b/stripe/api_resources/source_transaction.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.stripe_object import StripeObject
 
 

--- a/stripe/api_resources/subscription.py
+++ b/stripe/api_resources/subscription.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe import api_requestor, util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import DeletableAPIResource

--- a/stripe/api_resources/subscription_item.py
+++ b/stripe/api_resources/subscription_item.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource

--- a/stripe/api_resources/three_d_secure.py
+++ b/stripe/api_resources/three_d_secure.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.api_resources.abstract import CreateableAPIResource
 
 

--- a/stripe/api_resources/token.py
+++ b/stripe/api_resources/token.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.api_resources.abstract import CreateableAPIResource
 
 

--- a/stripe/api_resources/transfer.py
+++ b/stripe/api_resources/transfer.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource

--- a/stripe/error.py
+++ b/stripe/error.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe import six
 
 

--- a/stripe/error.py
+++ b/stripe/error.py
@@ -1,5 +1,4 @@
-# Exceptions
-import sys
+from stripe import six
 
 
 class StripeError(Exception):
@@ -29,7 +28,7 @@ class StripeError(Exception):
         else:
             return self._message
 
-    if sys.version_info > (3, 0):
+    if six.PY3:
         def __str__(self):
             return self.__unicode__()
     else:

--- a/stripe/http_client.py
+++ b/stripe/http_client.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import os
 import sys
 import textwrap

--- a/stripe/importer.py
+++ b/stripe/importer.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import warnings
 
 warnings.warn("The importers module is deprecated and will be removed in "

--- a/stripe/multipart_data_generator.py
+++ b/stripe/multipart_data_generator.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import random
 import io
 

--- a/stripe/multipart_data_generator.py
+++ b/stripe/multipart_data_generator.py
@@ -1,6 +1,7 @@
 import random
-import sys
 import io
+
+from stripe import six
 
 
 class MultipartDataGenerator(object):
@@ -11,7 +12,7 @@ class MultipartDataGenerator(object):
         self.chunk_size = chunk_size
 
     def add_params(self, params):
-        for key, value in params.iteritems():
+        for key, value in six.iteritems(params):
             if value is None:
                 continue
 
@@ -50,7 +51,7 @@ class MultipartDataGenerator(object):
         return self.data.getvalue()
 
     def _write(self, value):
-        if sys.version_info < (3,):
+        if six.PY2:
             binary_type = str
             text_type = unicode
         else:

--- a/stripe/oauth.py
+++ b/stripe/oauth.py
@@ -1,6 +1,5 @@
-import urllib
-
 from stripe import api_requestor, connect_api_base, error
+from stripe.six.moves.urllib.parse import urlencode
 
 
 class OAuth(object):
@@ -30,7 +29,7 @@ class OAuth(object):
         OAuth._set_client_id(params)
         if 'response_type' not in params:
             params['response_type'] = 'code'
-        query = urllib.urlencode(list(api_requestor._api_encode(params)))
+        query = urlencode(list(api_requestor._api_encode(params)))
         url = connect_api_base + path + '?' + query
         return url
 

--- a/stripe/oauth.py
+++ b/stripe/oauth.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe import api_requestor, connect_api_base, error
 from stripe.six.moves.urllib.parse import urlencode
 

--- a/stripe/oauth_error.py
+++ b/stripe/oauth_error.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from stripe.error import StripeError
 
 

--- a/stripe/resource.py
+++ b/stripe/resource.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 #
 # This module doesn't serve much purpose anymore. It's only here to maintain
 # backwards compatibility.

--- a/stripe/six.py
+++ b/stripe/six.py
@@ -1,0 +1,891 @@
+# Copyright (c) 2010-2017 Benjamin Peterson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Utilities for writing code that runs on Python 2 and 3"""
+
+from __future__ import absolute_import
+
+import functools
+import itertools
+import operator
+import sys
+import types
+
+__author__ = "Benjamin Peterson <benjamin@python.org>"
+__version__ = "1.11.0"
+
+
+# Useful for very coarse version differentiation.
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+PY34 = sys.version_info[0:2] >= (3, 4)
+
+if PY3:
+    string_types = str,
+    integer_types = int,
+    class_types = type,
+    text_type = str
+    binary_type = bytes
+
+    MAXSIZE = sys.maxsize
+else:
+    string_types = basestring,
+    integer_types = (int, long)
+    class_types = (type, types.ClassType)
+    text_type = unicode
+    binary_type = str
+
+    if sys.platform.startswith("java"):
+        # Jython always uses 32 bits.
+        MAXSIZE = int((1 << 31) - 1)
+    else:
+        # It's possible to have sizeof(long) != sizeof(Py_ssize_t).
+        class X(object):
+
+            def __len__(self):
+                return 1 << 31
+        try:
+            len(X())
+        except OverflowError:
+            # 32-bit
+            MAXSIZE = int((1 << 31) - 1)
+        else:
+            # 64-bit
+            MAXSIZE = int((1 << 63) - 1)
+        del X
+
+
+def _add_doc(func, doc):
+    """Add documentation to a function."""
+    func.__doc__ = doc
+
+
+def _import_module(name):
+    """Import module, returning the module after the last dot."""
+    __import__(name)
+    return sys.modules[name]
+
+
+class _LazyDescr(object):
+
+    def __init__(self, name):
+        self.name = name
+
+    def __get__(self, obj, tp):
+        result = self._resolve()
+        setattr(obj, self.name, result)  # Invokes __set__.
+        try:
+            # This is a bit ugly, but it avoids running this again by
+            # removing this descriptor.
+            delattr(obj.__class__, self.name)
+        except AttributeError:
+            pass
+        return result
+
+
+class MovedModule(_LazyDescr):
+
+    def __init__(self, name, old, new=None):
+        super(MovedModule, self).__init__(name)
+        if PY3:
+            if new is None:
+                new = name
+            self.mod = new
+        else:
+            self.mod = old
+
+    def _resolve(self):
+        return _import_module(self.mod)
+
+    def __getattr__(self, attr):
+        _module = self._resolve()
+        value = getattr(_module, attr)
+        setattr(self, attr, value)
+        return value
+
+
+class _LazyModule(types.ModuleType):
+
+    def __init__(self, name):
+        super(_LazyModule, self).__init__(name)
+        self.__doc__ = self.__class__.__doc__
+
+    def __dir__(self):
+        attrs = ["__doc__", "__name__"]
+        attrs += [attr.name for attr in self._moved_attributes]
+        return attrs
+
+    # Subclasses should override this
+    _moved_attributes = []
+
+
+class MovedAttribute(_LazyDescr):
+
+    def __init__(self, name, old_mod, new_mod, old_attr=None, new_attr=None):
+        super(MovedAttribute, self).__init__(name)
+        if PY3:
+            if new_mod is None:
+                new_mod = name
+            self.mod = new_mod
+            if new_attr is None:
+                if old_attr is None:
+                    new_attr = name
+                else:
+                    new_attr = old_attr
+            self.attr = new_attr
+        else:
+            self.mod = old_mod
+            if old_attr is None:
+                old_attr = name
+            self.attr = old_attr
+
+    def _resolve(self):
+        module = _import_module(self.mod)
+        return getattr(module, self.attr)
+
+
+class _SixMetaPathImporter(object):
+
+    """
+    A meta path importer to import six.moves and its submodules.
+
+    This class implements a PEP302 finder and loader. It should be compatible
+    with Python 2.5 and all existing versions of Python3
+    """
+
+    def __init__(self, six_module_name):
+        self.name = six_module_name
+        self.known_modules = {}
+
+    def _add_module(self, mod, *fullnames):
+        for fullname in fullnames:
+            self.known_modules[self.name + "." + fullname] = mod
+
+    def _get_module(self, fullname):
+        return self.known_modules[self.name + "." + fullname]
+
+    def find_module(self, fullname, path=None):
+        if fullname in self.known_modules:
+            return self
+        return None
+
+    def __get_module(self, fullname):
+        try:
+            return self.known_modules[fullname]
+        except KeyError:
+            raise ImportError("This loader does not know module " + fullname)
+
+    def load_module(self, fullname):
+        try:
+            # in case of a reload
+            return sys.modules[fullname]
+        except KeyError:
+            pass
+        mod = self.__get_module(fullname)
+        if isinstance(mod, MovedModule):
+            mod = mod._resolve()
+        else:
+            mod.__loader__ = self
+        sys.modules[fullname] = mod
+        return mod
+
+    def is_package(self, fullname):
+        """
+        Return true, if the named module is a package.
+
+        We need this method to get correct spec objects with
+        Python 3.4 (see PEP451)
+        """
+        return hasattr(self.__get_module(fullname), "__path__")
+
+    def get_code(self, fullname):
+        """Return None
+
+        Required, if is_package is implemented"""
+        self.__get_module(fullname)  # eventually raises ImportError
+        return None
+    get_source = get_code  # same as get_code
+
+_importer = _SixMetaPathImporter(__name__)
+
+
+class _MovedItems(_LazyModule):
+
+    """Lazy loading of moved objects"""
+    __path__ = []  # mark as package
+
+
+_moved_attributes = [
+    MovedAttribute("cStringIO", "cStringIO", "io", "StringIO"),
+    MovedAttribute("filter", "itertools", "builtins", "ifilter", "filter"),
+    MovedAttribute("filterfalse", "itertools", "itertools", "ifilterfalse", "filterfalse"),
+    MovedAttribute("input", "__builtin__", "builtins", "raw_input", "input"),
+    MovedAttribute("intern", "__builtin__", "sys"),
+    MovedAttribute("map", "itertools", "builtins", "imap", "map"),
+    MovedAttribute("getcwd", "os", "os", "getcwdu", "getcwd"),
+    MovedAttribute("getcwdb", "os", "os", "getcwd", "getcwdb"),
+    MovedAttribute("getoutput", "commands", "subprocess"),
+    MovedAttribute("range", "__builtin__", "builtins", "xrange", "range"),
+    MovedAttribute("reload_module", "__builtin__", "importlib" if PY34 else "imp", "reload"),
+    MovedAttribute("reduce", "__builtin__", "functools"),
+    MovedAttribute("shlex_quote", "pipes", "shlex", "quote"),
+    MovedAttribute("StringIO", "StringIO", "io"),
+    MovedAttribute("UserDict", "UserDict", "collections"),
+    MovedAttribute("UserList", "UserList", "collections"),
+    MovedAttribute("UserString", "UserString", "collections"),
+    MovedAttribute("xrange", "__builtin__", "builtins", "xrange", "range"),
+    MovedAttribute("zip", "itertools", "builtins", "izip", "zip"),
+    MovedAttribute("zip_longest", "itertools", "itertools", "izip_longest", "zip_longest"),
+    MovedModule("builtins", "__builtin__"),
+    MovedModule("configparser", "ConfigParser"),
+    MovedModule("copyreg", "copy_reg"),
+    MovedModule("dbm_gnu", "gdbm", "dbm.gnu"),
+    MovedModule("_dummy_thread", "dummy_thread", "_dummy_thread"),
+    MovedModule("http_cookiejar", "cookielib", "http.cookiejar"),
+    MovedModule("http_cookies", "Cookie", "http.cookies"),
+    MovedModule("html_entities", "htmlentitydefs", "html.entities"),
+    MovedModule("html_parser", "HTMLParser", "html.parser"),
+    MovedModule("http_client", "httplib", "http.client"),
+    MovedModule("email_mime_base", "email.MIMEBase", "email.mime.base"),
+    MovedModule("email_mime_image", "email.MIMEImage", "email.mime.image"),
+    MovedModule("email_mime_multipart", "email.MIMEMultipart", "email.mime.multipart"),
+    MovedModule("email_mime_nonmultipart", "email.MIMENonMultipart", "email.mime.nonmultipart"),
+    MovedModule("email_mime_text", "email.MIMEText", "email.mime.text"),
+    MovedModule("BaseHTTPServer", "BaseHTTPServer", "http.server"),
+    MovedModule("CGIHTTPServer", "CGIHTTPServer", "http.server"),
+    MovedModule("SimpleHTTPServer", "SimpleHTTPServer", "http.server"),
+    MovedModule("cPickle", "cPickle", "pickle"),
+    MovedModule("queue", "Queue"),
+    MovedModule("reprlib", "repr"),
+    MovedModule("socketserver", "SocketServer"),
+    MovedModule("_thread", "thread", "_thread"),
+    MovedModule("tkinter", "Tkinter"),
+    MovedModule("tkinter_dialog", "Dialog", "tkinter.dialog"),
+    MovedModule("tkinter_filedialog", "FileDialog", "tkinter.filedialog"),
+    MovedModule("tkinter_scrolledtext", "ScrolledText", "tkinter.scrolledtext"),
+    MovedModule("tkinter_simpledialog", "SimpleDialog", "tkinter.simpledialog"),
+    MovedModule("tkinter_tix", "Tix", "tkinter.tix"),
+    MovedModule("tkinter_ttk", "ttk", "tkinter.ttk"),
+    MovedModule("tkinter_constants", "Tkconstants", "tkinter.constants"),
+    MovedModule("tkinter_dnd", "Tkdnd", "tkinter.dnd"),
+    MovedModule("tkinter_colorchooser", "tkColorChooser",
+                "tkinter.colorchooser"),
+    MovedModule("tkinter_commondialog", "tkCommonDialog",
+                "tkinter.commondialog"),
+    MovedModule("tkinter_tkfiledialog", "tkFileDialog", "tkinter.filedialog"),
+    MovedModule("tkinter_font", "tkFont", "tkinter.font"),
+    MovedModule("tkinter_messagebox", "tkMessageBox", "tkinter.messagebox"),
+    MovedModule("tkinter_tksimpledialog", "tkSimpleDialog",
+                "tkinter.simpledialog"),
+    MovedModule("urllib_parse", __name__ + ".moves.urllib_parse", "urllib.parse"),
+    MovedModule("urllib_error", __name__ + ".moves.urllib_error", "urllib.error"),
+    MovedModule("urllib", __name__ + ".moves.urllib", __name__ + ".moves.urllib"),
+    MovedModule("urllib_robotparser", "robotparser", "urllib.robotparser"),
+    MovedModule("xmlrpc_client", "xmlrpclib", "xmlrpc.client"),
+    MovedModule("xmlrpc_server", "SimpleXMLRPCServer", "xmlrpc.server"),
+]
+# Add windows specific modules.
+if sys.platform == "win32":
+    _moved_attributes += [
+        MovedModule("winreg", "_winreg"),
+    ]
+
+for attr in _moved_attributes:
+    setattr(_MovedItems, attr.name, attr)
+    if isinstance(attr, MovedModule):
+        _importer._add_module(attr, "moves." + attr.name)
+del attr
+
+_MovedItems._moved_attributes = _moved_attributes
+
+moves = _MovedItems(__name__ + ".moves")
+_importer._add_module(moves, "moves")
+
+
+class Module_six_moves_urllib_parse(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_parse"""
+
+
+_urllib_parse_moved_attributes = [
+    MovedAttribute("ParseResult", "urlparse", "urllib.parse"),
+    MovedAttribute("SplitResult", "urlparse", "urllib.parse"),
+    MovedAttribute("parse_qs", "urlparse", "urllib.parse"),
+    MovedAttribute("parse_qsl", "urlparse", "urllib.parse"),
+    MovedAttribute("urldefrag", "urlparse", "urllib.parse"),
+    MovedAttribute("urljoin", "urlparse", "urllib.parse"),
+    MovedAttribute("urlparse", "urlparse", "urllib.parse"),
+    MovedAttribute("urlsplit", "urlparse", "urllib.parse"),
+    MovedAttribute("urlunparse", "urlparse", "urllib.parse"),
+    MovedAttribute("urlunsplit", "urlparse", "urllib.parse"),
+    MovedAttribute("quote", "urllib", "urllib.parse"),
+    MovedAttribute("quote_plus", "urllib", "urllib.parse"),
+    MovedAttribute("unquote", "urllib", "urllib.parse"),
+    MovedAttribute("unquote_plus", "urllib", "urllib.parse"),
+    MovedAttribute("unquote_to_bytes", "urllib", "urllib.parse", "unquote", "unquote_to_bytes"),
+    MovedAttribute("urlencode", "urllib", "urllib.parse"),
+    MovedAttribute("splitquery", "urllib", "urllib.parse"),
+    MovedAttribute("splittag", "urllib", "urllib.parse"),
+    MovedAttribute("splituser", "urllib", "urllib.parse"),
+    MovedAttribute("splitvalue", "urllib", "urllib.parse"),
+    MovedAttribute("uses_fragment", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_netloc", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_params", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_query", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_relative", "urlparse", "urllib.parse"),
+]
+for attr in _urllib_parse_moved_attributes:
+    setattr(Module_six_moves_urllib_parse, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_parse._moved_attributes = _urllib_parse_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_parse(__name__ + ".moves.urllib_parse"),
+                      "moves.urllib_parse", "moves.urllib.parse")
+
+
+class Module_six_moves_urllib_error(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_error"""
+
+
+_urllib_error_moved_attributes = [
+    MovedAttribute("URLError", "urllib2", "urllib.error"),
+    MovedAttribute("HTTPError", "urllib2", "urllib.error"),
+    MovedAttribute("ContentTooShortError", "urllib", "urllib.error"),
+]
+for attr in _urllib_error_moved_attributes:
+    setattr(Module_six_moves_urllib_error, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_error._moved_attributes = _urllib_error_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_error(__name__ + ".moves.urllib.error"),
+                      "moves.urllib_error", "moves.urllib.error")
+
+
+class Module_six_moves_urllib_request(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_request"""
+
+
+_urllib_request_moved_attributes = [
+    MovedAttribute("urlopen", "urllib2", "urllib.request"),
+    MovedAttribute("install_opener", "urllib2", "urllib.request"),
+    MovedAttribute("build_opener", "urllib2", "urllib.request"),
+    MovedAttribute("pathname2url", "urllib", "urllib.request"),
+    MovedAttribute("url2pathname", "urllib", "urllib.request"),
+    MovedAttribute("getproxies", "urllib", "urllib.request"),
+    MovedAttribute("Request", "urllib2", "urllib.request"),
+    MovedAttribute("OpenerDirector", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPDefaultErrorHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPRedirectHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPCookieProcessor", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyHandler", "urllib2", "urllib.request"),
+    MovedAttribute("BaseHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPPasswordMgr", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPPasswordMgrWithDefaultRealm", "urllib2", "urllib.request"),
+    MovedAttribute("AbstractBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("AbstractDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPSHandler", "urllib2", "urllib.request"),
+    MovedAttribute("FileHandler", "urllib2", "urllib.request"),
+    MovedAttribute("FTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("CacheFTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("UnknownHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPErrorProcessor", "urllib2", "urllib.request"),
+    MovedAttribute("urlretrieve", "urllib", "urllib.request"),
+    MovedAttribute("urlcleanup", "urllib", "urllib.request"),
+    MovedAttribute("URLopener", "urllib", "urllib.request"),
+    MovedAttribute("FancyURLopener", "urllib", "urllib.request"),
+    MovedAttribute("proxy_bypass", "urllib", "urllib.request"),
+    MovedAttribute("parse_http_list", "urllib2", "urllib.request"),
+    MovedAttribute("parse_keqv_list", "urllib2", "urllib.request"),
+]
+for attr in _urllib_request_moved_attributes:
+    setattr(Module_six_moves_urllib_request, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_request._moved_attributes = _urllib_request_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_request(__name__ + ".moves.urllib.request"),
+                      "moves.urllib_request", "moves.urllib.request")
+
+
+class Module_six_moves_urllib_response(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_response"""
+
+
+_urllib_response_moved_attributes = [
+    MovedAttribute("addbase", "urllib", "urllib.response"),
+    MovedAttribute("addclosehook", "urllib", "urllib.response"),
+    MovedAttribute("addinfo", "urllib", "urllib.response"),
+    MovedAttribute("addinfourl", "urllib", "urllib.response"),
+]
+for attr in _urllib_response_moved_attributes:
+    setattr(Module_six_moves_urllib_response, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_response._moved_attributes = _urllib_response_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_response(__name__ + ".moves.urllib.response"),
+                      "moves.urllib_response", "moves.urllib.response")
+
+
+class Module_six_moves_urllib_robotparser(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_robotparser"""
+
+
+_urllib_robotparser_moved_attributes = [
+    MovedAttribute("RobotFileParser", "robotparser", "urllib.robotparser"),
+]
+for attr in _urllib_robotparser_moved_attributes:
+    setattr(Module_six_moves_urllib_robotparser, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_robotparser._moved_attributes = _urllib_robotparser_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_robotparser(__name__ + ".moves.urllib.robotparser"),
+                      "moves.urllib_robotparser", "moves.urllib.robotparser")
+
+
+class Module_six_moves_urllib(types.ModuleType):
+
+    """Create a six.moves.urllib namespace that resembles the Python 3 namespace"""
+    __path__ = []  # mark as package
+    parse = _importer._get_module("moves.urllib_parse")
+    error = _importer._get_module("moves.urllib_error")
+    request = _importer._get_module("moves.urllib_request")
+    response = _importer._get_module("moves.urllib_response")
+    robotparser = _importer._get_module("moves.urllib_robotparser")
+
+    def __dir__(self):
+        return ['parse', 'error', 'request', 'response', 'robotparser']
+
+_importer._add_module(Module_six_moves_urllib(__name__ + ".moves.urllib"),
+                      "moves.urllib")
+
+
+def add_move(move):
+    """Add an item to six.moves."""
+    setattr(_MovedItems, move.name, move)
+
+
+def remove_move(name):
+    """Remove item from six.moves."""
+    try:
+        delattr(_MovedItems, name)
+    except AttributeError:
+        try:
+            del moves.__dict__[name]
+        except KeyError:
+            raise AttributeError("no such move, %r" % (name,))
+
+
+if PY3:
+    _meth_func = "__func__"
+    _meth_self = "__self__"
+
+    _func_closure = "__closure__"
+    _func_code = "__code__"
+    _func_defaults = "__defaults__"
+    _func_globals = "__globals__"
+else:
+    _meth_func = "im_func"
+    _meth_self = "im_self"
+
+    _func_closure = "func_closure"
+    _func_code = "func_code"
+    _func_defaults = "func_defaults"
+    _func_globals = "func_globals"
+
+
+try:
+    advance_iterator = next
+except NameError:
+    def advance_iterator(it):
+        return it.next()
+next = advance_iterator
+
+
+try:
+    callable = callable
+except NameError:
+    def callable(obj):
+        return any("__call__" in klass.__dict__ for klass in type(obj).__mro__)
+
+
+if PY3:
+    def get_unbound_function(unbound):
+        return unbound
+
+    create_bound_method = types.MethodType
+
+    def create_unbound_method(func, cls):
+        return func
+
+    Iterator = object
+else:
+    def get_unbound_function(unbound):
+        return unbound.im_func
+
+    def create_bound_method(func, obj):
+        return types.MethodType(func, obj, obj.__class__)
+
+    def create_unbound_method(func, cls):
+        return types.MethodType(func, None, cls)
+
+    class Iterator(object):
+
+        def next(self):
+            return type(self).__next__(self)
+
+    callable = callable
+_add_doc(get_unbound_function,
+         """Get the function out of a possibly unbound function""")
+
+
+get_method_function = operator.attrgetter(_meth_func)
+get_method_self = operator.attrgetter(_meth_self)
+get_function_closure = operator.attrgetter(_func_closure)
+get_function_code = operator.attrgetter(_func_code)
+get_function_defaults = operator.attrgetter(_func_defaults)
+get_function_globals = operator.attrgetter(_func_globals)
+
+
+if PY3:
+    def iterkeys(d, **kw):
+        return iter(d.keys(**kw))
+
+    def itervalues(d, **kw):
+        return iter(d.values(**kw))
+
+    def iteritems(d, **kw):
+        return iter(d.items(**kw))
+
+    def iterlists(d, **kw):
+        return iter(d.lists(**kw))
+
+    viewkeys = operator.methodcaller("keys")
+
+    viewvalues = operator.methodcaller("values")
+
+    viewitems = operator.methodcaller("items")
+else:
+    def iterkeys(d, **kw):
+        return d.iterkeys(**kw)
+
+    def itervalues(d, **kw):
+        return d.itervalues(**kw)
+
+    def iteritems(d, **kw):
+        return d.iteritems(**kw)
+
+    def iterlists(d, **kw):
+        return d.iterlists(**kw)
+
+    viewkeys = operator.methodcaller("viewkeys")
+
+    viewvalues = operator.methodcaller("viewvalues")
+
+    viewitems = operator.methodcaller("viewitems")
+
+_add_doc(iterkeys, "Return an iterator over the keys of a dictionary.")
+_add_doc(itervalues, "Return an iterator over the values of a dictionary.")
+_add_doc(iteritems,
+         "Return an iterator over the (key, value) pairs of a dictionary.")
+_add_doc(iterlists,
+         "Return an iterator over the (key, [values]) pairs of a dictionary.")
+
+
+if PY3:
+    def b(s):
+        return s.encode("latin-1")
+
+    def u(s):
+        return s
+    unichr = chr
+    import struct
+    int2byte = struct.Struct(">B").pack
+    del struct
+    byte2int = operator.itemgetter(0)
+    indexbytes = operator.getitem
+    iterbytes = iter
+    import io
+    StringIO = io.StringIO
+    BytesIO = io.BytesIO
+    _assertCountEqual = "assertCountEqual"
+    if sys.version_info[1] <= 1:
+        _assertRaisesRegex = "assertRaisesRegexp"
+        _assertRegex = "assertRegexpMatches"
+    else:
+        _assertRaisesRegex = "assertRaisesRegex"
+        _assertRegex = "assertRegex"
+else:
+    def b(s):
+        return s
+    # Workaround for standalone backslash
+
+    def u(s):
+        return unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
+    unichr = unichr
+    int2byte = chr
+
+    def byte2int(bs):
+        return ord(bs[0])
+
+    def indexbytes(buf, i):
+        return ord(buf[i])
+    iterbytes = functools.partial(itertools.imap, ord)
+    import StringIO
+    StringIO = BytesIO = StringIO.StringIO
+    _assertCountEqual = "assertItemsEqual"
+    _assertRaisesRegex = "assertRaisesRegexp"
+    _assertRegex = "assertRegexpMatches"
+_add_doc(b, """Byte literal""")
+_add_doc(u, """Text literal""")
+
+
+def assertCountEqual(self, *args, **kwargs):
+    return getattr(self, _assertCountEqual)(*args, **kwargs)
+
+
+def assertRaisesRegex(self, *args, **kwargs):
+    return getattr(self, _assertRaisesRegex)(*args, **kwargs)
+
+
+def assertRegex(self, *args, **kwargs):
+    return getattr(self, _assertRegex)(*args, **kwargs)
+
+
+if PY3:
+    exec_ = getattr(moves.builtins, "exec")
+
+    def reraise(tp, value, tb=None):
+        try:
+            if value is None:
+                value = tp()
+            if value.__traceback__ is not tb:
+                raise value.with_traceback(tb)
+            raise value
+        finally:
+            value = None
+            tb = None
+
+else:
+    def exec_(_code_, _globs_=None, _locs_=None):
+        """Execute code in a namespace."""
+        if _globs_ is None:
+            frame = sys._getframe(1)
+            _globs_ = frame.f_globals
+            if _locs_ is None:
+                _locs_ = frame.f_locals
+            del frame
+        elif _locs_ is None:
+            _locs_ = _globs_
+        exec("""exec _code_ in _globs_, _locs_""")
+
+    exec_("""def reraise(tp, value, tb=None):
+    try:
+        raise tp, value, tb
+    finally:
+        tb = None
+""")
+
+
+if sys.version_info[:2] == (3, 2):
+    exec_("""def raise_from(value, from_value):
+    try:
+        if from_value is None:
+            raise value
+        raise value from from_value
+    finally:
+        value = None
+""")
+elif sys.version_info[:2] > (3, 2):
+    exec_("""def raise_from(value, from_value):
+    try:
+        raise value from from_value
+    finally:
+        value = None
+""")
+else:
+    def raise_from(value, from_value):
+        raise value
+
+
+print_ = getattr(moves.builtins, "print", None)
+if print_ is None:
+    def print_(*args, **kwargs):
+        """The new-style print function for Python 2.4 and 2.5."""
+        fp = kwargs.pop("file", sys.stdout)
+        if fp is None:
+            return
+
+        def write(data):
+            if not isinstance(data, basestring):
+                data = str(data)
+            # If the file has an encoding, encode unicode with it.
+            if (isinstance(fp, file) and
+                    isinstance(data, unicode) and
+                    fp.encoding is not None):
+                errors = getattr(fp, "errors", None)
+                if errors is None:
+                    errors = "strict"
+                data = data.encode(fp.encoding, errors)
+            fp.write(data)
+        want_unicode = False
+        sep = kwargs.pop("sep", None)
+        if sep is not None:
+            if isinstance(sep, unicode):
+                want_unicode = True
+            elif not isinstance(sep, str):
+                raise TypeError("sep must be None or a string")
+        end = kwargs.pop("end", None)
+        if end is not None:
+            if isinstance(end, unicode):
+                want_unicode = True
+            elif not isinstance(end, str):
+                raise TypeError("end must be None or a string")
+        if kwargs:
+            raise TypeError("invalid keyword arguments to print()")
+        if not want_unicode:
+            for arg in args:
+                if isinstance(arg, unicode):
+                    want_unicode = True
+                    break
+        if want_unicode:
+            newline = unicode("\n")
+            space = unicode(" ")
+        else:
+            newline = "\n"
+            space = " "
+        if sep is None:
+            sep = space
+        if end is None:
+            end = newline
+        for i, arg in enumerate(args):
+            if i:
+                write(sep)
+            write(arg)
+        write(end)
+if sys.version_info[:2] < (3, 3):
+    _print = print_
+
+    def print_(*args, **kwargs):
+        fp = kwargs.get("file", sys.stdout)
+        flush = kwargs.pop("flush", False)
+        _print(*args, **kwargs)
+        if flush and fp is not None:
+            fp.flush()
+
+_add_doc(reraise, """Reraise an exception.""")
+
+if sys.version_info[0:2] < (3, 4):
+    def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,
+              updated=functools.WRAPPER_UPDATES):
+        def wrapper(f):
+            f = functools.wraps(wrapped, assigned, updated)(f)
+            f.__wrapped__ = wrapped
+            return f
+        return wrapper
+else:
+    wraps = functools.wraps
+
+
+def with_metaclass(meta, *bases):
+    """Create a base class with a metaclass."""
+    # This requires a bit of explanation: the basic idea is to make a dummy
+    # metaclass for one level of class instantiation that replaces itself with
+    # the actual metaclass.
+    class metaclass(type):
+
+        def __new__(cls, name, this_bases, d):
+            return meta(name, bases, d)
+
+        @classmethod
+        def __prepare__(cls, name, this_bases):
+            return meta.__prepare__(name, bases)
+    return type.__new__(metaclass, 'temporary_class', (), {})
+
+
+def add_metaclass(metaclass):
+    """Class decorator for creating a class with a metaclass."""
+    def wrapper(cls):
+        orig_vars = cls.__dict__.copy()
+        slots = orig_vars.get('__slots__')
+        if slots is not None:
+            if isinstance(slots, str):
+                slots = [slots]
+            for slots_var in slots:
+                orig_vars.pop(slots_var)
+        orig_vars.pop('__dict__', None)
+        orig_vars.pop('__weakref__', None)
+        return metaclass(cls.__name__, cls.__bases__, orig_vars)
+    return wrapper
+
+
+def python_2_unicode_compatible(klass):
+    """
+    A decorator that defines __unicode__ and __str__ methods under Python 2.
+    Under Python 3 it does nothing.
+
+    To support Python 2 and 3 with a single code base, define a __str__ method
+    returning text and apply this decorator to the class.
+    """
+    if PY2:
+        if '__str__' not in klass.__dict__:
+            raise ValueError("@python_2_unicode_compatible cannot be applied "
+                             "to %s because it doesn't define __str__()." %
+                             klass.__name__)
+        klass.__unicode__ = klass.__str__
+        klass.__str__ = lambda self: self.__unicode__().encode('utf-8')
+    return klass
+
+
+# Complete the moves implementation.
+# This code is at the end of this module to speed up module loading.
+# Turn this module into a package.
+__path__ = []  # required for PEP 302 and PEP 451
+__package__ = __name__  # see PEP 366 @ReservedAssignment
+if globals().get("__spec__") is not None:
+    __spec__.submodule_search_locations = []  # PEP 451 @UndefinedVariable
+# Remove other six meta path importers, since they cause problems. This can
+# happen if six is removed from sys.modules and then reloaded. (Setuptools does
+# this for some reason.)
+if sys.meta_path:
+    for i, importer in enumerate(sys.meta_path):
+        # Here's some real nastiness: Another "instance" of the six module might
+        # be floating around. Therefore, we can't use isinstance() to check for
+        # the six meta path importer, since the other six instance will have
+        # inserted an importer with different class.
+        if (type(importer).__name__ == "_SixMetaPathImporter" and
+                importer.name == __name__):
+            del sys.meta_path[i]
+            break
+    del i, importer
+# Finally, add the importer to the meta path import hook.
+sys.meta_path.append(_importer)

--- a/stripe/stripe_object.py
+++ b/stripe/stripe_object.py
@@ -1,9 +1,8 @@
-import sys
 import warnings
 from copy import deepcopy
 
 import stripe
-from stripe import api_requestor, util
+from stripe import api_requestor, util, six
 
 
 def _compute_diff(current, previous):
@@ -104,7 +103,7 @@ class StripeObject(dict):
                     "the result returned by Stripe's API, probably as a "
                     "result of a save().  The attributes currently "
                     "available on this object are: %s" %
-                    (k, k, ', '.join(self.keys())))
+                    (k, k, ', '.join(list(self.keys()))))
             else:
                 raise err
 
@@ -169,7 +168,7 @@ class StripeObject(dict):
 
         self._transient_values = self._transient_values - set(values)
 
-        for k, v in values.iteritems():
+        for k, v in six.iteritems(values):
             super(StripeObject, self).__setitem__(
                 k, util.convert_to_stripe_object(v, api_key, stripe_version,
                                                  stripe_account))
@@ -195,16 +194,16 @@ class StripeObject(dict):
     def __repr__(self):
         ident_parts = [type(self).__name__]
 
-        if isinstance(self.get('object'), basestring):
+        if isinstance(self.get('object'), six.string_types):
             ident_parts.append(self.get('object'))
 
-        if isinstance(self.get('id'), basestring):
+        if isinstance(self.get('id'), six.string_types):
             ident_parts.append('id=%s' % (self.get('id'),))
 
         unicode_repr = '<%s at %s> JSON: %s' % (
             ' '.join(ident_parts), hex(id(self)), str(self))
 
-        if sys.version_info[0] < 3:
+        if six.PY2:
             return unicode_repr.encode('utf-8')
         else:
             return unicode_repr
@@ -230,7 +229,7 @@ class StripeObject(dict):
         unsaved_keys = self._unsaved_values or set()
         previous = previous or self._previous or {}
 
-        for k, v in self.items():
+        for k, v in six.iteritems(self):
             if k == 'id' or (isinstance(k, str) and k.startswith('_')):
                 continue
             elif isinstance(v, stripe.api_resources.abstract.APIResource):
@@ -256,7 +255,7 @@ class StripeObject(dict):
 
         copied._retrieve_params = self._retrieve_params
 
-        for k, v in self.items():
+        for k, v in six.iteritems(self):
             # Call parent's __setitem__ to avoid checks that we've added in the
             # overridden version that can throw exceptions.
             super(StripeObject, copied).__setitem__(k, v)
@@ -272,7 +271,7 @@ class StripeObject(dict):
         copied = self.__copy__()
         memo[id(self)] = copied
 
-        for k, v in self.items():
+        for k, v in six.iteritems(self):
             # Call parent's __setitem__ to avoid checks that we've added in the
             # overridden version that can throw exceptions.
             super(StripeObject, copied).__setitem__(k, deepcopy(v, memo))

--- a/stripe/stripe_object.py
+++ b/stripe/stripe_object.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import warnings
 from copy import deepcopy
 

--- a/stripe/test/__init__.py
+++ b/stripe/test/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import os
 import unittest2
 

--- a/stripe/test/api_resources/abstract/test_api_resource.py
+++ b/stripe/test/api_resources/abstract/test_api_resource.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeApiTestCase
 

--- a/stripe/test/api_resources/abstract/test_createable_api_resource.py
+++ b/stripe/test/api_resources/abstract/test_createable_api_resource.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeApiTestCase
 

--- a/stripe/test/api_resources/abstract/test_deletable_api_resource.py
+++ b/stripe/test/api_resources/abstract/test_deletable_api_resource.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeApiTestCase
 

--- a/stripe/test/api_resources/abstract/test_listable_api_resource.py
+++ b/stripe/test/api_resources/abstract/test_listable_api_resource.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeApiTestCase
 

--- a/stripe/test/api_resources/abstract/test_nested_resource_class_methods.py
+++ b/stripe/test/api_resources/abstract/test_nested_resource_class_methods.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeApiTestCase
 

--- a/stripe/test/api_resources/abstract/test_singleton_api_resource.py
+++ b/stripe/test/api_resources/abstract/test_singleton_api_resource.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeApiTestCase
 

--- a/stripe/test/api_resources/abstract/test_updateable_api_resource.py
+++ b/stripe/test/api_resources/abstract/test_updateable_api_resource.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeApiTestCase
 

--- a/stripe/test/api_resources/test_account.py
+++ b/stripe/test/api_resources/test_account.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 

--- a/stripe/test/api_resources/test_apple_pay_domain.py
+++ b/stripe/test/api_resources/test_apple_pay_domain.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 

--- a/stripe/test/api_resources/test_application_fee.py
+++ b/stripe/test/api_resources/test_application_fee.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 

--- a/stripe/test/api_resources/test_application_fee_refund.py
+++ b/stripe/test/api_resources/test_application_fee_refund.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 

--- a/stripe/test/api_resources/test_balance.py
+++ b/stripe/test/api_resources/test_balance.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 

--- a/stripe/test/api_resources/test_balance_transaction.py
+++ b/stripe/test/api_resources/test_balance_transaction.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 

--- a/stripe/test/api_resources/test_bitcoin_receiver.py
+++ b/stripe/test/api_resources/test_bitcoin_receiver.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 

--- a/stripe/test/api_resources/test_charge.py
+++ b/stripe/test/api_resources/test_charge.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import (
     StripeResourceTest, NOW, DUMMY_CHARGE

--- a/stripe/test/api_resources/test_country_spec.py
+++ b/stripe/test/api_resources/test_country_spec.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 

--- a/stripe/test/api_resources/test_coupon.py
+++ b/stripe/test/api_resources/test_coupon.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 

--- a/stripe/test/api_resources/test_customer.py
+++ b/stripe/test/api_resources/test_customer.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import datetime
 import time
 import warnings

--- a/stripe/test/api_resources/test_dispute.py
+++ b/stripe/test/api_resources/test_dispute.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeResourceTest, NOW
 

--- a/stripe/test/api_resources/test_ephemeral_key.py
+++ b/stripe/test/api_resources/test_ephemeral_key.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import warnings
 
 import stripe

--- a/stripe/test/api_resources/test_exchange_rate.py
+++ b/stripe/test/api_resources/test_exchange_rate.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 

--- a/stripe/test/api_resources/test_file_upload.py
+++ b/stripe/test/api_resources/test_file_upload.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import tempfile
 
 import stripe

--- a/stripe/test/api_resources/test_invoice.py
+++ b/stripe/test/api_resources/test_invoice.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 

--- a/stripe/test/api_resources/test_list_object.py
+++ b/stripe/test/api_resources/test_list_object.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeApiTestCase
 

--- a/stripe/test/api_resources/test_metadata.py
+++ b/stripe/test/api_resources/test_metadata.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 

--- a/stripe/test/api_resources/test_order.py
+++ b/stripe/test/api_resources/test_order.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 

--- a/stripe/test/api_resources/test_order_return.py
+++ b/stripe/test/api_resources/test_order_return.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 

--- a/stripe/test/api_resources/test_payout.py
+++ b/stripe/test/api_resources/test_payout.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 

--- a/stripe/test/api_resources/test_plans.py
+++ b/stripe/test/api_resources/test_plans.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import (
     StripeResourceTest, DUMMY_PLAN

--- a/stripe/test/api_resources/test_product.py
+++ b/stripe/test/api_resources/test_product.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 

--- a/stripe/test/api_resources/test_recipient.py
+++ b/stripe/test/api_resources/test_recipient.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import (StripeResourceTest)
 

--- a/stripe/test/api_resources/test_refund.py
+++ b/stripe/test/api_resources/test_refund.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 

--- a/stripe/test/api_resources/test_reversal.py
+++ b/stripe/test/api_resources/test_reversal.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 

--- a/stripe/test/api_resources/test_sku.py
+++ b/stripe/test/api_resources/test_sku.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 

--- a/stripe/test/api_resources/test_source.py
+++ b/stripe/test/api_resources/test_source.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import warnings
 
 import stripe

--- a/stripe/test/api_resources/test_source_transaction.py
+++ b/stripe/test/api_resources/test_source_transaction.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 

--- a/stripe/test/api_resources/test_subscription.py
+++ b/stripe/test/api_resources/test_subscription.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import datetime
 import time
 

--- a/stripe/test/api_resources/test_subscription_item.py
+++ b/stripe/test/api_resources/test_subscription_item.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import (
     StripeResourceTest, DUMMY_PLAN

--- a/stripe/test/api_resources/test_three_d_secure.py
+++ b/stripe/test/api_resources/test_three_d_secure.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 

--- a/stripe/test/api_resources/test_transfer.py
+++ b/stripe/test/api_resources/test_transfer.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import stripe
 from stripe.test.helper import StripeResourceTest
 

--- a/stripe/test/helper.py
+++ b/stripe/test/helper.py
@@ -2,12 +2,12 @@ import datetime
 import os
 import random
 import string
-import sys
 import unittest2
 
 from mock import patch, Mock
 
 import stripe
+from stripe import six
 
 NOW = datetime.datetime.now()
 
@@ -54,12 +54,7 @@ class StripeTestCase(unittest2.TestCase):
 
 
 class StripeUnitTestCase(StripeTestCase):
-    REQUEST_LIBRARIES = ['urlfetch', 'requests', 'pycurl']
-
-    if sys.version_info >= (3, 0):
-        REQUEST_LIBRARIES.append('urllib.request')
-    else:
-        REQUEST_LIBRARIES.append('urllib2')
+    REQUEST_LIBRARIES = ['urlfetch', 'requests', 'pycurl', 'urllib.request']
 
     def setUp(self):
         super(StripeUnitTestCase, self).setUp()
@@ -75,7 +70,7 @@ class StripeUnitTestCase(StripeTestCase):
     def tearDown(self):
         super(StripeUnitTestCase, self).tearDown()
 
-        for patcher in self.request_patchers.itervalues():
+        for patcher in six.itervalues(self.request_patchers):
             patcher.stop()
 
 

--- a/stripe/test/helper.py
+++ b/stripe/test/helper.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import datetime
 import os
 import random

--- a/stripe/test/test_api_requestor.py
+++ b/stripe/test/test_api_requestor.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import datetime
 import unittest2

--- a/stripe/test/test_api_requestor.py
+++ b/stripe/test/test_api_requestor.py
@@ -1,12 +1,16 @@
+from __future__ import print_function
+
 import datetime
 import unittest2
-import urlparse
 
 from mock import Mock, ANY
 
 import stripe
+from stripe import six
 
 from stripe.test.helper import StripeUnitTestCase
+
+from six.moves.urllib.parse import urlsplit
 
 
 VALID_API_METHODS = ('get', 'post', 'delete')
@@ -49,7 +53,7 @@ class APIHeaderMatcher(object):
                 self._extra_match(other))
 
     def _keys_match(self, other):
-        expected_keys = list(set(self.EXP_KEYS + self.extra.keys()))
+        expected_keys = list(set(self.EXP_KEYS + list(self.extra.keys())))
         if self.request_method is not None and self.request_method in \
                 self.METHOD_EXTRA_KEYS:
             expected_keys.extend(self.METHOD_EXTRA_KEYS[self.request_method])
@@ -74,7 +78,7 @@ class APIHeaderMatcher(object):
         return True
 
     def _extra_match(self, other):
-        for k, v in self.extra.iteritems():
+        for k, v in six.iteritems(self.extra):
             if other[k] != v:
                 return False
 
@@ -87,7 +91,7 @@ class QueryMatcher(object):
         self.expected = sorted(expected)
 
     def __eq__(self, other):
-        query = urlparse.urlsplit(other).query or other
+        query = urlsplit(other).query or other
 
         parsed = stripe.util.parse_qsl(query)
         return self.expected == sorted(parsed)
@@ -96,17 +100,17 @@ class QueryMatcher(object):
 class UrlMatcher(object):
 
     def __init__(self, expected):
-        self.exp_parts = urlparse.urlsplit(expected)
+        self.exp_parts = urlsplit(expected)
 
     def __eq__(self, other):
-        other_parts = urlparse.urlsplit(other)
+        other_parts = urlsplit(other)
 
         for part in ('scheme', 'netloc', 'path', 'fragment'):
             expected = getattr(self.exp_parts, part)
             actual = getattr(other_parts, part)
             if expected != actual:
-                print 'Expected %s "%s" but got "%s"' % (
-                    part, expected, actual)
+                print('Expected %s "%s" but got "%s"' % (
+                    part, expected, actual))
                 return False
 
         q_matcher = QueryMatcher(stripe.util.parse_qsl(self.exp_parts.query))
@@ -222,7 +226,7 @@ class APIRequestorRequestTests(StripeUnitTestCase):
         self.requestor.request('get', '', self.ENCODE_INPUTS)
 
         expectation = []
-        for type_, values in self.ENCODE_EXPECTATIONS.iteritems():
+        for type_, values in six.iteritems(self.ENCODE_EXPECTATIONS):
             expectation.extend([(k % (type_,), str(v)) for k, v in values])
 
         self.check_call('get', QueryMatcher(expectation))

--- a/stripe/test/test_error.py
+++ b/stripe/test/test_error.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
-import sys
-
 import unittest2
 
-from stripe import StripeError
+from stripe import six, StripeError
 from stripe.test.helper import StripeUnitTestCase
 
 
@@ -11,7 +9,7 @@ class StripeErrorTests(StripeUnitTestCase):
 
     def test_formatting(self):
         err = StripeError(u'öre')
-        if sys.version_info > (3, 0):
+        if six.PY3:
             assert str(err) == u'öre'
         else:
             assert str(err) == '\xc3\xb6re'
@@ -19,7 +17,7 @@ class StripeErrorTests(StripeUnitTestCase):
 
     def test_formatting_with_request_id(self):
         err = StripeError(u'öre', headers={'request-id': '123'})
-        if sys.version_info > (3, 0):
+        if six.PY3:
             assert str(err) == u'Request 123: öre'
         else:
             assert str(err) == 'Request 123: \xc3\xb6re'
@@ -27,7 +25,7 @@ class StripeErrorTests(StripeUnitTestCase):
 
     def test_formatting_with_none(self):
         err = StripeError(None, headers={'request-id': '123'})
-        if sys.version_info > (3, 0):
+        if six.PY3:
             assert str(err) == u'Request 123: <empty message>'
         else:
             assert str(err) == 'Request 123: <empty message>'

--- a/stripe/test/test_error.py
+++ b/stripe/test/test_error.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function
+
 import unittest2
 
 from stripe import six, StripeError

--- a/stripe/test/test_http_client.py
+++ b/stripe/test/test_http_client.py
@@ -1,9 +1,9 @@
-import sys
 import unittest2
 
 from mock import MagicMock, Mock, patch
 
 import stripe
+from stripe import six
 
 from stripe.test.helper import StripeUnitTestCase
 
@@ -219,7 +219,7 @@ class Urllib2ClientTests(StripeUnitTestCase, ClientTestBase):
         mock.build_opener.reset_mock()
 
     def check_call(self, mock, meth, url, post_data, headers):
-        if sys.version_info >= (3, 0) and isinstance(post_data, basestring):
+        if six.PY3 and isinstance(post_data, six.string_types):
             post_data = post_data.encode('utf-8')
 
         mock.Request.assert_called_with(url, post_data, headers)

--- a/stripe/test/test_http_client.py
+++ b/stripe/test/test_http_client.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import unittest2
 
 from mock import MagicMock, Mock, patch

--- a/stripe/test/test_integration.py
+++ b/stripe/test/test_integration.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function
+
 import os
 import unittest2
 import stripe

--- a/stripe/test/test_integration.py
+++ b/stripe/test/test_integration.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 import os
-import sys
 import unittest2
 import stripe
 
 from mock import patch
+
+from stripe import six
+
 from stripe.test.helper import (StripeTestCase, DUMMY_CHARGE)
 
 
@@ -106,7 +108,7 @@ class PycurlFunctionalTests(FunctionalTests):
     def setUp(self):
         if not os.environ.get('STRIPE_TEST_PYCURL'):
             self.skipTest('Pycurl skipped as STRIPE_TEST_PYCURL is not set')
-        if sys.version_info >= (3, 0):
+        if six.PY3:
             self.skipTest('Pycurl is not supported in Python 3')
         else:
             super(PycurlFunctionalTests, self).setUp()
@@ -123,7 +125,7 @@ class AuthenticationErrorTest(StripeTestCase):
             stripe.Customer.create()
         except stripe.error.AuthenticationError as e:
             self.assertEqual(401, e.http_status)
-            self.assertTrue(isinstance(e.http_body, basestring))
+            self.assertTrue(isinstance(e.http_body, six.string_types))
             self.assertTrue(isinstance(e.json_body, dict))
             # Note that an invalid API key bypasses many of the standard
             # facilities in the API server so currently no Request ID is
@@ -140,7 +142,7 @@ class CardErrorTest(StripeTestCase):
                                  source='tok_chargeDeclinedExpiredCard')
         except stripe.error.CardError as e:
             self.assertEqual(402, e.http_status)
-            self.assertTrue(isinstance(e.http_body, basestring))
+            self.assertTrue(isinstance(e.http_body, six.string_types))
             self.assertTrue(isinstance(e.json_body, dict))
             self.assertTrue(e.request_id.startswith('req_'))
 
@@ -152,7 +154,7 @@ class InvalidRequestErrorTest(StripeTestCase):
             stripe.Charge.retrieve('invalid')
         except stripe.error.InvalidRequestError as e:
             self.assertEqual(404, e.http_status)
-            self.assertTrue(isinstance(e.http_body, basestring))
+            self.assertTrue(isinstance(e.http_body, six.string_types))
             self.assertTrue(isinstance(e.json_body, dict))
             self.assertTrue(e.request_id.startswith('req_'))
 
@@ -161,7 +163,7 @@ class InvalidRequestErrorTest(StripeTestCase):
             stripe.Charge.create()
         except stripe.error.InvalidRequestError as e:
             self.assertEqual(400, e.http_status)
-            self.assertTrue(isinstance(e.http_body, basestring))
+            self.assertTrue(isinstance(e.http_body, six.string_types))
             self.assertTrue(isinstance(e.json_body, dict))
             self.assertTrue(e.request_id.startswith('req_'))
 

--- a/stripe/test/test_multipart_data_generator.py
+++ b/stripe/test/test_multipart_data_generator.py
@@ -1,4 +1,6 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function
 
 import re
 

--- a/stripe/test/test_multipart_data_generator.py
+++ b/stripe/test/test_multipart_data_generator.py
@@ -1,9 +1,8 @@
 # -*- encoding: utf-8 -*-
 
 import re
-import sys
-import StringIO
 
+from stripe import six
 from stripe.multipart_data_generator import MultipartDataGenerator
 from stripe.test.helper import StripeTestCase
 
@@ -20,7 +19,7 @@ class MultipartDataGeneratorTests(StripeTestCase):
         generator.add_params(params)
         http_body = generator.get_post_data()
 
-        if sys.version_info >= (3,):
+        if six.PY3:
             http_body = http_body.decode('utf-8')
 
         self.assertTrue(re.search(
@@ -39,7 +38,7 @@ class MultipartDataGeneratorTests(StripeTestCase):
         test_file.seek(0)
         file_contents = test_file.read()
 
-        if sys.version_info >= (3,) and isinstance(file_contents, bytes):
+        if six.PY3 and isinstance(file_contents, bytes):
             file_contents = file_contents.decode('utf-8')
 
         self.assertNotEqual(-1, http_body.find(file_contents))
@@ -53,5 +52,5 @@ class MultipartDataGeneratorTests(StripeTestCase):
             self.run_test_multipart_data_with_file(test_file)
 
     def test_multipart_data_stringio(self):
-        string = StringIO.StringIO("foo")
+        string = six.StringIO("foo")
         self.run_test_multipart_data_with_file(string)

--- a/stripe/test/test_oauth.py
+++ b/stripe/test/test_oauth.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from six.moves.urllib.parse import parse_qs, urlparse
 
 import stripe

--- a/stripe/test/test_oauth.py
+++ b/stripe/test/test_oauth.py
@@ -1,4 +1,4 @@
-import urlparse
+from six.moves.urllib.parse import parse_qs, urlparse
 
 import stripe
 from stripe.test.helper import StripeApiTestCase
@@ -26,8 +26,8 @@ class OAuthTests(StripeApiTestCase):
                 'country': 'US',
             })
 
-        o = urlparse.urlparse(url)
-        params = urlparse.parse_qs(o.query)
+        o = urlparse(url)
+        params = parse_qs(o.query)
 
         self.assertEqual('https', o.scheme)
         self.assertEqual('connect.stripe.com', o.netloc)

--- a/stripe/test/test_stripe_object.py
+++ b/stripe/test/test_stripe_object.py
@@ -1,9 +1,8 @@
 import pickle
-import sys
 from copy import copy, deepcopy
 
 import stripe
-from stripe import util
+from stripe import util, six
 from stripe.test.helper import StripeUnitTestCase
 
 
@@ -160,8 +159,8 @@ class StripeObjectTests(StripeUnitTestCase):
 
     def check_invoice_data(self, data):
         # Check rough structure
-        self.assertEqual(20, len(data.keys()))
-        self.assertEqual(3, len(data['lines'].keys()))
+        self.assertEqual(20, len(list(data.keys())))
+        self.assertEqual(3, len(list(data['lines'].keys())))
         self.assertEqual(0, len(data['lines']['invoiceitems']))
         self.assertEqual(1, len(data['lines']['subscriptions']))
 
@@ -180,7 +179,7 @@ class StripeObjectTests(StripeUnitTestCase):
 
         res = repr(obj)
 
-        if sys.version_info[0] < 3:
+        if six.PY2:
             res = unicode(repr(obj), 'utf-8')
 
         self.assertTrue(u'<StripeObject \u4e00boo\u1f00' in res)

--- a/stripe/test/test_stripe_object.py
+++ b/stripe/test/test_stripe_object.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import pickle
 from copy import copy, deepcopy
 

--- a/stripe/test/test_util.py
+++ b/stripe/test/test_util.py
@@ -10,10 +10,9 @@ except ImportError:
 
 from stripe import util
 from stripe.test.helper import StripeUnitTestCase
+from stripe.six.moves import builtins
 
-import __builtin__
-
-PRINT_FUNC_STRING = __builtin__.__name__ + '.print'
+PRINT_FUNC_STRING = builtins.__name__ + '.print'
 
 LogTestCase = namedtuple('LogTestCase', 'env flag should_output')
 FmtTestCase = namedtuple('FmtTestCase', 'props expected')

--- a/stripe/test/test_util.py
+++ b/stripe/test/test_util.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import sys
 from collections import namedtuple

--- a/stripe/test/test_webhook.py
+++ b/stripe/test/test_webhook.py
@@ -1,7 +1,7 @@
-import sys
 import time
 
 import stripe
+from stripe import six
 from stripe.test.helper import StripeUnitTestCase
 
 
@@ -43,7 +43,7 @@ class WebhookTests(StripeUnitTestCase):
     def test_construct_event_from_bytes(self):
         # This test is only applicable to Python 3 as `bytes` is not a symbol
         # in Python 2.
-        if sys.version_info < (3, 0):
+        if six.PY2:
             return
 
         header = WebhookSignatureTests.generate_header()
@@ -70,7 +70,7 @@ class WebhookSignatureTests(StripeUnitTestCase):
 
     def test_raise_on_malformed_header(self):
         header = "i'm not even a real signature header"
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 stripe.error.SignatureVerificationError,
                 "Unable to extract timestamp and signatures from header"):
             stripe.WebhookSignature.verify_header(
@@ -78,7 +78,7 @@ class WebhookSignatureTests(StripeUnitTestCase):
 
     def test_raise_on_no_signatures_with_expected_scheme(self):
         header = self.generate_header(scheme='v0')
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 stripe.error.SignatureVerificationError,
                 "No signatures found with expected scheme v1"):
             stripe.WebhookSignature.verify_header(
@@ -86,7 +86,7 @@ class WebhookSignatureTests(StripeUnitTestCase):
 
     def test_raise_on_no_valid_signatures_for_payload(self):
         header = self.generate_header(signature='bad_signature')
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 stripe.error.SignatureVerificationError,
                 "No signatures found matching the expected signature for "
                 "payload"):
@@ -95,7 +95,7 @@ class WebhookSignatureTests(StripeUnitTestCase):
 
     def test_raise_on_timestamp_outside_tolerance(self):
         header = self.generate_header(timestamp=int(time.time()) - 15)
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 stripe.error.SignatureVerificationError,
                 "Timestamp outside the tolerance zone"):
             stripe.WebhookSignature.verify_header(

--- a/stripe/test/test_webhook.py
+++ b/stripe/test/test_webhook.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import time
 
 import stripe

--- a/stripe/util.py
+++ b/stripe/util.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import hmac
 import io

--- a/stripe/version.py
+++ b/stripe/version.py
@@ -1,1 +1,3 @@
+from __future__ import absolute_import, division, print_function
+
 VERSION = '1.72.0'

--- a/stripe/webhook.py
+++ b/stripe/webhook.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import hmac
 import time
 from hashlib import sha256

--- a/stripe/webhook.py
+++ b/stripe/webhook.py
@@ -35,7 +35,7 @@ class WebhookSignature(object):
 
     @staticmethod
     def _get_timestamp_and_signatures(header, scheme):
-        list_items = map(lambda i: i.split('=', 2), header.split(','))
+        list_items = [i.split('=', 2) for i in header.split(',')]
         timestamp = int([i[1] for i in list_items if i[0] == 't'][0])
         signatures = [i[1] for i in list_items if i[0] == scheme]
         return timestamp, signatures

--- a/tox.ini
+++ b/tox.ini
@@ -29,3 +29,7 @@ commands =
     flake8 stripe
     python setup.py clean --all
     python -W all -bb -W error::BytesWarning setup.py test {posargs}
+
+[flake8]
+exclude =
+    six.py


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

This PR replaces `2to3` with [`six`](http://six.readthedocs.io/#) to make the library's code directly compatible with both Python 2 and 3. I'm not saying we should merge this as is but I want to at least start a discussion:

- This adds a new dependency. However, `six` is one of the most popular and ubiquitous Python modules and there's a good chance our users will already have it installed.

- Arguably, this is just trading one magic layer for another. However, I think that it is much easier to reason around `six` than around `2to3` because with the latter, when running under Python 3, the code that is being executed is not the code that you're seeing.

- Additionally (and my main motivation if I'm being honest), once we stop using `2to3` we will be able to move the tests out of the main library's directory and into a dedicated directory that will not be installed when the library is packaged as a wheel.
