### PR TITLE
Register unsaved attributes on assignment regardless of new value

### DIFF
--- a/stripe/stripe_object.py
+++ b/stripe/stripe_object.py
@@ -98,12 +98,11 @@ class StripeObject(dict):
                 "You may set %s.%s = None to delete the property" % (
                     k, str(self), k))
 
-        if not hasattr(self, k) or v != getattr(self, k):
-            # Allows for unpickling in Python 3.x
-            if not hasattr(self, '_unsaved_values'):
-                self._unsaved_values = set()
+        # Allows for unpickling in Python 3.x
+        if not hasattr(self, '_unsaved_values'):
+            self._unsaved_values = set()
 
-            self._unsaved_values.add(k)
+        self._unsaved_values.add(k)
 
         super(StripeObject, self).__setitem__(k, v)
 

--- a/tests/api_resources/abstract/test_updateable_api_resource.py
+++ b/tests/api_resources/abstract/test_updateable_api_resource.py
@@ -16,7 +16,8 @@ class UpdateableAPIResourceTests(StripeTestCase):
             'post',
             '/v1/myupdateables/myid',
             {
-                'thats': 'it'
+                'id': 'myid',
+                'thats': 'it',
             }
         )
 
@@ -83,17 +84,35 @@ class UpdateableAPIResourceTests(StripeTestCase):
         self.checkSave()
         self.assert_no_request()
 
-        # Setting the same value should not cause any request.
+        # Setting the same value should cause a request.
+        self.stub_request(
+            'post',
+            '/v1/myupdateables/myid',
+            {
+                'id': 'myid',
+                'thats': 'it',
+            }
+        )
+
         self.obj.thats = 'it'
         self.checkSave()
-        self.assert_no_request()
+
+        self.assert_requested(
+            'post',
+            '/v1/myupdateables/myid',
+            {
+                'thats': 'it',
+            },
+            None
+        )
 
         # Changing the value should cause a request.
         self.stub_request(
             'post',
             '/v1/myupdateables/myid',
             {
-                'thats': 'it'
+                'id': 'myid',
+                'thats': 'it',
             }
         )
 


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

When setting an attribute on a Stripe object, register the attribute as unsaved regardless of whether the new value is different from the existing value.

This aligns the behavior with that of our Ruby and PHP libraries.

Fixes #388.
