### PR TITLE
Support for flexible billing and usage records

### DIFF
--- a/stripe/api_resources/__init__.py
+++ b/stripe/api_resources/__init__.py
@@ -45,3 +45,4 @@ from stripe.api_resources.three_d_secure import ThreeDSecure
 from stripe.api_resources.token import Token
 from stripe.api_resources.topup import Topup
 from stripe.api_resources.transfer import Transfer
+from stripe.api_resources.usage_record import UsageRecord

--- a/stripe/api_resources/usage_record.py
+++ b/stripe/api_resources/usage_record.py
@@ -1,0 +1,26 @@
+from __future__ import absolute_import, division, print_function
+
+from stripe.api_resources.abstract.api_resource import APIResource
+from stripe import api_requestor, util
+
+
+class UsageRecord(APIResource):
+    OBJECT_NAME = 'usage_record'
+
+    @classmethod
+    def create(cls, api_key=None, idempotency_key=None,
+               stripe_version=None, stripe_account=None, **params):
+        if 'subscription_item' not in params:
+            raise ValueError("Params must have a subscription_item key")
+
+        subscription_item = params.pop('subscription_item')
+
+        requestor = api_requestor.APIRequestor(api_key,
+                                               api_version=stripe_version,
+                                               account=stripe_account)
+        url = "/v1/subscription_items/%s/usage_records" % subscription_item
+        headers = util.populate_headers(idempotency_key)
+        response, api_key = requestor.request('post', url, params, headers)
+
+        return util.convert_to_stripe_object(response, api_key, stripe_version,
+                                             stripe_account)

--- a/stripe/util.py
+++ b/stripe/util.py
@@ -218,6 +218,7 @@ def load_object_classes():
         api_resources.Token.OBJECT_NAME: api_resources.Token,
         api_resources.Topup.OBJECT_NAME: api_resources.Topup,
         api_resources.Transfer.OBJECT_NAME: api_resources.Transfer,
+        api_resources.UsageRecord.OBJECT_NAME: api_resources.UsageRecord,
     }
 
 

--- a/tests/api_resources/test_usage_record.py
+++ b/tests/api_resources/test_usage_record.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import, division, print_function
+
+import stripe
+from tests.helper import StripeTestCase
+
+
+TEST_SUBSCRIPTION_ITEM_ID = 'si_123'
+
+
+class UsageRecordTest(StripeTestCase):
+    def test_is_creatable(self):
+        resource = stripe.UsageRecord.create(
+            subscription_item=TEST_SUBSCRIPTION_ITEM_ID,
+            quantity=5000,
+            timestamp=1524182400,
+            action='increment',
+        )
+        self.assert_requested(
+            'post',
+            '/v1/subscription_items/%s/usage_records' % (
+                TEST_SUBSCRIPTION_ITEM_ID
+            )
+        )
+        self.assertIsInstance(resource, stripe.UsageRecord)
+
+    def test_raises_when_creating_without_subscription_item(self):
+        with self.assertRaises(ValueError):
+            stripe.UsageRecord.create(
+                quantity=5000,
+                timestamp=1524182400,
+                action='increment',
+            )


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @alexander-stripe 

Since stripe-python uses keyword arguments for request parameters, I simply added `subscription_item` as a a required argument to `UsageRecord.create()`.
