### PR TITLE
Better `class_url` method

### DIFF
--- a/stripe/api_resources/abstract/api_resource.py
+++ b/stripe/api_resources/abstract/api_resource.py
@@ -18,17 +18,15 @@ class APIResource(StripeObject):
         return self
 
     @classmethod
-    def class_name(cls):
+    def class_url(cls):
         if cls == APIResource:
             raise NotImplementedError(
                 'APIResource is an abstract class.  You should perform '
                 'actions on its subclasses (e.g. Charge, Customer)')
-        return str(quote_plus(cls.__name__.lower()))
-
-    @classmethod
-    def class_url(cls):
-        cls_name = cls.class_name()
-        return "/v1/%ss" % (cls_name,)
+        # Namespaces are separated in object names with periods (.) and in URLs
+        # with forward slashes (/), so replace the former with the latter.
+        base = cls.OBJECT_NAME.replace('.', '/')
+        return "/v1/%ss" % (base,)
 
     def instance_url(self):
         id = self.get('id')

--- a/stripe/api_resources/abstract/singleton_api_resource.py
+++ b/stripe/api_resources/abstract/singleton_api_resource.py
@@ -11,8 +11,14 @@ class SingletonAPIResource(APIResource):
 
     @classmethod
     def class_url(cls):
-        cls_name = cls.class_name()
-        return "/v1/%s" % (cls_name,)
+        if cls == SingletonAPIResource:
+            raise NotImplementedError(
+                'SingletonAPIResource is an abstract class.  You should '
+                'perform actions on its subclasses (e.g. Balance)')
+        # Namespaces are separated in object names with periods (.) and in URLs
+        # with forward slashes (/), so replace the former with the latter.
+        base = cls.OBJECT_NAME.replace('.', '/')
+        return "/v1/%s" % (base,)
 
     def instance_url(self):
         return self.class_url()

--- a/stripe/api_resources/application_fee.py
+++ b/stripe/api_resources/application_fee.py
@@ -10,10 +10,6 @@ from stripe.api_resources.abstract import nested_resource_class_methods
 class ApplicationFee(ListableAPIResource):
     OBJECT_NAME = 'application_fee'
 
-    @classmethod
-    def class_name(cls):
-        return 'application_fee'
-
     def refund(self, idempotency_key=None, **params):
         headers = util.populate_headers(idempotency_key)
         url = self.instance_url() + '/refund'

--- a/stripe/api_resources/country_spec.py
+++ b/stripe/api_resources/country_spec.py
@@ -5,7 +5,3 @@ from stripe.api_resources import abstract
 
 class CountrySpec(abstract.ListableAPIResource):
     OBJECT_NAME = 'country_spec'
-
-    @classmethod
-    def class_name(cls):
-        return 'country_spec'

--- a/stripe/api_resources/ephemeral_key.py
+++ b/stripe/api_resources/ephemeral_key.py
@@ -8,10 +8,6 @@ class EphemeralKey(DeletableAPIResource):
     OBJECT_NAME = 'ephemeral_key'
 
     @classmethod
-    def class_name(cls):
-        return 'ephemeral_key'
-
-    @classmethod
     def create(cls, api_key=None, idempotency_key=None,
                stripe_version=None, stripe_account=None,
                **params):

--- a/stripe/api_resources/exchange_rate.py
+++ b/stripe/api_resources/exchange_rate.py
@@ -5,7 +5,3 @@ from stripe.api_resources.abstract import ListableAPIResource
 
 class ExchangeRate(ListableAPIResource):
     OBJECT_NAME = 'exchange_rate'
-
-    @classmethod
-    def class_name(cls):
-        return 'exchange_rate'

--- a/stripe/api_resources/file_upload.py
+++ b/stripe/api_resources/file_upload.py
@@ -13,8 +13,8 @@ class FileUpload(ListableAPIResource):
         return stripe.upload_api_base
 
     @classmethod
