### PR TITLE
Fix some parameters being sent in tests

### DIFF
--- a/tests/api_resources/test_account.py
+++ b/tests/api_resources/test_account.py
@@ -52,22 +52,26 @@ class AccountTest(StripeTestCase):
         # stripe-mock does not return additional owners so we construct
         account = stripe.Account.construct_from({
             'id': '%s' % TEST_RESOURCE_ID,
-            'additional_owners': [{
-                'first_name': 'name',
-                'verification': {},
-            }]
+            'legal_entity': {
+                'additional_owners': [{
+                    'first_name': 'name',
+                    'verification': {},
+                }],
+            }
         }, stripe.api_key)
-        owner = account.additional_owners[0]
+        owner = account.legal_entity.additional_owners[0]
         owner.verification.document = 'file_foo'
         resource = account.save()
         self.assert_requested(
             'post',
             '/v1/accounts/%s' % TEST_RESOURCE_ID,
             {
-                'additional_owners': {
-                    '0': {
-                        'verification': {
-                            'document': 'file_foo',
+                'legal_entity': {
+                    'additional_owners': {
+                        '0': {
+                            'verification': {
+                                'document': 'file_foo',
+                            },
                         },
                     },
                 },

--- a/tests/api_resources/test_subscription.py
+++ b/tests/api_resources/test_subscription.py
@@ -28,7 +28,6 @@ class SubscriptionTest(StripeTestCase):
     def test_is_creatable(self):
         resource = stripe.Subscription.create(
             customer='cus_123',
-            plan='plan'
         )
         self.assert_requested(
             'post',


### PR DESCRIPTION
Fixes one parameter being sent so that the suite is compliant with a
version of stripe-mock that's checking for extra parameters.

See https://github.com/stripe/stripe-ruby/pull/650 as another sample
with more context.