### PR TITLE
Add property accessor for error messages

### DIFF
--- a/stripe/error.py
+++ b/stripe/error.py
@@ -32,6 +32,10 @@ class StripeError(Exception):
         else:
             return self._message
 
+    @property
+    def plain_message(self):
+        return self._message
+
 
 class APIError(StripeError):
     pass

--- a/stripe/error.py
+++ b/stripe/error.py
@@ -33,7 +33,11 @@ class StripeError(Exception):
             return self._message
 
     @property
-    def plain_message(self):
+    def user_message(self):
+        # Returns the underlying Exception (base class) message,
+        # which was available in python2 via error.message. As
+        # opposed to str(error), this omits the Request ch_...
+        # prefix that is not end-user friendly.
         return self._message
 
 


### PR DESCRIPTION
In python3, it's no longer possible to do `error.message`.

The official python alternative of `str(error)` does not work with the stripe library because `__str__` is overridden and would print 
```
Request ch_ae7361827ab7: Your card was Declined.
``` 
which is not user-friendly. The three alternatives I've identified are
```python
error.args[0]
```
```python
error._message
```
```python
super(stripe.error.StripeError, error).__str__()
```
none of which are super elegant. This PR would allow
```python
error.plain_message
```
instead. Happy to rename it to something else too.