### PR TITLE
Update setup.py and test flow

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+source = stripe
+omit =
+    stripe/six.py

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+exclude =
+    six.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,21 +12,13 @@ python:
   - "pypy3"
 
 cache:
-  apt: true
   directories:
     - stripe-mock
   pip: false
 
 env:
   global:
-    - PYCURL_SSL_LIBRARY=gnutls
     - STRIPE_MOCK_VERSION=0.8.0
-
-addons:
-  apt:
-    packages:
-      - libcurl4-gnutls-dev
-      - librtmp-dev
 
 before_install:
   # Unpack and start stripe-mock so that the test suite can talk to it
@@ -41,20 +33,12 @@ before_install:
     STRIPE_MOCK_PID=$!
 
 install:
-  - pip install -U setuptools pip
-  - pip install pycurl flake8 coveralls
-  - python setup.py clean --all
+  - pip install -U setuptools pip flake8 coveralls
   - python setup.py install
 
 script:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then flake8 stripe tests; fi
-  - python -W all -bb -W error::BytesWarning setup.py test --addopts "--cov=stripe"
+  - python setup.py test -a "-n 8"
 
 after_success:
   coveralls
-
-matrix:
-  allow_failures:
-    - python: 3.7-dev
-    - python: pypy
-    - python: pypy3

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -p no:warnings

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[aliases]
-test=pytest
-
 [bdist_wheel]
 universal = 1
 

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,31 @@
-import os
 import sys
+from codecs import open
+from os import path
+from setuptools import setup, find_packages
+from setuptools.command.test import test as TestCommand
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+
+class PyTest(TestCommand):
+    user_options = [('pytest-args=', 'a', "Arguments to pass into py.test")]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = '-n auto'
+
+    def run_tests(self):
+        import shlex
+        import pytest
+        errno = pytest.main(shlex.split(self.pytest_args))
+        sys.exit(errno)
 
 
-path, script = os.path.split(sys.argv[0])
-os.chdir(os.path.abspath(path))
+here = path.abspath(path.dirname(__file__))
 
-with open('LONG_DESCRIPTION.rst') as f:
+with open(path.join(here, 'LONG_DESCRIPTION.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 version_contents = {}
-with open(os.path.join('stripe', 'version.py')) as f:
+with open(path.join(here, 'stripe', 'version.py'), encoding='utf-8') as f:
     exec(f.read(), version_contents)
 
 setup(
@@ -26,18 +37,27 @@ setup(
     author_email='support@stripe.com',
     url='https://github.com/stripe/stripe-python',
     license='MIT',
-    packages=['stripe', 'stripe.api_resources',
-              'stripe.api_resources.abstract'],
+    keywords='stripe api payments',
+    packages=find_packages(exclude=['tests', 'tests.*']),
     package_data={'stripe': ['data/ca-certificates.crt']},
+    zip_safe=False,
     install_requires=[
-        'requests >= 0.8.8',
+        'requests >= 2',
+        'requests[security] >= 2; python_version < "3.0"',
     ],
-    setup_requires=['pytest-runner'],
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     tests_require=[
         'pytest >= 3.4',
         'pytest-mock >= 1.7',
+        'pytest-xdist >= 1.22',
         'pytest-cov >= 2.5',
     ],
+    cmdclass={'test': PyTest},
+    project_urls={
+        'Bug Tracker': 'https://github.com/stripe/stripe-python/issues',
+        'Documentation': 'https://stripe.com/docs/api/python',
+        'Source Code': 'https://github.com/stripe/stripe-python',
+    },
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
@@ -52,4 +72,5 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Libraries :: Python Modules",
-    ])
+    ],
+)

--- a/tox.ini
+++ b/tox.ini
@@ -7,30 +7,12 @@
 envlist = py27, py34, py35, py36, pypy, pypy3
 
 [testenv]
-deps =
-    pycurl>=7.19
-    requests>=0.8.8
 commands =
-    python setup.py clean --all
-    python -W all -bb -W error::BytesWarning setup.py test --addopts "--cov=stripe {posargs}"
-setenv =
-    STRIPE_TEST_PYCURL = true
+    python setup.py test -a "{posargs:-n auto}"
 
 [testenv:py27]
 deps =
     flake8
-    pycurl>=7.19
-    requests>=0.8.8
 commands =
     flake8 stripe tests
-    python setup.py clean --all
-    python -W all -bb -W error::BytesWarning setup.py test --addopts "--cov=stripe {posargs}"
-
-[flake8]
-exclude =
-    six.py
-
-[coverage:run]
-source = stripe
-omit =
-    stripe/six.py
+    python setup.py test -a "{posargs:-n auto}"


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

(This is for the upcoming v2.0.)

Update setup.py and test flow:
- refactor `setup.py` to use best practices described in https://github.com/pypa/sampleproject/blob/master/setup.py
- bump minimum `requests` version to 2 (current major version)
- add `requests[security]` to dependencies for Python 2. This should help with TLS 1.2 issues, e.g. when using the default OS X Python interpreter.
- removed `pytest-runner` from `setup_requires` to avoid installing the package for every `setup.py` invocation. Instead use a custom `PyTest` command as described [here](https://docs.pytest.org/en/latest/goodpractices.html#manual-integration).
- use `pytest-xdist` to distribute tests over multiple cores. This is not very useful when running tests on a reasonably powerful local machine, but gives a noticeable speed increase on Travis.
- use `find_packages` to discover packages automatically

- Greatly simply `tox.ini` by putting coverage and flake8 configurations in dedicateds files, and simply running `python setup.py test`

- Don't install `pycurl` package when running tests as it wasn't actually used anywhere

- Remove `allow_failures` from Travis configuration as we probably want to not merge PRs that break PyPy or 3.7 compatibility
