### PR TITLE
Add support for ScheduledQueryRun

### DIFF
--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -26,6 +26,7 @@ log = None
 # API resources
 from stripe.api_resources import *  # noqa
 from stripe.api_resources import issuing  # noqa
+from stripe.api_resources import sigma  # noqa
 
 # OAuth
 from stripe.oauth import OAuth  # noqa

--- a/stripe/api_resources/sigma/__init__.py
+++ b/stripe/api_resources/sigma/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
+# flake8: noqa
+
+from stripe.api_resources.sigma.scheduled_query_run import ScheduledQueryRun

--- a/stripe/api_resources/sigma/scheduled_query_run.py
+++ b/stripe/api_resources/sigma/scheduled_query_run.py
@@ -1,0 +1,11 @@
+from __future__ import absolute_import, division, print_function
+
+from stripe.api_resources.abstract import ListableAPIResource
+
+
+class ScheduledQueryRun(ListableAPIResource):
+    OBJECT_NAME = 'scheduled_query_run'
+
+    @classmethod
+    def class_url(cls):
+        return '/v1/sigma/scheduled_query_runs'

--- a/stripe/util.py
+++ b/stripe/util.py
@@ -192,6 +192,8 @@ def load_object_classes():
             api_resources.RecipientTransfer,
         api_resources.Refund.OBJECT_NAME: api_resources.Refund,
         api_resources.Reversal.OBJECT_NAME: api_resources.Reversal,
+        api_resources.sigma.ScheduledQueryRun.OBJECT_NAME:
+            api_resources.sigma.ScheduledQueryRun,
         api_resources.SKU.OBJECT_NAME: api_resources.SKU,
         api_resources.Source.OBJECT_NAME: api_resources.Source,
         api_resources.SourceTransaction.OBJECT_NAME:

--- a/tests/api_resources/sigma/test_scheduled_query_run.py
+++ b/tests/api_resources/sigma/test_scheduled_query_run.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import, division, print_function
+
+import stripe
+
+
+TEST_RESOURCE_ID = 'sqr_123'
+
+
+class TestTransaction(object):
+    FIXTURE = {
+        'id': TEST_RESOURCE_ID,
+        'object': 'scheduled_query_run'
+    }
+
+    def test_is_listable(self, request_mock):
+        request_mock.stub_request(
+            'get',
+            '/v1/sigma/scheduled_query_runs',
+            {
+                'object': 'list',
+                'data': [self.FIXTURE],
+            }
+        )
+        resources = stripe.sigma.ScheduledQueryRun.list()
+        request_mock.assert_requested(
+            'get',
+            '/v1/sigma/scheduled_query_runs'
+        )
+        assert isinstance(resources.data, list)
+        assert isinstance(resources.data[0], stripe.sigma.ScheduledQueryRun)
+
+    def test_is_retrievable(self, request_mock):
+        request_mock.stub_request(
+            'get',
+            '/v1/sigma/scheduled_query_runs/%s' % TEST_RESOURCE_ID,
+            {
+                'id': '%s' % TEST_RESOURCE_ID,
+                'object': 'scheduled_query_run'
+            }
+        )
+        resource = stripe.sigma.ScheduledQueryRun.retrieve(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            'get',
+            '/v1/sigma/scheduled_query_runs/%s' % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.sigma.ScheduledQueryRun)


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries 

This fixes https://github.com/stripe/stripe-python/issues/454