### PR TITLE
Add support for /v1/topups endpoints

### DIFF
--- a/stripe/api_resources/__init__.py
+++ b/stripe/api_resources/__init__.py
@@ -43,4 +43,5 @@ from stripe.api_resources.subscription import Subscription
 from stripe.api_resources.subscription_item import SubscriptionItem
 from stripe.api_resources.three_d_secure import ThreeDSecure
 from stripe.api_resources.token import Token
+from stripe.api_resources.topup import Topup
 from stripe.api_resources.transfer import Transfer

--- a/stripe/api_resources/topup.py
+++ b/stripe/api_resources/topup.py
@@ -1,0 +1,7 @@
+from stripe.api_resources.abstract import CreateableAPIResource
+from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.abstract import ListableAPIResource
+
+
+class Topup(CreateableAPIResource, ListableAPIResource, UpdateableAPIResource):
+    OBJECT_NAME = 'topup'

--- a/stripe/util.py
+++ b/stripe/util.py
@@ -219,6 +219,7 @@ def load_object_classes():
             api_resources.SubscriptionItem,
         api_resources.ThreeDSecure.OBJECT_NAME: api_resources.ThreeDSecure,
         api_resources.Token.OBJECT_NAME: api_resources.Token,
+        api_resources.Topup.OBJECT_NAME: api_resources.Topup,
         api_resources.Transfer.OBJECT_NAME: api_resources.Transfer,
     }
 

--- a/tests/api_resources/test_topup.py
+++ b/tests/api_resources/test_topup.py
@@ -1,0 +1,58 @@
+import stripe
+from tests.helper import StripeTestCase
+
+
+TEST_RESOURCE_ID = 'tu_123'
+
+
+class TopupTest(StripeTestCase):
+    def test_is_listable(self):
+        resources = stripe.Topup.list()
+        self.assert_requested(
+            'get',
+            '/v1/topups'
+        )
+        self.assertIsInstance(resources.data, list)
+        self.assertIsInstance(resources.data[0], stripe.Topup)
+
+    def test_is_retrievable(self):
+        resource = stripe.Topup.retrieve(TEST_RESOURCE_ID)
+        self.assert_requested(
+            'get',
+            '/v1/topups/%s' % TEST_RESOURCE_ID
+        )
+        self.assertIsInstance(resource, stripe.Topup)
+
+    def test_is_creatable(self):
+        resource = stripe.Topup.create(
+            amount=100,
+            currency='usd',
+            source='src_123',
+            description='description',
+            statement_descriptor='statement descriptor'
+        )
+        self.assert_requested(
+            'post',
+            '/v1/topups'
+        )
+        self.assertIsInstance(resource, stripe.Topup)
+
+    def test_is_saveable(self):
+        resource = stripe.Topup.retrieve(TEST_RESOURCE_ID)
+        resource.metadata['key'] = 'value'
+        resource.save()
+        self.assert_requested(
+            'post',
+            '/v1/topups/%s' % resource.id
+        )
+
+    def test_is_modifiable(self):
+        resource = stripe.Topup.modify(
+            TEST_RESOURCE_ID,
+            metadata={'key': 'value'}
+        )
+        self.assert_requested(
+            'post',
+            '/v1/topups/%s' % TEST_RESOURCE_ID
+        )
+        self.assertIsInstance(resource, stripe.Topup)


### PR DESCRIPTION
This add standard retrieve, create and update client support for the new `/v1/topups` endpoint.

r? @apakulov-stripe @ccontinanza-stripe @chellman-stripe @kenneth-stripe @miguel-stripe
r? @stripe/api-libraries 