### PR TITLE
Remove util.json and use json module directly everywhere

### DIFF
--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import calendar
 import datetime
+import json
 import platform
 import time
 
@@ -209,7 +210,7 @@ class APIRequestor(object):
             ua['application'] = stripe.app_info
 
         headers = {
-            'X-Stripe-Client-User-Agent': util.json.dumps(ua),
+            'X-Stripe-Client-User-Agent': json.dumps(ua),
             'User-Agent': user_agent,
             'Authorization': 'Bearer %s' % (api_key,),
         }

--- a/stripe/stripe_object.py
+++ b/stripe/stripe_object.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import datetime
+import json
 from copy import deepcopy
 
 import stripe
@@ -33,7 +34,7 @@ def _serialize_list(array, previous):
 
 
 class StripeObject(dict):
-    class ReprJSONEncoder(util.json.JSONEncoder):
+    class ReprJSONEncoder(json.JSONEncoder):
         def default(self, obj):
             if isinstance(obj, datetime.datetime):
                 return api_requestor._encode_datetime(obj)
@@ -227,8 +228,8 @@ class StripeObject(dict):
             return unicode_repr
 
     def __str__(self):
-        return util.json.dumps(self, sort_keys=True, indent=2,
-                               cls=self.ReprJSONEncoder)
+        return json.dumps(self, sort_keys=True, indent=2,
+                          cls=self.ReprJSONEncoder)
 
     def to_dict(self):
         return dict(self)

--- a/stripe/stripe_response.py
+++ b/stripe/stripe_response.py
@@ -1,4 +1,6 @@
-from stripe import util
+from __future__ import absolute_import, division, print_function
+
+import json
 
 
 class StripeResponse:
@@ -7,7 +9,7 @@ class StripeResponse:
         self.body = body
         self.code = code
         self.headers = headers
-        self.data = util.json.loads(body)
+        self.data = json.loads(body)
 
     @property
     def idempotency_key(self):

--- a/stripe/util.py
+++ b/stripe/util.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import hmac
 import io
-import json
 import logging
 import sys
 import os
@@ -20,7 +19,6 @@ logger = logging.getLogger('stripe')
 __all__ = [
     'io',
     'parse_qsl',
-    'json',
     'utf8',
     'log_info',
     'log_debug',

--- a/stripe/webhook.py
+++ b/stripe/webhook.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import hmac
+import json
 import time
 from hashlib import sha256
 
@@ -18,7 +19,7 @@ class Webhook(object):
             payload = payload.decode('utf-8')
         if api_key is None:
             api_key = stripe.api_key
-        data = util.json.loads(payload)
+        data = json.loads(payload)
         event = stripe.Event.construct_from(data, api_key)
 
         WebhookSignature.verify_header(payload, sig_header, secret, tolerance)

--- a/tests/request_mock.py
+++ b/tests/request_mock.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import json
+
 import stripe
 from stripe import six
 from stripe.stripe_response import StripeResponse
@@ -100,7 +102,7 @@ class StubRequestHandler(object):
         if (method, url) in self._entries:
             rbody, rcode, rheaders = self._entries.pop((method, url))
             if not isinstance(rbody, six.string_types):
-                rbody = stripe.util.json.dumps(rbody)
+                rbody = json.dumps(rbody)
             stripe_response = StripeResponse(rbody, rcode, rheaders)
             return stripe_response
 

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import datetime
+import json
 import tempfile
 
 import pytest
@@ -8,7 +9,6 @@ import pytest
 import stripe
 from stripe import six
 from stripe.stripe_response import StripeResponse
-from stripe import util
 
 from six.moves.urllib.parse import urlsplit
 
@@ -76,7 +76,7 @@ class APIHeaderMatcher(object):
 
     def _x_stripe_ua_contains_app_info(self, other):
         if self.app_info:
-            ua = stripe.util.json.loads(other['X-Stripe-Client-User-Agent'])
+            ua = json.loads(other['X-Stripe-Client-User-Agent'])
             if 'application' not in ua:
                 return False
             return ua['application'] == self.app_info
@@ -311,7 +311,7 @@ class TestAPIRequestor(object):
             assert isinstance(resp, StripeResponse)
 
             assert resp.data == {}
-            assert resp.data == util.json.loads(resp.body)
+            assert resp.data == json.loads(resp.body)
 
     def test_methods_with_params_and_response(self, requestor, mock_response,
                                               check_call):
@@ -330,7 +330,7 @@ class TestAPIRequestor(object):
             assert isinstance(resp, StripeResponse)
 
             assert resp.data == {'foo': 'bar', 'baz': 6}
-            assert resp.data == util.json.loads(resp.body)
+            assert resp.data == json.loads(resp.body)
 
             if method == 'post':
                 check_call(

--- a/tests/test_stripe_object.py
+++ b/tests/test_stripe_object.py
@@ -1,16 +1,17 @@
 from __future__ import absolute_import, division, print_function
 
 import datetime
+import json
 import pickle
 from copy import copy, deepcopy
 
 import pytest
 
 import stripe
-from stripe import util, six
+from stripe import six
 
 
-SAMPLE_INVOICE = stripe.util.json.loads("""
+SAMPLE_INVOICE = json.loads("""
 {
   "amount_due": 1305,
   "attempt_count": 0,
@@ -168,7 +169,7 @@ class TestStripeObject(object):
         obj = stripe.stripe_object.StripeObject.construct_from(
             SAMPLE_INVOICE, 'key')
 
-        self.check_invoice_data(util.json.loads(str(obj)))
+        self.check_invoice_data(json.loads(str(obj)))
 
     def check_invoice_data(self, data):
         # Check rough structure

--- a/tests/test_stripe_response.py
+++ b/tests/test_stripe_response.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
-from stripe import util
+import json
+
 from stripe.stripe_response import StripeResponse
 
 
@@ -27,7 +28,7 @@ class TestStripeResponse(object):
 
     def test_data(self):
         response, headers, body, code = self.mock_stripe_response()
-        assert response.data == util.json.loads(body)
+        assert response.data == json.loads(body)
 
     @staticmethod
     def mock_stripe_response():


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Since we dropped simplejson, there's no point in centralizing all JSON usage through the `util` module anymore. Other modules can simply import the stdlib `json` module as needed.
