### PR TITLE
Add close() method to HTTPClient classes

### DIFF
--- a/stripe/http_client.py
+++ b/stripe/http_client.py
@@ -93,6 +93,10 @@ class HTTPClient(object):
         raise NotImplementedError(
             'HTTPClient subclasses must implement `request`')
 
+    def close(self):
+        raise NotImplementedError(
+            'HTTPClient subclasses must implement `close`')
+
 
 class RequestsClient(HTTPClient):
     name = 'requests'
@@ -160,6 +164,10 @@ class RequestsClient(HTTPClient):
         msg = textwrap.fill(msg) + "\n\n(Network error: %s)" % (err,)
         raise error.APIConnectionError(msg)
 
+    def close(self):
+        if self._session is not None:
+            self._session.close()
+
 
 class UrlFetchClient(HTTPClient):
     name = 'urlfetch'
@@ -217,6 +225,9 @@ class UrlFetchClient(HTTPClient):
 
         msg = textwrap.fill(msg) + "\n\n(Network error: " + str(e) + ")"
         raise error.APIConnectionError(msg)
+
+    def close(self):
+        pass
 
 
 class PycurlClient(HTTPClient):
@@ -337,6 +348,9 @@ class PycurlClient(HTTPClient):
                     return proxy[scheme]
         return None
 
+    def close(self):
+        pass
+
 
 class Urllib2Client(HTTPClient):
     name = 'urllib.request'
@@ -382,3 +396,6 @@ class Urllib2Client(HTTPClient):
                "If this problem persists, let us know at support@stripe.com.")
         msg = textwrap.fill(msg) + "\n\n(Network error: " + str(e) + ")"
         raise error.APIConnectionError(msg)
+
+    def close(self):
+        pass

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -44,10 +44,14 @@ class StripeTestCase(unittest2.TestCase):
             'api_base': stripe.api_base,
             'api_key': stripe.api_key,
             'client_id': stripe.client_id,
+            'default_http_client': stripe.default_http_client,
         }
         stripe.api_base = 'http://localhost:%s' % MOCK_PORT
         stripe.api_key = 'sk_test_123'
         stripe.client_id = 'ca_123'
+
+        self.client = stripe.http_client.new_default_http_client()
+        stripe.default_http_client = self.client
 
         self.request_mock = RequestMock()
         self.request_mock.start()
@@ -57,9 +61,12 @@ class StripeTestCase(unittest2.TestCase):
 
         self.request_mock.stop()
 
+        self.client.close()
+
         stripe.api_base = stripe.orig_attrs['api_base']
         stripe.api_key = stripe.orig_attrs['api_key']
         stripe.client_id = stripe.orig_attrs['client_id']
+        stripe.default_http_client = stripe.orig_attrs['default_http_client']
 
     def stub_request(self, *args, **kwargs):
         return self.request_mock.stub_request(*args, **kwargs)


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

We're seeing intermittent test failures because unclosed requests sessions can cause `ResourceWarning`s (cf. https://github.com/requests/requests/issues/3912) and some of our tests capture and count warnings.

This PR adds a `close()` method to all `HTTPClient` subclasses. The method is a no-op for all clients except `RequestClient`, which cleanly closes the session (if it exists). The PR also updates the `StripeTestCase` class to manually instantiate a client so that we can call `close()` in the `tearDown()` method. This should hopefully get rid of the unwanted `ResourceWarning`s.
