### PR TITLE
Adds 'partner_id' property to set_app_info hash

### DIFF
--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -79,10 +79,11 @@ from stripe.util import (  # noqa
 # communicating with Stripe.
 #
 # Takes a name and optional version and plugin URL.
-def set_app_info(name, version=None, url=None):
+def set_app_info(name, partner_id=None, url=None, version=None):
     global app_info
     app_info = {
         'name': name,
-        'version': version,
+        'partner_id': partner_id,
         'url': url,
+        'version': version,
     }

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -386,7 +386,8 @@ class APIRequestorRequestTests(StripeTestCase):
             stripe.set_app_info(
                 'MyAwesomePlugin',
                 url='https://myawesomeplugin.info',
-                version='1.2.34'
+                version='1.2.34',
+                partner_id='partner_12345',
             )
 
             self.mock_response('{}', 200)
@@ -400,6 +401,7 @@ class APIRequestorRequestTests(StripeTestCase):
                     'name': 'MyAwesomePlugin',
                     'url': 'https://myawesomeplugin.info',
                     'version': '1.2.34',
+                    'partner_id': 'partner_12345',
                 }
             )
             self.check_call('get', headers=header_matcher)


### PR DESCRIPTION
This adds support for an optional partner_id attribute in the SetAppInfo hash.