### PR TITLE
Hide .pyc files and __pycache__ folders in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.exclude": {
+        "**/*.pyc": {"when": "$(basename).py"},
+        "**/__pycache__": true
+    }
+}


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Just a nice little improvement for developers using VSCode. This hides `.pyc` files (with a matching `.py` file) and `__pycache__` folders from the sidebar.
