### PR TITLE
Make last_response available on save()

### DIFF
--- a/stripe/oauth.py
+++ b/stripe/oauth.py
@@ -40,7 +40,7 @@ class OAuth(object):
         requestor = api_requestor.APIRequestor(api_base=connect_api_base)
         response, api_key = requestor.request(
             'post', '/oauth/token', params, None)
-        return response
+        return response.data
 
     @staticmethod
     def deauthorize(**params):
@@ -48,4 +48,4 @@ class OAuth(object):
         OAuth._set_client_id(params)
         response, api_key = requestor.request(
             'post', '/oauth/deauthorize', params, None)
-        return response
+        return response.data

--- a/stripe/stripe_object.py
+++ b/stripe/stripe_object.py
@@ -171,7 +171,8 @@ class StripeObject(dict):
             stripe_version or getattr(values, 'stripe_version', None)
         self.stripe_account = \
             stripe_account or getattr(values, 'stripe_account', None)
-        self._last_response = last_response
+        self._last_response = \
+            last_response or getattr(values, '_last_response', None)
 
         # Wipe old state before setting new.  This is useful for e.g.
         # updating a customer, where there is no persistent card

--- a/tests/api_resources/abstract/test_api_resource.py
+++ b/tests/api_resources/abstract/test_api_resource.py
@@ -18,7 +18,8 @@ class APIResourceTests(StripeTestCase):
             {
                 'id': 'foo2',
                 'bobble': 'scrobble',
-            }
+            },
+            rheaders={'request-id': 'req_id'}
         )
 
         res = MyResource.retrieve('foo*', myparam=5)
@@ -34,6 +35,9 @@ class APIResourceTests(StripeTestCase):
         self.assertEqual('scrobble', res.bobble)
         self.assertEqual('foo2', res.id)
         self.assertEqual('sk_test_123', res.api_key)
+
+        self.assertTrue(res.last_response is not None)
+        self.assertEqual('req_id', res.last_response.request_id)
 
         url = '/v1/myresources/foo2'
         self.stub_request(

--- a/tests/api_resources/abstract/test_createable_api_resource.py
+++ b/tests/api_resources/abstract/test_createable_api_resource.py
@@ -17,7 +17,8 @@ class CreateableAPIResourceTests(StripeTestCase):
             {
                 'object': 'charge',
                 'foo': 'bar',
-            }
+            },
+            rheaders={'request-id': 'req_id'}
         )
 
         res = MyCreatable.create()
@@ -30,6 +31,9 @@ class CreateableAPIResourceTests(StripeTestCase):
         self.assertTrue(isinstance(res, stripe.Charge))
         self.assertEqual('bar', res.foo)
 
+        self.assertTrue(res.last_response is not None)
+        self.assertEqual('req_id', res.last_response.request_id)
+
     def test_idempotent_create(self):
         self.stub_request(
             'post',
@@ -37,7 +41,8 @@ class CreateableAPIResourceTests(StripeTestCase):
             {
                 'object': 'charge',
                 'foo': 'bar',
-            }
+            },
+            rheaders={'idempotency-key': 'foo'}
         )
 
         res = MyCreatable.create(idempotency_key='foo')
@@ -50,3 +55,6 @@ class CreateableAPIResourceTests(StripeTestCase):
         )
         self.assertTrue(isinstance(res, stripe.Charge))
         self.assertEqual('bar', res.foo)
+
+        self.assertTrue(res.last_response is not None)
+        self.assertEqual('foo', res.last_response.idempotency_key)

--- a/tests/api_resources/abstract/test_deletable_api_resource.py
+++ b/tests/api_resources/abstract/test_deletable_api_resource.py
@@ -16,7 +16,8 @@ class DeletableAPIResourceTests(StripeTestCase):
             {
                 'id': 'mid',
                 'deleted': True,
-            }
+            },
+            rheaders={'request-id': 'req_id'}
         )
 
         obj = MyDeletable.construct_from({
@@ -31,3 +32,6 @@ class DeletableAPIResourceTests(StripeTestCase):
         )
         self.assertEqual(True, obj.deleted)
         self.assertEqual('mid', obj.id)
+
+        self.assertTrue(obj.last_response is not None)
+        self.assertEqual('req_id', obj.last_response.request_id)

--- a/tests/api_resources/abstract/test_listable_api_resource.py
+++ b/tests/api_resources/abstract/test_listable_api_resource.py
@@ -28,7 +28,8 @@ class ListableAPIResourceTests(StripeTestCase):
                 ],
                 'url': '/v1/charges',
                 'has_more': False,
