### PR TITLE
Fix items serialization when items is a dict

### DIFF
--- a/stripe/api_resources/subscription.py
+++ b/stripe/api_resources/subscription.py
@@ -32,8 +32,13 @@ class Subscription(CreateableAPIResource, DeletableAPIResource,
         return super(Subscription, cls).create(**params)
 
     def serialize(self, previous):
-        updated_params = super(UpdateableAPIResource, self).serialize(previous)
-        if "items" in updated_params:
-            updated_params["items"] = util.convert_array_to_dict(
-                updated_params["items"])
-        return updated_params
+        if self._unsaved_values and "items" in self._unsaved_values:
+            self["items"] = util.convert_array_to_dict(self["items"])
+
+            # Ignore the previous values of `items` since it's likely the list
+            # object returned by the API and we want to treat `items` as a
+            # standalone parameter, not an update of the list object.
+            if self._previous and "items" in self._previous:
+                del self._previous["items"]
+
+        return super(UpdateableAPIResource, self).serialize(previous)

--- a/tests/api_resources/test_subscription.py
+++ b/tests/api_resources/test_subscription.py
@@ -131,4 +131,42 @@ class TestSubscription(object):
     #    )
     #    assert isinstance(resource, stripe.Subscription)
 
-    # TODO: Test serialize
+    def test_serializes_when_items_is_a_list(self):
+        resource = stripe.Subscription.construct_from({
+            'object': 'subscription',
+            'items': {
+                'object': 'list',
+                'data': [],
+            }
+        }, stripe.api_key)
+        resource.items = [
+            {'id': 'si_foo', 'deleted': True},
+            {'plan': 'plan_bar'},
+        ]
+        expected = {
+            'items': {
+                '0': {'id': 'si_foo', 'deleted': True},
+                '1': {'plan': 'plan_bar'},
+            }
+        }
+        assert resource.serialize(None) == expected
+
+    def test_serializes_when_items_is_a_dict(self):
+        resource = stripe.Subscription.construct_from({
+            'object': 'subscription',
+            'items': {
+                'object': 'list',
+                'data': [],
+            }
+        }, stripe.api_key)
+        resource.items = {
+            '0': {'id': 'si_foo', 'deleted': True},
+            '1': {'plan': 'plan_bar'},
+        }
+        expected = {
+            'items': {
+                '0': {'id': 'si_foo', 'deleted': True},
+                '1': {'plan': 'plan_bar'},
+            }
+        }
+        assert resource.serialize(None) == expected


### PR DESCRIPTION
r? @dpetrovics-stripe (DP run, feel free to re-assign)
cc @stripe/api-libraries @remi-stripe 

Fixes an issue where if you set `items` to an integer-indexed dict on a subscription that was retrieved from the API, the library would try to unset the properties of the list object that was returned in the `items` attribute.

This is basically exactly the same problem as the 2nd issue mentioned here: https://github.com/stripe/stripe-ruby/pull/596, and the fix is similar (simply ignore the previous value of `items`).
