### PR TITLE
Fix tests for deleted resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
 env:
   global:
     - PYCURL_SSL_LIBRARY=gnutls
-    - STRIPE_MOCK_VERSION=0.8.0
+    - STRIPE_MOCK_VERSION=0.9.0
 
 addons:
   apt:

--- a/tests/api_resources/test_account.py
+++ b/tests/api_resources/test_account.py
@@ -89,12 +89,15 @@ class AccountTest(StripeTestCase):
 
     def test_is_deletable(self):
         resource = stripe.Account.retrieve(TEST_RESOURCE_ID)
+        # Unfortunately stripe-mock will return a resource with a different
+        # ID, so we need to store the original ID for the request assertion
+        resource_id = resource.id
         resource.delete()
         self.assert_requested(
             'delete',
-            '/v1/accounts/%s' % resource.id
+            '/v1/accounts/%s' % resource_id
         )
-        self.assertIsInstance(resource, stripe.Account)
+        self.assertTrue(resource.deleted)
 
     def test_can_retrieve_no_id(self):
         resource = stripe.Account.retrieve()
@@ -190,7 +193,7 @@ class AccountExternalAccountsTests(StripeTestCase):
             '/v1/accounts/%s/external_accounts/%s' % (TEST_RESOURCE_ID,
                                                       TEST_EXTERNALACCOUNT_ID)
         )
-        self.assertIsInstance(resource, stripe.BankAccount)
+        self.assertTrue(resource.deleted)
 
 
 class AccountLoginLinksTests(StripeTestCase):

--- a/tests/api_resources/test_apple_pay_domain.py
+++ b/tests/api_resources/test_apple_pay_domain.py
@@ -37,9 +37,12 @@ class ApplePayDomainTest(StripeTestCase):
 
     def test_is_deletable(self):
         resource = stripe.ApplePayDomain.retrieve(TEST_RESOURCE_ID)
+        # Unfortunately stripe-mock will return a resource with a different
+        # ID, so we need to store the original ID for the request assertion
+        resource_id = resource.id
         resource.delete()
         self.assert_requested(
             'delete',
-            '/v1/apple_pay/domains/%s' % resource.id
+            '/v1/apple_pay/domains/%s' % resource_id
         )
-        self.assertIsInstance(resource, stripe.ApplePayDomain)
+        self.assertTrue(resource.deleted)

--- a/tests/api_resources/test_bank_account.py
+++ b/tests/api_resources/test_bank_account.py
@@ -61,6 +61,8 @@ class BankAccountTest(StripeTestCase):
             'delete',
             '/v1/customers/cus_123/sources/%s' % TEST_RESOURCE_ID
         )
+        # stripe-mock does not yet correctly handle deleting customer sources
+        # self.assertTrue(resource.deleted)
 
     def test_is_verifiable(self):
         resource = self.construct_resource(customer='cus_123')

--- a/tests/api_resources/test_coupon.py
+++ b/tests/api_resources/test_coupon.py
@@ -60,9 +60,12 @@ class CouponTest(StripeTestCase):
 
     def test_is_deletable(self):
         resource = stripe.Coupon.retrieve(TEST_RESOURCE_ID)
+        # Unfortunately stripe-mock will return a resource with a different
+        # ID, so we need to store the original ID for the request assertion
+        resource_id = resource.id
         resource.delete()
         self.assert_requested(
             'delete',
-            '/v1/coupons/%s' % resource.id
+            '/v1/coupons/%s' % resource_id
         )
-        self.assertIsInstance(resource, stripe.Coupon)
+        self.assertTrue(resource.deleted)

--- a/tests/api_resources/test_customer.py
+++ b/tests/api_resources/test_customer.py
@@ -59,12 +59,15 @@ class CustomerTest(StripeTestCase):
 
     def test_is_deletable(self):
         resource = stripe.Customer.retrieve(TEST_RESOURCE_ID)
+        # Unfortunately stripe-mock will return a resource with a different
+        # ID, so we need to store the original ID for the request assertion
+        resource_id = resource.id
         resource.delete()
         self.assert_requested(
             'delete',
-            '/v1/customers/%s' % resource.id
+            '/v1/customers/%s' % resource_id
         )
-        self.assertIsInstance(resource, stripe.Customer)
+        self.assertTrue(resource.deleted)
 
 
 # stripe-mock does not handle the legacy subscription endpoint so we stub

