### PR TITLE
Add .coveragerc for generating coverage reports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+source = stripe
+omit =
+    stripe/six.py


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

This is a configuration file for [coverage.py](https://coverage.readthedocs.io/en/coverage-4.4.2/). It lets us create coverage reports for the library, e.g. by running:

```
coverage run setup.py test
```

The `.gitignore` file already has the correct exclusions for the generated reports, so we only need this configuration to point to our source code and exclude our vendored version of `six`.
