### PR TITLE
Make custom action methods more consistent

### DIFF
--- a/stripe/api_resources/account.py
+++ b/stripe/api_resources/account.py
@@ -41,16 +41,10 @@ class Account(CreateableAPIResource, ListableAPIResource,
     def instance_url(self):
         return self._build_instance_url(self.get('id'))
 
-    def reject(self, reason=None, idempotency_key=None):
+    def reject(self, idempotency_key=None, **params):
         url = self.instance_url() + '/reject'
         headers = util.populate_headers(idempotency_key)
-        if reason:
-            params = {"reason": reason}
-        else:
-            params = {}
-        self.refresh_from(
-            self.request('post', url, params, headers)
-        )
+        self.refresh_from(self.request('post', url, params, headers))
         return self
 
     def deauthorize(self, **params):

--- a/stripe/api_resources/charge.py
+++ b/stripe/api_resources/charge.py
@@ -32,13 +32,13 @@ class Charge(CreateableAPIResource, ListableAPIResource,
         self.refresh_from({'dispute': response}, api_key, True)
         return self.dispute
 
-    def close_dispute(self, idempotency_key=None):
+    def close_dispute(self, idempotency_key=None, **params):
         requestor = api_requestor.APIRequestor(self.api_key,
                                                api_version=self.stripe_version,
                                                account=self.stripe_account)
         url = self.instance_url() + '/dispute/close'
         headers = util.populate_headers(idempotency_key)
-        response, api_key = requestor.request('post', url, {}, headers)
+        response, api_key = requestor.request('post', url, params, headers)
         self.refresh_from({'dispute': response}, api_key, True)
         return self.dispute
 

--- a/stripe/api_resources/dispute.py
+++ b/stripe/api_resources/dispute.py
@@ -8,8 +8,8 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 class Dispute(ListableAPIResource, UpdateableAPIResource):
     OBJECT_NAME = 'dispute'
 
-    def close(self, idempotency_key=None):
+    def close(self, idempotency_key=None, **params):
         url = self.instance_url() + '/close'
         headers = util.populate_headers(idempotency_key)
-        self.refresh_from(self.request('post', url, {}, headers))
+        self.refresh_from(self.request('post', url, params, headers))
         return self

--- a/stripe/api_resources/invoice.py
+++ b/stripe/api_resources/invoice.py
@@ -11,9 +11,10 @@ class Invoice(CreateableAPIResource, ListableAPIResource,
     OBJECT_NAME = 'invoice'
 
     def pay(self, idempotency_key=None, **params):
+        url = self.instance_url() + '/pay'
         headers = util.populate_headers(idempotency_key)
-        return self.request(
-            'post', self.instance_url() + '/pay', params, headers)
+        self.refresh_from(self.request('post', url, params, headers))
+        return self
 
     @classmethod
     def upcoming(cls, api_key=None, stripe_version=None, stripe_account=None,

--- a/stripe/api_resources/order.py
+++ b/stripe/api_resources/order.py
@@ -17,9 +17,10 @@ class Order(CreateableAPIResource, UpdateableAPIResource,
         return super(Order, cls).create(**params)
 
     def pay(self, idempotency_key=None, **params):
+        url = self.instance_url() + '/pay'
         headers = util.populate_headers(idempotency_key)
-        return self.request(
-            'post', self.instance_url() + '/pay', params, headers)
+        self.refresh_from(self.request('post', url, params, headers))
+        return self
 
     def return_order(self, idempotency_key=None, **params):
         if "items" in params:

--- a/stripe/api_resources/payout.py
+++ b/stripe/api_resources/payout.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
@@ -9,6 +10,8 @@ class Payout(CreateableAPIResource, UpdateableAPIResource,
              ListableAPIResource):
     OBJECT_NAME = 'payout'
 
-    def cancel(self):
-        self.refresh_from(self.request('post',
-                          self.instance_url() + '/cancel'))
+    def cancel(self, idempotency_key=None, **params):
+        url = self.instance_url() + '/cancel'
+        headers = util.populate_headers(idempotency_key)
+        self.refresh_from(self.request('post', url, params, headers))
+        return self

--- a/stripe/api_resources/source.py
+++ b/stripe/api_resources/source.py
@@ -13,15 +13,16 @@ from stripe.six.moves.urllib.parse import quote_plus
 class Source(CreateableAPIResource, UpdateableAPIResource, VerifyMixin):
     OBJECT_NAME = 'source'
 
-    def detach(self, **params):
+    def detach(self, idempotency_key=None, **params):
         if hasattr(self, 'customer') and self.customer:
             extn = quote_plus(util.utf8(self.id))
             customer = util.utf8(self.customer)
             base = Customer.class_url()
             owner_extn = quote_plus(customer)
             url = "%s/%s/sources/%s" % (base, owner_extn, extn)
+            headers = util.populate_headers(idempotency_key)
 
-            self.refresh_from(self.request('delete', url, params))
+            self.refresh_from(self.request('delete', url, params, headers))
             return self
 
         else:

--- a/stripe/api_resources/transfer.py
+++ b/stripe/api_resources/transfer.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
@@ -12,6 +13,8 @@ class Transfer(CreateableAPIResource, UpdateableAPIResource,
                ListableAPIResource):
     OBJECT_NAME = 'transfer'
 
-    def cancel(self):
-        self.refresh_from(self.request('post',
-                          self.instance_url() + '/cancel'))
+    def cancel(self, idempotency_key=None, **params):
+        url = self.instance_url() + '/cancel'
+        headers = util.populate_headers(idempotency_key)
+        self.refresh_from(self.request('post', url, params, headers))
+        return self

--- a/tests/api_resources/test_invoice.py
+++ b/tests/api_resources/test_invoice.py
@@ -69,19 +69,35 @@ class InvoiceTest(StripeResourceTest):
         )
 
     def test_pay_invoice(self):
+        self.mock_response({
+            'id': 'ii_pay',
+            'paid': True,
+        })
+
         invoice = stripe.Invoice(id="ii_pay")
-        invoice.pay()
+
+        self.assertTrue(invoice is invoice.pay(idempotency_key='idem-foo'))
+        self.assertEquals(True, invoice.paid)
+        self.assertEquals('ii_pay', invoice.id)
 
         self.requestor_mock.request.assert_called_with(
             'post',
             '/v1/invoices/ii_pay/pay',
             {},
-            None
+            {'Idempotency-Key': 'idem-foo'}
         )
 
     def test_pay_invoice_params(self):
+        self.mock_response({
+            'id': 'ii_pay',
+            'paid': True,
+        })
+
         invoice = stripe.Invoice(id="ii_pay")
-        invoice.pay(source="src_foo")
+
+        self.assertTrue(invoice is invoice.pay(source="src_foo"))
+        self.assertEquals(True, invoice.paid)
+        self.assertEquals('ii_pay', invoice.id)
 
         self.requestor_mock.request.assert_called_with(
             'post',

--- a/tests/api_resources/test_order.py
+++ b/tests/api_resources/test_order.py
@@ -15,13 +15,42 @@ class OrderTest(StripeResourceTest):
         )
 
     def test_pay_order(self):
+        self.mock_response({
+            'id': 'or_pay',
+            'status': 'paid',
+        })
+
         order = stripe.Order(id="or_pay")
-        order.pay()
+
+        self.assertTrue(order is order.pay())
+        self.assertEquals('paid', order.status)
+        self.assertEquals('or_pay', order.id)
 
         self.requestor_mock.request.assert_called_with(
             'post',
             '/v1/orders/or_pay/pay',
             {},
+            None
+        )
+
+    def test_pay_order_with_params(self):
+        self.mock_response({
+            'id': 'or_pay',
+            'status': 'paid',
+        })
+
+        order = stripe.Order(id="or_pay")
+
+        self.assertTrue(order is order.pay(source="src_foo"))
+        self.assertEquals('paid', order.status)
+        self.assertEquals('or_pay', order.id)
+
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/v1/orders/or_pay/pay',
+            {
+                'source': 'src_foo',
+            },
             None
         )
 

--- a/tests/api_resources/test_payout.py
+++ b/tests/api_resources/test_payout.py
@@ -15,12 +15,20 @@ class PayoutTest(StripeResourceTest):
         )
 
     def test_cancel_payout(self):
+        self.mock_response({
+            'id': 'po_cancel',
+            'status': 'canceled',
+        })
+
         payout = stripe.Payout(id='po_cancel')
-        payout.cancel()
+
+        self.assertTrue(payout is payout.cancel(idempotency_key='idem-foo'))
+        self.assertEquals('canceled', payout.status)
+        self.assertEquals('po_cancel', payout.id)
 
         self.requestor_mock.request.assert_called_with(
             'post',
             '/v1/payouts/po_cancel/cancel',
             {},
-            None
+            {'Idempotency-Key': 'idem-foo'}
         )

--- a/tests/api_resources/test_source.py
+++ b/tests/api_resources/test_source.py
@@ -57,17 +57,24 @@ class SourceTest(StripeResourceTest):
         self.assertRaises(NotImplementedError, source.detach)
 
     def test_detach_source_attached(self):
+        self.mock_response({
+            'id': 'src_foo'
+        })
+
         source = stripe.Source.construct_from({
             'id': 'src_foo',
             'customer': 'cus_bar',
         }, 'api_key')
-        source.detach()
+
+        self.assertTrue(source is source.detach(idempotency_key='idem-foo'))
+        self.assertFalse('customer' in source)
+        self.assertEquals('src_foo', source.id)
 
         self.requestor_mock.request.assert_called_with(
             'delete',
             '/v1/customers/cus_bar/sources/src_foo',
             {},
-            None
+            {'Idempotency-Key': 'idem-foo'}
         )
 
     def test_delete_source(self):

--- a/tests/api_resources/test_transfer.py
+++ b/tests/api_resources/test_transfer.py
@@ -15,14 +15,22 @@ class TransferTest(StripeResourceTest):
         )
 
     def test_cancel_transfer(self):
+        self.mock_response({
+            'id': 'tr_cancel',
+            'status': 'canceled',
+        })
+
         transfer = stripe.Transfer(id='tr_cancel')
-        transfer.cancel()
+
+        self.assertTrue(transfer is transfer.cancel(idempotency_key='idem-foo'))
+        self.assertEquals('canceled', transfer.status)
+        self.assertEquals('tr_cancel', transfer.id)
 
         self.requestor_mock.request.assert_called_with(
             'post',
             '/v1/transfers/tr_cancel/cancel',
             {},
-            None
+            {'Idempotency-Key': 'idem-foo'}
         )
 
 


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @remi-stripe 

Custom methods (e.g. pay an invoice, reject an account, etc.) were handled inconsistently throughout the library:
- some updated the instance but did not return it (`Payout.cancel`, `Transfer.cancel`)
- some returned the new object but did not update the instance (`Invoice.pay`, `Order.pay`)
- some did not handle idempotency keys (`Source.detach`, `Payout.cancel`, `Transfer.cancel`)
- some did not accept parameters, or accepted a single specific parameter (those were not a problem as the API does not accept parameters for those, but we might as well make everything more consistent as well as future-proof the library)

~I have not written any new tests because I'm fairly confident about these changes and because @remi-stripe is working on updating the tests to use stripe-mock in #367.~

I did add some tests after all.
