### PR TITLE
Configure VSCode linting

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ms-python.python"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,10 @@
     "files.exclude": {
         "**/*.pyc": {"when": "$(basename).py"},
         "**/__pycache__": true
-    }
+    },
+
+    // Linting
+    "python.linting.enabled": true,
+    "python.linting.pylintEnabled": false,
+    "python.linting.flake8Enabled": true
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Configure linting with flake8 when using VSCode.

(Technically, comments are not allowed in JSON, but VSCode supports this.)