-            }
+            },
+            rheaders={'request-id': 'req_id'}
         )
 
         res = MyListable.list()
@@ -42,3 +43,6 @@ class ListableAPIResourceTests(StripeTestCase):
                             for obj in res.data))
         self.assertEqual('jose', res.data[0].name)
         self.assertEqual('curly', res.data[1].name)
+
+        self.assertTrue(res.last_response is not None)
+        self.assertEqual('req_id', res.last_response.request_id)

--- a/tests/api_resources/abstract/test_singleton_api_resource.py
+++ b/tests/api_resources/abstract/test_singleton_api_resource.py
@@ -16,7 +16,8 @@ class SingletonAPIResourceTests(StripeTestCase):
             '/v1/mysingleton',
             {
                 'single': 'ton'
-            }
+            },
+            rheaders={'request-id': 'req_id'}
         )
 
         res = MySingleton.retrieve()
@@ -27,3 +28,5 @@ class SingletonAPIResourceTests(StripeTestCase):
             {}
         )
         self.assertEqual('ton', res.single)
+        self.assertTrue(res.last_response is not None)
+        self.assertEqual('req_id', res.last_response.request_id)

--- a/tests/api_resources/abstract/test_updateable_api_resource.py
+++ b/tests/api_resources/abstract/test_updateable_api_resource.py
@@ -18,7 +18,8 @@ class UpdateableAPIResourceTests(StripeTestCase):
             {
                 'id': 'myid',
                 'thats': 'it',
-            }
+            },
+            rheaders={'request-id': 'req_id'}
         )
 
         self.obj = MyUpdateable.construct_from({
@@ -78,6 +79,9 @@ class UpdateableAPIResourceTests(StripeTestCase):
             },
             None
         )
+
+        self.assertTrue(self.obj.last_response is not None)
+        self.assertEqual('req_id', self.obj.last_response.request_id)
 
         # Saving again should not cause any request.
         self.request_mock.reset_mock()

--- a/tests/test_stripe_object.py
+++ b/tests/test_stripe_object.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import datetime
 import pickle
 from copy import copy, deepcopy
+from mock import Mock
 
 import stripe
 from stripe import util, six
@@ -106,11 +107,18 @@ class StripeObjectTests(StripeTestCase):
         self.assertEqual('me', obj['trans'])
         self.assertEqual(None, obj.stripe_version)
         self.assertEqual(None, obj.stripe_account)
+        self.assertEqual(None, obj.last_response)
 
-        obj.refresh_from({
-            'foo': 'baz',
-            'johnny': 5,
-        }, 'key2', stripe_version='2017-08-15', stripe_account='acct_foo')
+        last_response = Mock()
+        obj.refresh_from(
+            {
+                'foo': 'baz',
+                'johnny': 5,
+            }, 'key2',
+            stripe_version='2017-08-15',
+            stripe_account='acct_foo',
+            last_response=last_response
+        )
 
         self.assertEqual(5, obj.johnny)
         self.assertEqual('baz', obj.foo)
@@ -118,6 +126,7 @@ class StripeObjectTests(StripeTestCase):
         self.assertEqual('key2', obj.api_key)
         self.assertEqual('2017-08-15', obj.stripe_version)
         self.assertEqual('acct_foo', obj.stripe_account)
+        self.assertEqual(last_response, obj.last_response)
 
         obj.refresh_from({
             'trans': 4,


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @jleclanche

Fixes #393.

When calling `save()`, `convert_to_stripe_object` will call `refresh_from` with a `StripeObject` instance that already has the `_last_response` attribute set. However `refresh_from` only set the the `_last_response` attribute from an explicit `last_response` argument and did not check whether the instance already had a `_last_response` attribute like it does for other memorized attributes (e.g. `stripe_account`). This PR fixes that, and adds a bunch of tests to ensure that `last_response` is available on instances returned by all common API operations.

While fixing this, I also noticed a regression introduced by #371: the `OAuth.token` and `OAuth.deauthorize` methods used to directly return a dict with the JSON values returned by `connect.stripe.com`. After #371, those methods instead returned a `StripeResponse` instance. I've fixed it so that they return a dict again.