### PR TITLE
flake8: add "unicode" to builtins

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ universal = 1
 
 [metadata]
 license_file = LICENSE
+
+[flake8]
+builtins = unicode


### PR DESCRIPTION
This avoids "F821 undefined name 'unicode'" when using flake8 with
Python 3.