### PR TITLE
Add support for running unit tests from VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,10 @@
     // Linting
     "python.linting.enabled": true,
     "python.linting.pylintEnabled": false,
-    "python.linting.flake8Enabled": true
+    "python.linting.flake8Enabled": true,
+
+    // Tests
+    "python.unitTest.unittestEnabled": true,
+    "python.unitTest.pyTestEnabled": false,
+    "python.unitTest.nosetestsEnabled": false
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

As the title says.

Because we don't enforce a specific interpreter in the VS Code settings, the unit tests will be run with the default interpreter, so it's the responsibility of the developer to ensure that the `unittest2` and `mock` modules are available with the default interpreter.

In the 2.0 branch, this will not be an issue because VSCode will automatically use the Python interpreter from the pipenv virtual environment, which will have all the required dependencies.
