### PR TITLE
Add InvoiceLineItem class

### DIFF
--- a/stripe/api_resources/__init__.py
+++ b/stripe/api_resources/__init__.py
@@ -26,6 +26,7 @@ from stripe.api_resources.exchange_rate import ExchangeRate
 from stripe.api_resources.file_upload import FileUpload
 from stripe.api_resources.invoice import Invoice
 from stripe.api_resources.invoice_item import InvoiceItem
+from stripe.api_resources.invoice_line_item import InvoiceLineItem
 from stripe.api_resources.issuer_fraud_record import IssuerFraudRecord
 from stripe.api_resources.login_link import LoginLink
 from stripe.api_resources.order import Order

--- a/stripe/api_resources/invoice_line_item.py
+++ b/stripe/api_resources/invoice_line_item.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import, division, print_function
+
+from stripe.stripe_object import StripeObject
+
+
+class InvoiceLineItem(StripeObject):
+    OBJECT_NAME = 'line_item'

--- a/stripe/util.py
+++ b/stripe/util.py
@@ -165,6 +165,8 @@ def load_object_classes():
         api_resources.FileUpload.OBJECT_NAME: api_resources.FileUpload,
         api_resources.Invoice.OBJECT_NAME: api_resources.Invoice,
         api_resources.InvoiceItem.OBJECT_NAME: api_resources.InvoiceItem,
+        api_resources.InvoiceLineItem.OBJECT_NAME:
+            api_resources.InvoiceLineItem,
         api_resources.IssuerFraudRecord.OBJECT_NAME:
             api_resources.IssuerFraudRecord,
         api_resources.LoginLink.OBJECT_NAME: api_resources.LoginLink,

--- a/tests/api_resources/test_invoice_item.py
+++ b/tests/api_resources/test_invoice_item.py
@@ -1,0 +1,69 @@
+from __future__ import absolute_import, division, print_function
+
+import stripe
+
+
+TEST_RESOURCE_ID = 'ii_123'
+
+
+class TestInvoiceItem(object):
+    def test_is_listable(self, request_mock):
+        resources = stripe.InvoiceItem.list()
+        request_mock.assert_requested(
+            'get',
+            '/v1/invoiceitems'
+        )
+        assert isinstance(resources.data, list)
+        assert isinstance(resources.data[0], stripe.InvoiceItem)
+
+    def test_is_retrievable(self, request_mock):
+        resource = stripe.InvoiceItem.retrieve(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            'get',
+            '/v1/invoiceitems/%s' % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.InvoiceItem)
+
+    def test_is_creatable(self, request_mock):
+        resource = stripe.InvoiceItem.create(
+            customer='cus_123',
+            amount=123,
+            currency='usd'
+        )
+        request_mock.assert_requested(
+            'post',
+            '/v1/invoiceitems'
+        )
+        assert isinstance(resource, stripe.InvoiceItem)
+
+    def test_is_saveable(self, request_mock):
+        resource = stripe.InvoiceItem.retrieve(TEST_RESOURCE_ID)
+        resource.metadata['key'] = 'value'
+        resource.save()
+        request_mock.assert_requested(
+            'post',
+            '/v1/invoiceitems/%s' % resource.id
+        )
+
+    def test_is_modifiable(self, request_mock):
+        resource = stripe.InvoiceItem.modify(
+            TEST_RESOURCE_ID,
+            metadata={'key': 'value'}
+        )
+        request_mock.assert_requested(
+            'post',
+            '/v1/invoiceitems/%s' % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.InvoiceItem)
+
+    def test_is_deletable(self, request_mock):
+        resource = stripe.InvoiceItem.retrieve(TEST_RESOURCE_ID)
+        # Unfortunately stripe-mock will return a resource with a different
+        # ID, so we need to store the original ID for the request assertion
+        resource_id = resource.id
+        resource.delete()
+        request_mock.assert_requested(
+            'delete',
+            '/v1/invoiceitems/%s' % resource_id
+        )
+        assert resource.deleted is True

--- a/tests/api_resources/test_invoice_line_item.py
+++ b/tests/api_resources/test_invoice_line_item.py
@@ -1,0 +1,13 @@
+from __future__ import absolute_import, division, print_function
+
+import stripe
+
+
+TEST_INVOICE_ID = 'in_123'
+
+
+class TestInvoiceLineItem(object):
+    def test_deserialize(self, request_mock):
+        invoice = stripe.Invoice.retrieve(TEST_INVOICE_ID)
+        assert isinstance(invoice.lines.data, list)
+        assert isinstance(invoice.lines.data[0], stripe.InvoiceLineItem)


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries @jleclanche 

Adds an `InvoiceLineItem` class for invoice line items. The class derives from `StripeObject` instead of `ApiResource` as there are no API methods (similar to e.g. `SourceTransaction`).

Added a basic deserialization test.

Opportunistically added some tests for `InvoiceItem`, because apparently we didn't have any.

Fixes #451.
