### PR TITLE
Allow access to request metadata on success

### DIFF
--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -10,6 +10,7 @@ import stripe
 from stripe import error, oauth_error, http_client, version, util, six
 from stripe.multipart_data_generator import MultipartDataGenerator
 from stripe.six.moves.urllib.parse import urlencode, urlsplit, urlunsplit
+from stripe.stripe_response import StripeResponse
 
 
 def _encode_datetime(dttime):
@@ -349,14 +350,15 @@ class APIRequestor(object):
         try:
             if hasattr(rbody, 'decode'):
                 rbody = rbody.decode('utf-8')
-            resp = util.json.loads(rbody)
+            resp = StripeResponse(rbody, rcode, rheaders)
         except Exception:
             raise error.APIError(
                 "Invalid response body from API: %s "
                 "(HTTP response code was %d)" % (rbody, rcode),
                 rbody, rcode, rheaders)
         if not (200 <= rcode < 300):
-            self.handle_error_response(rbody, rcode, resp, rheaders)
+            self.handle_error_response(rbody, rcode, resp.data, rheaders)
+
         return resp
 
     # Deprecated request handling.  Will all be removed in 2.0

--- a/stripe/api_resources/abstract/createable_api_resource.py
+++ b/stripe/api_resources/abstract/createable_api_resource.py
@@ -15,5 +15,6 @@ class CreateableAPIResource(APIResource):
         url = cls.class_url()
         headers = util.populate_headers(idempotency_key)
         response, api_key = requestor.request('post', url, params, headers)
+
         return util.convert_to_stripe_object(response, api_key, stripe_version,
                                              stripe_account)

--- a/stripe/stripe_object.py
+++ b/stripe/stripe_object.py
@@ -34,11 +34,12 @@ def _serialize_list(array, previous):
 
 class StripeObject(dict):
     def __init__(self, id=None, api_key=None, stripe_version=None,
-                 stripe_account=None, **params):
+                 stripe_account=None, last_response=None, **params):
         super(StripeObject, self).__init__()
 
         self._unsaved_values = set()
         self._transient_values = set()
+        self._last_response = last_response
 
         self._retrieve_params = params
         self._previous = None
@@ -49,6 +50,10 @@ class StripeObject(dict):
 
         if id:
             self['id'] = id
+
+    @property
+    def last_response(self):
+        return self._last_response
 
     def update(self, update_dict):
         for k in update_dict:
@@ -140,22 +145,26 @@ class StripeObject(dict):
 
     @classmethod
     def construct_from(cls, values, key, stripe_version=None,
-                       stripe_account=None):
+                       stripe_account=None, last_response=None):
         instance = cls(values.get('id'), api_key=key,
                        stripe_version=stripe_version,
-                       stripe_account=stripe_account)
+                       stripe_account=stripe_account,
+                       last_response=last_response)
         instance.refresh_from(values, api_key=key,
                               stripe_version=stripe_version,
-                              stripe_account=stripe_account)
+                              stripe_account=stripe_account,
+                              last_response=last_response)
         return instance
 
     def refresh_from(self, values, api_key=None, partial=False,
-                     stripe_version=None, stripe_account=None):
+                     stripe_version=None, stripe_account=None,
+                     last_response=None):
         self.api_key = api_key or getattr(values, 'api_key', None)
         self.stripe_version = \
             stripe_version or getattr(values, 'stripe_version', None)
         self.stripe_account = \
             stripe_account or getattr(values, 'stripe_account', None)
+        self._last_response = last_response
 
         # Wipe old state before setting new.  This is useful for e.g.
         # updating a customer, where there is no persistent card

--- a/stripe/stripe_response.py
+++ b/stripe/stripe_response.py
@@ -1,0 +1,24 @@
+from stripe import util
+
+
+class StripeResponse:
+
+    def __init__(self, body, code, headers):
+        self.body = body
+        self.code = code
+        self.headers = headers
+        self.data = util.json.loads(body)
+
+    @property
+    def idempotency_key(self):
+        try:
+            return self.headers['idempotency-key']
+        except KeyError:
+            return None
+
+    @property
+    def request_id(self):
+        try:
+            return self.headers['request-id']
+        except KeyError:
+            return None

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -19,6 +19,13 @@ DUMMY_CHARGE = {
     'source': 'tok_visa'
 }
 
