### PR TITLE
Fix serialization of nested `ListObject`s

### DIFF
--- a/tests/api_resources/test_list_object.py
+++ b/tests/api_resources/test_list_object.py
@@ -125,6 +125,19 @@ class ListObjectTests(StripeTestCase):
             json.loads(serialized), 'mykey')
         self.assertEqual(empty, deserialized)
 
+    def test_serialize_nested_empty_list(self):
+        empty = stripe.ListObject.construct_from({
+            'object': 'list',
+            'data': [],
+        }, 'mykey')
+        obj = stripe.stripe_object.StripeObject.construct_from({
+            'nested': empty,
+        }, 'mykey')
+        serialized = str(obj)
+        deserialized = stripe.StripeObject.construct_from(
+            json.loads(serialized), 'mykey')
+        self.assertEqual(empty, deserialized.nested)
+
 
 class AutoPagingTests(StripeTestCase):
 


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @sazlin

Another attempt at fixing the serialization of `ListObject`s, this time for good hopefully 🤞 

Before calling the JSON serializer, all `StripeObject`s are recursively converted into regular `dict`s, which should prevent any of our custom stuff from interfering with the serialization.

Fixes #440.
