### PR TITLE
Fix warnings in tests

### DIFF
--- a/tests/api_resources/test_alipay_account.py
+++ b/tests/api_resources/test_alipay_account.py
@@ -19,7 +19,7 @@ class AlipayAccountTest(StripeTestCase):
 
     def test_has_instance_url(self):
         resource = self.construct_resource()
-        self.assertEquals(
+        self.assertEqual(
             '/v1/customers/cus_123/sources/%s' % TEST_RESOURCE_ID,
             resource.instance_url()
         )

--- a/tests/api_resources/test_bank_account.py
+++ b/tests/api_resources/test_bank_account.py
@@ -19,14 +19,14 @@ class BankAccountTest(StripeTestCase):
 
     def test_has_account_instance_url(self):
         resource = self.construct_resource(account='acct_123')
-        self.assertEquals(
+        self.assertEqual(
             '/v1/accounts/acct_123/external_accounts/%s' % TEST_RESOURCE_ID,
             resource.instance_url()
         )
 
     def test_has_customer_instance_url(self):
         resource = self.construct_resource(customer='cus_123')
-        self.assertEquals(
+        self.assertEqual(
             '/v1/customers/cus_123/sources/%s' % TEST_RESOURCE_ID,
             resource.instance_url()
         )

--- a/tests/api_resources/test_bitcoin_receiver.py
+++ b/tests/api_resources/test_bitcoin_receiver.py
@@ -19,14 +19,14 @@ class BitcoinReceiverTest(StripeTestCase):
 
     def test_has_customer_instance_url(self):
         resource = self.construct_resource(customer='cus_123')
-        self.assertEquals(
+        self.assertEqual(
             '/v1/customers/cus_123/sources/%s' % TEST_RESOURCE_ID,
             resource.instance_url()
         )
 
     def test_has_receiver_instance_url(self):
         resource = self.construct_resource()
-        self.assertEquals(
+        self.assertEqual(
             '/v1/bitcoin/receivers/%s' % TEST_RESOURCE_ID,
             resource.instance_url()
         )

--- a/tests/api_resources/test_card.py
+++ b/tests/api_resources/test_card.py
@@ -19,21 +19,21 @@ class CardTest(StripeTestCase):
 
     def test_has_account_instance_url(self):
         resource = self.construct_resource(account='acct_123')
-        self.assertEquals(
+        self.assertEqual(
             '/v1/accounts/acct_123/external_accounts/%s' % TEST_RESOURCE_ID,
             resource.instance_url()
         )
 
     def test_has_customer_instance_url(self):
         resource = self.construct_resource(customer='cus_123')
-        self.assertEquals(
+        self.assertEqual(
             '/v1/customers/cus_123/sources/%s' % TEST_RESOURCE_ID,
             resource.instance_url()
         )
 
     def test_has_recipient_instance_url(self):
         resource = self.construct_resource(recipient='rp_123')
-        self.assertEquals(
+        self.assertEqual(
             '/v1/recipients/rp_123/cards/%s' % TEST_RESOURCE_ID,
             resource.instance_url()
         )

--- a/tests/api_resources/test_customer.py
+++ b/tests/api_resources/test_customer.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import warnings
+
 import stripe
 from tests.helper import (StripeTestCase)
 
@@ -81,7 +83,9 @@ class CustomerLegacySubscriptionTest(StripeTestCase):
             '/v1/customers/%s/subscription' % TEST_RESOURCE_ID,
         )
         resource = self.construct_resource()
-        resource.update_subscription(plan='plan')
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            resource.update_subscription(plan='plan')
         self.assert_requested(
             'post',
             '/v1/customers/%s/subscription' % TEST_RESOURCE_ID
@@ -93,7 +97,9 @@ class CustomerLegacySubscriptionTest(StripeTestCase):
             '/v1/customers/%s/subscription' % TEST_RESOURCE_ID
         )
         resource = self.construct_resource()
-        resource.cancel_subscription()
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            resource.cancel_subscription()
         self.assert_requested(
             'delete',
             '/v1/customers/%s/subscription' % TEST_RESOURCE_ID

--- a/tests/api_resources/test_reversal.py
+++ b/tests/api_resources/test_reversal.py
@@ -19,7 +19,7 @@ class ReversalTest(StripeTestCase):
 
     def test_has_instance_url(self):
         resource = self.construct_resource()
-        self.assertEquals(
+        self.assertEqual(
             '/v1/transfers/tr_123/reversals/%s' % TEST_RESOURCE_ID,
             resource.instance_url()
         )


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Fix some test warnings:
- a few tests used the deprecated `assertEquals` function instead of `assertEqual`
- explicitly silenced the deprecation warnings in the legacy subscription tests
