### PR TITLE
Update MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
-include LICENSE VERSION stripe/data/ca-certificates.crt LONG_DESCRIPTION.rst
+include CHANGELOG.md LICENSE LONG_DESCRIPTION.rst README.md VERSION tox.ini
+recursive-include tests *.py


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Updates the `MANIFEST.in` file used by `setup.py` to create source distributions:
- removed `stripe/data/ca-certificates.crt` (it will automatically be picked up by `setup.py` from the `package_data` keyword)
- added `CHANGELOG.md`, `README.md` and `tox.ini`
- most importantly: added the `tests` directory
