### PR TITLE
Avoid duplicate dependency on requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     package_data={'stripe': ['data/ca-certificates.crt']},
     zip_safe=False,
     install_requires=[
-        'requests >= 2',
+        'requests >= 2; python_version >= "3.0"',
         'requests[security] >= 2; python_version < "3.0"',
     ],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",


### PR DESCRIPTION
The duplicate dependency is causing issues with pip on Python 2.7.

Context:
- https://github.com/stripe/stripe-python/issues/447
- https://github.com/pypa/pip/issues/4957

Fixes #447

----

Testing this:

- Ran `pip install .` in a python2.7 virtualenv in the root stripe-python folder
- Verified `python2.7 -c "import requests"` does not crash
- Installed pipdeptree and verified `requests` is not showing up twice:

```
pipdeptree==0.13.0
  - pip [required: >=6.0.0, installed: 10.0.1]
pyOpenSSL==18.0.0
  - cryptography [required: >=2.2.1, installed: 2.2.2]
    - asn1crypto [required: >=0.21.0, installed: 0.24.0]
    - cffi [required: >=1.7, installed: 1.11.5]
      - pycparser [required: Any, installed: 2.18]
    - enum34 [required: Any, installed: 1.1.6]
    - idna [required: >=2.1, installed: 2.7]
    - ipaddress [required: Any, installed: 1.0.22]
    - six [required: >=1.4.1, installed: 1.11.0]
  - six [required: >=1.5.2, installed: 1.11.0]
setuptools==40.0.0
stripe==2.0.1
  - requests [required: >=2, installed: 2.19.1]
    - certifi [required: >=2017.4.17, installed: 2018.4.16]
    - chardet [required: >=3.0.2,<3.1.0, installed: 3.0.4]
    - idna [required: >=2.5,<2.8, installed: 2.7]
    - urllib3 [required: >=1.21.1,<1.24, installed: 1.23]
wheel==0.31.1
```