### PR TITLE
Change exception type when detaching unattached sources to InvalidRequestError

### DIFF
--- a/stripe/api_resources/source.py
+++ b/stripe/api_resources/source.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from stripe import util
+from stripe import error, util
 from stripe.api_resources import Customer
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
@@ -12,8 +12,10 @@ class Source(CreateableAPIResource, UpdateableAPIResource, VerifyMixin):
     OBJECT_NAME = 'source'
 
     def detach(self, idempotency_key=None, **params):
+        token = util.utf8(self.id)
+
         if hasattr(self, 'customer') and self.customer:
-            extn = quote_plus(util.utf8(self.id))
+            extn = quote_plus(token)
             customer = util.utf8(self.customer)
             base = Customer.class_url()
             owner_extn = quote_plus(customer)
@@ -24,9 +26,9 @@ class Source(CreateableAPIResource, UpdateableAPIResource, VerifyMixin):
             return self
 
         else:
-            raise NotImplementedError(
-                "This source object does not appear to be currently attached "
-                "to a customer object.")
+            raise error.InvalidRequestError(
+                "Source %s does not appear to be currently attached "
+                "to a customer object." % token, 'id')
 
     def source_transactions(self, **params):
         return self.request(

--- a/tests/api_resources/test_source.py
+++ b/tests/api_resources/test_source.py
@@ -63,7 +63,7 @@ class TestSource(object):
 
     def test_is_not_detachable_when_unattached(self):
         resource = stripe.Source.retrieve(TEST_RESOURCE_ID)
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(stripe.error.InvalidRequestError):
             resource.detach()
 
     def test_is_verifiable(self, request_mock):


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @jleclanche

Changes the exception raised when trying to detach unattached sources from `NotImplementedError` to `stripe.error.InvalidRequestError`. This is consistent with other libraries.

Fixes #376.
