### PR TITLE
Upgrade stripe-mock to 0.11.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
 env:
   global:
     - PYCURL_SSL_LIBRARY=gnutls
-    - STRIPE_MOCK_VERSION=0.11.0
+    - STRIPE_MOCK_VERSION=0.11.2
 
 addons:
   apt:

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -13,7 +13,7 @@ from stripe.six.moves.urllib.error import HTTPError
 from tests.request_mock import RequestMock
 
 
-MOCK_MINIMUM_VERSION = '0.9.0'
+MOCK_MINIMUM_VERSION = '0.11.2'
 MOCK_PORT = os.environ.get('STRIPE_MOCK_PORT', 12111)
 
 


### PR DESCRIPTION
cc @stripe/api-libraries 

Self-approving this one since no changes are needed in the test suite.