-    def class_name(cls):
-        return 'file'
+    def class_url(cls):
+        return '/v1/files'
 
     @classmethod
     def create(cls, api_key=None, api_version=None, stripe_account=None,

--- a/stripe/api_resources/issuer_fraud_record.py
+++ b/stripe/api_resources/issuer_fraud_record.py
@@ -3,7 +3,3 @@ from stripe.api_resources.abstract import ListableAPIResource
 
 class IssuerFraudRecord(ListableAPIResource):
     OBJECT_NAME = 'issuer_fraud_record'
-
-    @classmethod
-    def class_name(cls):
-        return 'issuer_fraud_record'

--- a/stripe/api_resources/order_return.py
+++ b/stripe/api_resources/order_return.py
@@ -5,7 +5,3 @@ from stripe.api_resources.abstract import ListableAPIResource
 
 class OrderReturn(ListableAPIResource):
     OBJECT_NAME = 'order_return'
-
-    @classmethod
-    def class_url(cls):
-        return '/v1/order_returns'

--- a/stripe/api_resources/payment_intent.py
+++ b/stripe/api_resources/payment_intent.py
@@ -10,10 +10,6 @@ class PaymentIntent(CreateableAPIResource, UpdateableAPIResource,
                     ListableAPIResource):
     OBJECT_NAME = 'payment_intent'
 
-    @classmethod
-    def class_name(cls):
-        return 'payment_intent'
-
     def cancel(self, idempotency_key=None, **params):
         url = self.instance_url() + '/cancel'
         headers = util.populate_headers(idempotency_key)

--- a/stripe/api_resources/subscription_item.py
+++ b/stripe/api_resources/subscription_item.py
@@ -9,7 +9,3 @@ from stripe.api_resources.abstract import ListableAPIResource
 class SubscriptionItem(CreateableAPIResource, DeletableAPIResource,
                        UpdateableAPIResource, ListableAPIResource):
     OBJECT_NAME = 'subscription_item'
-
-    @classmethod
-    def class_name(cls):
-        return 'subscription_item'

--- a/tests/api_resources/abstract/test_api_resource.py
+++ b/tests/api_resources/abstract/test_api_resource.py
@@ -7,7 +7,7 @@ import stripe
 
 class TestAPIResource(object):
     class MyResource(stripe.api_resources.abstract.APIResource):
-        pass
+        OBJECT_NAME = 'myresource'
 
     def test_retrieve_and_refresh(self, request_mock):
         url = '/v1/myresources/foo%2A'

--- a/tests/api_resources/abstract/test_createable_api_resource.py
+++ b/tests/api_resources/abstract/test_createable_api_resource.py
@@ -5,7 +5,7 @@ import stripe
 
 class TestCreateableAPIResource(object):
     class MyCreatable(stripe.api_resources.abstract.CreateableAPIResource):
-        pass
+        OBJECT_NAME = 'mycreatable'
 
     def test_create(self, request_mock):
         request_mock.stub_request(

--- a/tests/api_resources/abstract/test_deletable_api_resource.py
+++ b/tests/api_resources/abstract/test_deletable_api_resource.py
@@ -5,7 +5,7 @@ import stripe
 
 class TestDeletableAPIResource(object):
     class MyDeletable(stripe.api_resources.abstract.DeletableAPIResource):
-        pass
+        OBJECT_NAME = 'mydeletable'
 
     def test_delete(self, request_mock):
         request_mock.stub_request(

--- a/tests/api_resources/abstract/test_listable_api_resource.py
+++ b/tests/api_resources/abstract/test_listable_api_resource.py
@@ -5,7 +5,7 @@ import stripe
 
 class TestListableAPIResource(object):
     class MyListable(stripe.api_resources.abstract.ListableAPIResource):
-        pass
+        OBJECT_NAME = 'mylistable'
 
     def test_all(self, request_mock):
         request_mock.stub_request(

--- a/tests/api_resources/abstract/test_nested_resource_class_methods.py
+++ b/tests/api_resources/abstract/test_nested_resource_class_methods.py
@@ -9,7 +9,7 @@ class TestNestedResourceClassMethods(object):
         operations=['create', 'retrieve', 'update', 'delete', 'list']
     )
     class MainResource(stripe.api_resources.abstract.APIResource):
-        pass
+        OBJECT_NAME = 'mainresource'
 
     def test_create_nested(self, request_mock):
         request_mock.stub_request(

--- a/tests/api_resources/abstract/test_singleton_api_resource.py
+++ b/tests/api_resources/abstract/test_singleton_api_resource.py
@@ -5,7 +5,7 @@ import stripe
 
 class TestSingletonAPIResource(object):
     class MySingleton(stripe.api_resources.abstract.SingletonAPIResource):
-        pass
+        OBJECT_NAME = 'mysingleton'
 
     def test_retrieve(self, request_mock):
         request_mock.stub_request(

--- a/tests/api_resources/abstract/test_updateable_api_resource.py
+++ b/tests/api_resources/abstract/test_updateable_api_resource.py
@@ -7,7 +7,7 @@ import stripe
 
 class TestUpdateableAPIResource(object):
     class MyUpdateable(stripe.api_resources.abstract.UpdateableAPIResource):
-        pass
+        OBJECT_NAME = 'myupdateable'
 
     @pytest.fixture
     def obj(self, request_mock):


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Removes `class_name` and updates `class_url` to use `OBJECT_NAME`. Like https://github.com/stripe/stripe-php/pull/498 and https://github.com/stripe/stripe-ruby/pull/663.
