### PR TITLE
Remove unicode symbols, use six helpers instead

### DIFF
--- a/stripe/error.py
+++ b/stripe/error.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
-from stripe import six
+from stripe.six import python_2_unicode_compatible
 
 
+@python_2_unicode_compatible
 class StripeError(Exception):
 
     def __init__(self, message=None, http_body=None, http_status=None,
@@ -24,19 +25,12 @@ class StripeError(Exception):
         self.code = code
         self.request_id = self.headers.get('request-id', None)
 
-    def __unicode__(self):
+    def __str__(self):
         if self.request_id is not None:
             msg = self._message or "<empty message>"
             return u"Request {0}: {1}".format(self.request_id, msg)
         else:
             return self._message
-
-    if six.PY3:
-        def __str__(self):
-            return self.__unicode__()
-    else:
-        def __str__(self):
-            return unicode(self).encode('utf-8')
 
 
 class APIError(StripeError):

--- a/stripe/multipart_data_generator.py
+++ b/stripe/multipart_data_generator.py
@@ -53,16 +53,9 @@ class MultipartDataGenerator(object):
         return self.data.getvalue()
 
     def _write(self, value):
-        if six.PY2:
-            binary_type = str
-            text_type = unicode
-        else:
-            binary_type = bytes
-            text_type = str
-
-        if isinstance(value, binary_type):
+        if isinstance(value, six.binary_type):
             array = bytearray(value)
-        elif isinstance(value, text_type):
+        elif isinstance(value, six.text_type):
             array = bytearray(value, encoding='utf-8')
         else:
             raise TypeError("unexpected type: {value_type}"

--- a/stripe/util.py
+++ b/stripe/util.py
@@ -59,10 +59,7 @@ if not (json and hasattr(json, 'loads')):
 
 
 def utf8(value):
-    # Note the ordering of these conditionals: `unicode` isn't a symbol in
-    # Python 3 so make sure to check version before trying to use it. Python
-    # 2to3 will also boil out `unicode`.
-    if six.PY2 and isinstance(value, unicode):
+    if six.PY2 and isinstance(value, six.text_type):
         return value.encode('utf-8')
     else:
         return value

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -10,24 +10,18 @@ class StripeErrorTests(StripeTestCase):
 
     def test_formatting(self):
         err = StripeError(u'öre')
-        if six.PY3:
-            assert str(err) == u'öre'
-        else:
-            assert str(err) == '\xc3\xb6re'
-            assert unicode(err) == u'öre'
+        self.assertEqual(u'öre', six.text_type(err))
+        if six.PY2:
+            self.assertEqual('\xc3\xb6re', str(err))
 
     def test_formatting_with_request_id(self):
         err = StripeError(u'öre', headers={'request-id': '123'})
-        if six.PY3:
-            assert str(err) == u'Request 123: öre'
-        else:
-            assert str(err) == 'Request 123: \xc3\xb6re'
-            assert unicode(err) == u'Request 123: öre'
+        self.assertEqual(u'Request 123: öre', six.text_type(err))
+        if six.PY2:
+            self.assertEqual('Request 123: \xc3\xb6re', str(err))
 
     def test_formatting_with_none(self):
         err = StripeError(None, headers={'request-id': '123'})
-        if six.PY3:
-            assert str(err) == u'Request 123: <empty message>'
-        else:
-            assert str(err) == 'Request 123: <empty message>'
-            assert unicode(err) == u'Request 123: <empty message>'
+        self.assertEqual(u'Request 123: <empty message>', six.text_type(err))
+        if six.PY2:
+            self.assertEqual('Request 123: <empty message>', str(err))

--- a/tests/test_stripe_object.py
+++ b/tests/test_stripe_object.py
@@ -193,7 +193,7 @@ class StripeObjectTests(StripeTestCase):
         res = repr(obj)
 
         if six.PY2:
-            res = unicode(repr(obj), 'utf-8')
+            res = six.text_type(repr(obj), 'utf-8')
 
         self.assertTrue(u'<StripeObject \u4e00boo\u1f00' in res)
         self.assertTrue(u'id=foo' in res)


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @blueyed 

This PR replaces all uses of the `unicode` symbol with helper methods from six. This fixes flake8 warnings when running flake8 with Python 3 ( as `unicode` is not a valid symbol in Py3).

Replaces #412.
