### PR TITLE
Bump stripe-mock to 0.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
 env:
   global:
     - PYCURL_SSL_LIBRARY=gnutls
-    - STRIPE_MOCK_VERSION=0.11.2
+    - STRIPE_MOCK_VERSION=0.12.0
 
 addons:
   apt:

--- a/tests/api_resources/test_account.py
+++ b/tests/api_resources/test_account.py
@@ -112,7 +112,7 @@ class AccountTest(StripeTestCase):
         resource = account.reject(reason='fraud')
         self.assert_requested(
             'post',
-            '/v1/accounts/%s/reject' % account.id
+            '/v1/accounts/%s/reject' % TEST_RESOURCE_ID
         )
         self.assertIsInstance(resource, stripe.Account)
         self.assertTrue(resource is account)

--- a/tests/api_resources/test_application_fee.py
+++ b/tests/api_resources/test_application_fee.py
@@ -25,7 +25,7 @@ class ApplicationFeeRefundsTests(StripeTestCase):
         resource = appfee.refund()
         self.assert_requested(
             'post',
-            '/v1/application_fees/%s/refund' % appfee.id
+            '/v1/application_fees/%s/refund' % TEST_RESOURCE_ID
         )
         self.assertIsInstance(resource, stripe.ApplicationFee)
         self.assertTrue(resource is appfee)

--- a/tests/api_resources/test_application_fee_refund.py
+++ b/tests/api_resources/test_application_fee_refund.py
@@ -16,7 +16,7 @@ class ApplicationFeeRefundTest(StripeTestCase):
         resource.save()
         self.assert_requested(
             'post',
-            '/v1/application_fees/%s/refunds/%s' % (appfee.id,
+            '/v1/application_fees/%s/refunds/%s' % (resource.fee,
                                                     resource.id)
         )
 

--- a/tests/api_resources/test_charge.py
+++ b/tests/api_resources/test_charge.py
@@ -64,7 +64,7 @@ class ChargeMethodsTest(StripeTestCase):
         resource = charge.refund()
         self.assert_requested(
             'post',
-            '/v1/charges/%s/refund' % charge.id
+            '/v1/charges/%s/refund' % TEST_RESOURCE_ID
         )
         self.assertIsInstance(resource, stripe.Charge)
 
@@ -73,7 +73,7 @@ class ChargeMethodsTest(StripeTestCase):
         resource = charge.capture()
         self.assert_requested(
             'post',
-            '/v1/charges/%s/capture' % charge.id
+            '/v1/charges/%s/capture' % TEST_RESOURCE_ID
         )
         self.assertIsInstance(resource, stripe.Charge)
 

--- a/tests/api_resources/test_payout.py
+++ b/tests/api_resources/test_payout.py
@@ -61,6 +61,6 @@ class PayoutTest(StripeTestCase):
         resource = payout.cancel()
         self.assert_requested(
             'post',
-            '/v1/payouts/%s/cancel' % payout.id
+            '/v1/payouts/%s/cancel' % TEST_RESOURCE_ID
         )
         self.assertIsInstance(resource, stripe.Payout)

--- a/tests/api_resources/test_source.py
+++ b/tests/api_resources/test_source.py
@@ -87,6 +87,6 @@ class SourceTest(StripeTestCase):
         self.assertTrue(source is resource)
         self.assert_requested(
             'post',
-            '/v1/sources/%s/verify' % resource.id,
+            '/v1/sources/%s/verify' % TEST_RESOURCE_ID,
             {'values': [1, 2]}
         )

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -13,7 +13,7 @@ from stripe.six.moves.urllib.error import HTTPError
 from tests.request_mock import RequestMock
 
 
-MOCK_MINIMUM_VERSION = '0.11.2'
+MOCK_MINIMUM_VERSION = '0.12.0'
 MOCK_PORT = os.environ.get('STRIPE_MOCK_PORT', 12111)
 
 


### PR DESCRIPTION
cc @stripe/api-libraries 

Bump stripe-mock to 0.12.0. I had to update a few tests to account for https://github.com/stripe/stripe-mock/issues/61.

