### PR TITLE
Disputes are not createable

### DIFF
--- a/stripe/api_resources/dispute.py
+++ b/stripe/api_resources/dispute.py
@@ -1,13 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
 from stripe import util
-from stripe.api_resources.abstract import CreateableAPIResource
-from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.abstract import UpdateableAPIResource
 
 
-class Dispute(CreateableAPIResource, ListableAPIResource,
-              UpdateableAPIResource):
+class Dispute(ListableAPIResource, UpdateableAPIResource):
     OBJECT_NAME = 'dispute'
 
     def close(self, idempotency_key=None):

--- a/tests/api_resources/test_dispute.py
+++ b/tests/api_resources/test_dispute.py
@@ -24,16 +24,6 @@ class DisputeTest(StripeResourceTest):
             }
         )
 
-    def test_create_dispute(self):
-        stripe.Dispute.create(idempotency_key='foo', **DUMMY_DISPUTE)
-
-        self.requestor_mock.request.assert_called_with(
-            'post',
-            '/v1/disputes',
-            DUMMY_DISPUTE,
-            {'Idempotency-Key': 'foo'},
-        )
-
     def test_retrieve_dispute(self):
         stripe.Dispute.retrieve('dp_test_id')
 


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @remi-stripe 

This was noticed by @remi-stripe while working on tests. The `Dispute` resource was declared as createable, however that is not the case. The test was passing because the request was not being sent to the API.