+DUMMY_CHARGE_IDEMPOTENT = {
+    'amount': 100,
+    'currency': 'usd',
+    'source': 'tok_visa',
+    'idempotency_key': '12345'
+}
+
 DUMMY_PLAN = {
     'amount': 2000,
     'interval': 'month',

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -7,6 +7,8 @@ from mock import Mock, ANY
 
 import stripe
 from stripe import six
+from stripe.stripe_response import StripeResponse
+from stripe import util
 
 from tests.helper import StripeUnitTestCase
 
@@ -273,7 +275,7 @@ class APIRequestorRequestTests(StripeUnitTestCase):
         for meth in VALID_API_METHODS:
             self.mock_response('{}', 200)
 
-            body, key = self.requestor.request(meth, self.valid_path, {})
+            resp, key = self.requestor.request(meth, self.valid_path, {})
 
             if meth == 'post':
                 post_data = ''
@@ -281,7 +283,10 @@ class APIRequestorRequestTests(StripeUnitTestCase):
                 post_data = None
 
             self.check_call(meth, post_data=post_data)
-            self.assertEqual({}, body)
+            self.assertTrue(isinstance(resp, StripeResponse))
+
+            self.assertEqual({}, resp.data)
+            self.assertEqual(util.json.loads(resp.body), resp.data)
 
     def test_methods_with_params_and_response(self):
         for meth in VALID_API_METHODS:
@@ -295,9 +300,16 @@ class APIRequestorRequestTests(StripeUnitTestCase):
             encoded = ('adict%5Bfrobble%5D=bits&adatetime=1356994800&'
                        'alist%5B%5D=1&alist%5B%5D=2&alist%5B%5D=3')
 
-            body, key = self.requestor.request(meth, self.valid_path,
+            resp, key = self.requestor.request(meth, self.valid_path,
                                                params)
-            self.assertEqual({'foo': 'bar', 'baz': 6}, body)
+            self.assertTrue(isinstance(resp, StripeResponse))
+
+            self.assertEqual({
+                'foo': 'bar',
+                'baz': 6 },
+            resp.data)
+            self.assertEqual(util.json.loads(resp.body),
+            resp.data)
 
             if meth == 'post':
                 self.check_call(
@@ -320,7 +332,7 @@ class APIRequestorRequestTests(StripeUnitTestCase):
 
         self.mock_response('{}', 200, requestor=requestor)
 
-        body, used_key = requestor.request('get', self.valid_path, {})
+        resp, used_key = requestor.request('get', self.valid_path, {})
 
         self.check_call('get', headers=APIHeaderMatcher(
             key, request_method='get'), requestor=requestor)

--- a/tests/test_stripe_response.py
+++ b/tests/test_stripe_response.py
@@ -1,0 +1,50 @@
+from __future__ import absolute_import, division, print_function
+
+import time
+
+from stripe import util
+from stripe.stripe_response import StripeResponse
+from tests.helper import StripeUnitTestCase
+
+class StripeResponseTests(StripeUnitTestCase):
+    def test_idempotency_key(self):
+        response, headers, body, code = StripeResponseTests.mock_stripe_response()
+        self.assertEqual(response.idempotency_key, headers['idempotency-key'])
+
+    def test_request_id(self):
+        response, headers, body, code = StripeResponseTests.mock_stripe_response()
+        self.assertEqual(response.request_id, headers['request-id'])
+
+    def test_code(self):
+        response, headers, body, code = StripeResponseTests.mock_stripe_response()
+        self.assertEqual(response.code, code)
+
+    def test_headers(self):
+        response, headers, body, code = StripeResponseTests.mock_stripe_response()
+        self.assertEqual(response.headers, headers)
+
+    def test_body(self):
+        response, headers, body, code = StripeResponseTests.mock_stripe_response()
+        self.assertEqual(response.body, body)
+
+    def test_data(self):
+        response, headers, body, code = StripeResponseTests.mock_stripe_response()
+        self.assertEqual(response.data, util.json.loads(body))
+
+    @staticmethod
+    def mock_stripe_response():
+        code = 200
+        headers = StripeResponseTests.mock_headers()
+        body = StripeResponseTests.mock_body()
+        response = StripeResponse(body, code, headers)
+        return response, headers, body, code
+    @staticmethod
+    def mock_headers():
+        return {
+          'idempotency-key': '123456',
+          'request-id': 'req_123456'
+        }
+
+    @staticmethod
+    def mock_body():
+        return '{ "id": "ch_12345", "object": "charge", "amount": 1 }'


### PR DESCRIPTION
Hey @ob-stripe this is my first stab at getting response headers out of the python bindings.

I'm trying to follow the same pattern by including a `response` resource to the returned API models.

However one tricky part is understanding where the best spot is to place an optional flag to include the `response` field on returned API resources. Each API request method contains a `params`parameter that directly maps to the API's URL parameters. Placing some kind of `include_response` flag here would stick out since it won't be going to the API.

Another thought was using a static variable somewhere and checking that variable within the `api_requestor` to include the `response` or not.

Do you have any opinions here?