### PR TITLE
Start building universal wheels

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2010-2011 Stripe (http://stripe.com)
+Copyright (c) 2010-2018 Stripe (http://stripe.com)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,9 @@ else:
 with open('LONG_DESCRIPTION.rst') as f:
     long_description = f.read()
 
-# Don't import stripe module here, since deps may not be installed
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'stripe'))
-from version import VERSION
+version_contents = {}
+with open(os.path.join('stripe', 'version.py')) as f:
+    exec(f.read(), version_contents)
 
 # Get simplejson if we don't already have json
 if sys.version_info < (3, 0):
@@ -42,12 +42,13 @@ if sys.version_info < (3, 0):
 
 setup(
     name='stripe',
-    version=VERSION,
-    description='Stripe python bindings',
+    version=version_contents['VERSION'],
+    description='Python bindings for the Stripe API',
     long_description=long_description,
     author='Stripe',
     author_email='support@stripe.com',
     url='https://github.com/stripe/stripe-python',
+    license='MIT',
     packages=['stripe', 'stripe.api_resources',
               'stripe.api_resources.abstract'],
     package_data={'stripe': ['data/ca-certificates.crt']},


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Since we no longer use `2to3` and the library can now directly be used by Python 2 or 3, we also no longer need to build distinct wheels.

This PR enables the flag to start building universal wheels by default, as well as add a few opportunistic fixes to the `setup.py` and license files.
