### PR TITLE
Use custom JSON encoder to handle datetime objects

### DIFF
--- a/stripe/stripe_object.py
+++ b/stripe/stripe_object.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import datetime
 import warnings
 from copy import deepcopy
 
@@ -33,6 +34,12 @@ def _serialize_list(array, previous):
 
 
 class StripeObject(dict):
+    class ReprJSONEncoder(util.json.JSONEncoder):
+        def default(self, obj):
+            if isinstance(obj, datetime.datetime):
+                return api_requestor._encode_datetime(obj)
+            return super(StripeObject.ReprJSONEncoder, self).default(obj)
+
     def __init__(self, id=None, api_key=None, stripe_version=None,
                  stripe_account=None, **params):
         super(StripeObject, self).__init__()
@@ -211,7 +218,8 @@ class StripeObject(dict):
             return unicode_repr
 
     def __str__(self):
-        return util.json.dumps(self, sort_keys=True, indent=2)
+        return util.json.dumps(self, sort_keys=True, indent=2,
+                               cls=self.ReprJSONEncoder)
 
     def to_dict(self):
         warnings.warn(

--- a/tests/test_stripe_object.py
+++ b/tests/test_stripe_object.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import datetime
 import pickle
 from copy import copy, deepcopy
 
@@ -178,6 +179,7 @@ class StripeObjectTests(StripeUnitTestCase):
             'foo', 'bar', myparam=5)
 
         obj['object'] = u'\u4e00boo\u1f00'
+        obj.date = datetime.datetime.fromtimestamp(1511136000)
 
         res = repr(obj)
 
@@ -186,6 +188,7 @@ class StripeObjectTests(StripeUnitTestCase):
 
         self.assertTrue(u'<StripeObject \u4e00boo\u1f00' in res)
         self.assertTrue(u'id=foo' in res)
+        self.assertTrue(u'"date": 1511136000' in res)
 
     def test_pickling(self):
         obj = stripe.stripe_object.StripeObject(


### PR DESCRIPTION
r? @dpetrovics-stripe (dev-platform run)
cc @stripe/api-libraries @dalanmiller

Fixes #374.