### PR TITLE
Handle the case where both error messages are None and request ids are None.

### DIFF
--- a/stripe/error.py
+++ b/stripe/error.py
@@ -26,11 +26,11 @@ class StripeError(Exception):
         self.request_id = self.headers.get('request-id', None)
 
     def __str__(self):
+        msg = self._message or "<empty message>"
         if self.request_id is not None:
-            msg = self._message or "<empty message>"
             return u"Request {0}: {1}".format(self.request_id, msg)
         else:
-            return self._message
+            return msg
 
     # Returns the underlying `Exception` (base class) message, which is usually
     # the raw message returned by Stripe's API. This was previously available

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -24,10 +24,18 @@ class StripeErrorTests(StripeTestCase):
         else:
             self.assertEqual(u'Request 123: öre', str(err))
 
-    def test_formatting_with_none(self):
+    def test_formatting_with_message_none_and_request_id(self):
         err = StripeError(None, headers={'request-id': '123'})
         self.assertEqual(u'Request 123: <empty message>', six.text_type(err))
         if six.PY2:
             self.assertEqual('Request 123: <empty message>', str(err))
         else:
             self.assertEqual('Request 123: <empty message>', str(err))
+
+    def test_formatting_with_message_none_and_request_id_none(self):
+        err = StripeError(None)
+        self.assertEqual(u'<empty message>', six.text_type(err))
+        if six.PY2:
+            self.assertEqual('<empty message>', str(err))
+        else:
+            self.assertEqual('<empty message>', str(err))


### PR DESCRIPTION
https://github.com/stripe/stripe-python/pull/196 fixed this TypeError for
when request_id is set and message is None, but it didn't handle the
case where both were None.