### PR TITLE
Adds a couple more error assertions for Python 3

### DIFF
--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -13,15 +13,21 @@ class StripeErrorTests(StripeTestCase):
         self.assertEqual(u'öre', six.text_type(err))
         if six.PY2:
             self.assertEqual('\xc3\xb6re', str(err))
+        else:
+            self.assertEqual(u'öre', str(err))
 
     def test_formatting_with_request_id(self):
         err = StripeError(u'öre', headers={'request-id': '123'})
         self.assertEqual(u'Request 123: öre', six.text_type(err))
         if six.PY2:
             self.assertEqual('Request 123: \xc3\xb6re', str(err))
+        else:
+            self.assertEqual(u'Request 123: öre', str(err))
 
     def test_formatting_with_none(self):
         err = StripeError(None, headers={'request-id': '123'})
         self.assertEqual(u'Request 123: <empty message>', six.text_type(err))
         if six.PY2:
+            self.assertEqual('Request 123: <empty message>', str(err))
+        else:
             self.assertEqual('Request 123: <empty message>', str(err))


### PR DESCRIPTION
This is basically a no-op, but just adds a few more test case branches
for Python 3 to demonstrate what `str(...)` on an error should be
expected to return in that version (instead of just on Python 2).

r? @ob-stripe 