--- a/tests/api_resources/test_plan.py
+++ b/tests/api_resources/test_plan.py
@@ -61,9 +61,12 @@ class PlanTest(StripeTestCase):
 
     def test_is_deletable(self):
         resource = stripe.Plan.retrieve(TEST_RESOURCE_ID)
+        # Unfortunately stripe-mock will return a resource with a different
+        # ID, so we need to store the original ID for the request assertion
+        resource_id = resource.id
         resource.delete()
         self.assert_requested(
             'delete',
-            '/v1/plans/%s' % resource.id
+            '/v1/plans/%s' % resource_id
         )
-        self.assertIsInstance(resource, stripe.Plan)
+        self.assertTrue(resource.deleted)

--- a/tests/api_resources/test_product.py
+++ b/tests/api_resources/test_product.py
@@ -58,9 +58,12 @@ class ProductTest(StripeTestCase):
 
     def test_is_deletable(self):
         resource = stripe.Product.retrieve(TEST_RESOURCE_ID)
+        # Unfortunately stripe-mock will return a resource with a different
+        # ID, so we need to store the original ID for the request assertion
+        resource_id = resource.id
         resource.delete()
         self.assert_requested(
             'delete',
-            '/v1/products/%s' % resource.id
+            '/v1/products/%s' % resource_id
         )
-        self.assertIsInstance(resource, stripe.Product)
+        self.assertTrue(resource.deleted)

--- a/tests/api_resources/test_recipient.py
+++ b/tests/api_resources/test_recipient.py
@@ -58,12 +58,15 @@ class RecipientTest(StripeTestCase):
 
     def test_is_deletable(self):
         resource = stripe.Recipient.retrieve(TEST_RESOURCE_ID)
+        # Unfortunately stripe-mock will return a resource with a different
+        # ID, so we need to store the original ID for the request assertion
+        resource_id = resource.id
         resource.delete()
         self.assert_requested(
             'delete',
-            '/v1/recipients/%s' % resource.id
+            '/v1/recipients/%s' % resource_id
         )
-        self.assertIsInstance(resource, stripe.Recipient)
+        self.assertTrue(resource.deleted)
 
     def test_can_list_transfers(self):
         recipient = stripe.Recipient.retrieve(TEST_RESOURCE_ID)

--- a/tests/api_resources/test_sku.py
+++ b/tests/api_resources/test_sku.py
@@ -63,9 +63,12 @@ class SKUTest(StripeTestCase):
 
     def test_is_deletable(self):
         resource = stripe.SKU.retrieve(TEST_RESOURCE_ID)
+        # Unfortunately stripe-mock will return a resource with a different
+        # ID, so we need to store the original ID for the request assertion
+        resource_id = resource.id
         resource.delete()
         self.assert_requested(
             'delete',
-            '/v1/skus/%s' % resource.id
+            '/v1/skus/%s' % resource_id
         )
-        self.assertIsInstance(resource, stripe.SKU)
+        self.assertTrue(resource.deleted)

--- a/tests/api_resources/test_subscription_item.py
+++ b/tests/api_resources/test_subscription_item.py
@@ -65,9 +65,12 @@ class SubscriptionItemTest(StripeTestCase):
 
     def test_is_deletable(self):
         resource = stripe.SubscriptionItem.retrieve(TEST_RESOURCE_ID)
+        # Unfortunately stripe-mock will return a resource with a different
+        # ID, so we need to store the original ID for the request assertion
+        resource_id = resource.id
         resource.delete()
         self.assert_requested(
             'delete',
-            '/v1/subscription_items/%s' % resource.id
+            '/v1/subscription_items/%s' % resource_id
         )
-        self.assertIsInstance(resource, stripe.SubscriptionItem)
+        self.assertTrue(resource.deleted)

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -13,7 +13,7 @@ from stripe.six.moves.urllib.error import HTTPError
 from tests.request_mock import RequestMock
 
 
-MOCK_MINIMUM_VERSION = '0.5.0'
+MOCK_MINIMUM_VERSION = '0.9.0'
 MOCK_PORT = os.environ.get('STRIPE_MOCK_PORT', 12111)
 
 


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @tmaxwell-stripe @blueyed 

Fixes #405.

`0.9.0` is not a valid stripe-mock version yet, so it's expected that CI will fail at first. I'll rerun the tests and remove the wip tag once stripe-mock is updated.
