### PR TITLE
Introduce new `IdempotencyError` type

### DIFF
--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -43,6 +43,7 @@ from stripe.error import (  # noqa
     PermissionError,
     RateLimitError,
     CardError,
+    IdempotencyError,
     InvalidRequestError,
     SignatureVerificationError,
     StripeError)

--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -191,9 +191,13 @@ class APIRequestor(object):
             return error.RateLimitError(
                 error_data.get('message'), rbody, rcode, resp, rheaders)
         elif rcode in [400, 404]:
-            return error.InvalidRequestError(
-                error_data.get('message'), error_data.get('param'),
-                error_data.get('code'), rbody, rcode, resp, rheaders)
+            if error_data.get('type') == "idempotency_error":
+                return error.IdempotencyError(
+                    error_data.get('message'), rbody, rcode, resp, rheaders)
+            else:
+                return error.InvalidRequestError(
+                    error_data.get('message'), error_data.get('param'),
+                    error_data.get('code'), rbody, rcode, resp, rheaders)
         elif rcode == 401:
             return error.AuthenticationError(
                 error_data.get('message'), rbody, rcode, resp, rheaders)

--- a/stripe/error.py
+++ b/stripe/error.py
@@ -57,6 +57,10 @@ class CardError(StripeError):
         self.code = code
 
 
+class IdempotencyError(StripeError):
+    pass
+
+
 class InvalidRequestError(StripeError):
 
     def __init__(self, message, param, code=None, http_body=None,

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -391,10 +391,24 @@ class APIRequestorRequestTests(StripeUnitTestCase):
                           self.requestor.request,
                           'get', self.valid_path, {})
 
-    def test_not_found(self):
+    def test_invalid_request_error_404(self):
         self.mock_response('{"error": {}}', 404)
 
         self.assertRaises(stripe.error.InvalidRequestError,
+                          self.requestor.request,
+                          'get', self.valid_path, {})
+
+    def test_invalid_request_error_400(self):
+        self.mock_response('{"error": {}}', 400)
+
+        self.assertRaises(stripe.error.InvalidRequestError,
+                          self.requestor.request,
+                          'get', self.valid_path, {})
+
+    def test_idempotency_error(self):
+        self.mock_response('{"error": {"type": "idempotency_error"}}', 400)
+
+        self.assertRaises(stripe.error.IdempotencyError,
                           self.requestor.request,
                           'get', self.valid_path, {})
 


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Adds support for `idempotency_error`. Cf. https://github.com/stripe/stripe-ruby/pull/613