### PR TITLE
Upgrade to stripe-mock 0.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
 env:
   global:
     - PYCURL_SSL_LIBRARY=gnutls
-    - STRIPE_MOCK_VERSION=0.5.0
+    - STRIPE_MOCK_VERSION=0.8.0
 
 addons:
   apt:

--- a/README.md
+++ b/README.md
@@ -150,11 +150,11 @@ instructions for installing via Homebrew and other methods):
 
 Run a single test suite:
 
-    tox -e py27 -- --test-suite stripe.test.resources.test_updateable.UpdateableAPIResourceTests
+    tox -e py27 -- --test-suite tests.api_resources.abstract.test_updateable_api_resource.UpdateableAPIResourceTests
 
 Run a single test:
 
-    tox -e py27 -- --test-suite stripe.test.resources.test_updateable.UpdateableAPIResourceTests.test_save
+    tox -e py27 -- --test-suite tests.api_resources.abstract.test_updateable_api_resource.UpdateableAPIResourceTests.test_save
 
 Run the linter with:
 

--- a/tests/api_resources/test_product.py
+++ b/tests/api_resources/test_product.py
@@ -27,7 +27,8 @@ class ProductTest(StripeTestCase):
 
     def test_is_creatable(self):
         resource = stripe.Product.create(
-            name='NAME'
+            name='NAME',
+            type='good'
         )
         self.assert_requested(
             'post',


### PR DESCRIPTION
The upgrade broke a product related test that is now fixed. I also update the instructions around running tests, as they were no longer accurate.

r? @stripe/api-libraries 