### PR TITLE
Add support for coveralls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,0 @@
-[run]
-source = stripe
-omit =
-    stripe/six.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,14 @@ addons:
       - librtmp-dev
 install:
   - pip install -U setuptools pip
-  - pip install unittest2 mock pycurl flake8 tox-travis
+  - pip install unittest2 mock pycurl flake8 tox-travis coveralls
   - python setup.py clean --all
   - python setup.py install
 script:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then flake8 stripe; fi
-  - python -W all -bb -W error::BytesWarning setup.py test
+  - python -W all -bb -W error::BytesWarning -m coverage.__main__ run setup.py test
+after_success:
+  coveralls
 matrix:
   allow_failures:
     - python: 3.7-dev

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# Stripe Python Library [![Build Status](https://travis-ci.org/stripe/stripe-python.svg?branch=master)](https://travis-ci.org/stripe/stripe-python)
+# Stripe Python Library
+
+[![Build Status](https://travis-ci.org/stripe/stripe-python.svg?branch=master)](https://travis-ci.org/stripe/stripe-python)
+[![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-python/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-python?branch=master)
 
 The Stripe Python library provides convenient access to the Stripe API from
 applications written in the Python language. It includes a pre-defined set of

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, pypy, pypy3.3-5.2-alpha1, py33, py34, py35
+envlist = py26, py27, pypy, pypy3.3-5.2-alpha1, py33, py34, py35, py36
 
 [testenv]
 deps =
@@ -12,9 +12,10 @@ deps =
     pycurl>=7.19
     requests>=0.8.8
     mock
+    coverage
 commands =
     python setup.py clean --all
-    python -W all -bb -W error::BytesWarning setup.py test {posargs}
+    python -W all -bb -W error::BytesWarning -m coverage.__main__ run setup.py test {posargs}
 setenv =
     STRIPE_TEST_PYCURL = true
 
@@ -25,11 +26,17 @@ deps =
     pycurl>=7.19
     requests>=0.8.8
     mock
+    coverage
 commands =
     flake8 stripe
     python setup.py clean --all
-    python -W all -bb -W error::BytesWarning setup.py test {posargs}
+    python -W all -bb -W error::BytesWarning -m coverage.__main__ run setup.py test {posargs}
 
 [flake8]
 exclude =
     six.py
+
+[coverage:run]
+source = stripe
+omit =
+    stripe/six.py


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

- Add support for coveralls.io: https://coveralls.io/github/stripe/stripe-python.
- Move coverage configuration into `tox.ini`
- Opportunistically add `py36` to the list of versions in `tox.init`
- Add a badge to README.md
