### PR TITLE
Fix multiple tests after stripe-mock updates

### DIFF
--- a/tests/api_resources/issuing/test_authorization.py
+++ b/tests/api_resources/issuing/test_authorization.py
@@ -41,7 +41,7 @@ class TestAuthorization(object):
         authorization = resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/issuing/authorizations/%s' % resource.id
+            '/v1/issuing/authorizations/%s' % TEST_RESOURCE_ID
         )
         assert isinstance(resource, stripe.issuing.Authorization)
         assert resource is authorization

--- a/tests/api_resources/issuing/test_card.py
+++ b/tests/api_resources/issuing/test_card.py
@@ -52,7 +52,7 @@ class TestCard(object):
         card = resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/issuing/cards/%s' % resource.id
+            '/v1/issuing/cards/%s' % TEST_RESOURCE_ID
         )
         assert isinstance(resource, stripe.issuing.Card)
         assert resource is card
@@ -62,6 +62,6 @@ class TestCard(object):
         card_details = resource.details()
         request_mock.assert_requested(
             'get',
-            '/v1/issuing/cards/%s/details' % resource.id
+            '/v1/issuing/cards/%s/details' % TEST_RESOURCE_ID
         )
         assert isinstance(card_details, stripe.issuing.CardDetails)

--- a/tests/api_resources/issuing/test_cardholder.py
+++ b/tests/api_resources/issuing/test_cardholder.py
@@ -60,7 +60,7 @@ class TestCardholder(object):
         cardholder = resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/issuing/cardholders/%s' % resource.id
+            '/v1/issuing/cardholders/%s' % TEST_RESOURCE_ID
         )
         assert isinstance(resource, stripe.issuing.Cardholder)
         assert resource is cardholder

--- a/tests/api_resources/issuing/test_dispute.py
+++ b/tests/api_resources/issuing/test_dispute.py
@@ -52,7 +52,7 @@ class TestDispute(object):
         dispute = resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/issuing/disputes/%s' % resource.id
+            '/v1/issuing/disputes/%s' % TEST_RESOURCE_ID
         )
         assert isinstance(resource, stripe.issuing.Dispute)
         assert resource is dispute

--- a/tests/api_resources/issuing/test_transaction.py
+++ b/tests/api_resources/issuing/test_transaction.py
@@ -41,7 +41,7 @@ class TestTransaction(object):
         transaction = resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/issuing/transactions/%s' % resource.id
+            '/v1/issuing/transactions/%s' % TEST_RESOURCE_ID
         )
         assert isinstance(resource, stripe.issuing.Transaction)
         assert resource is transaction

--- a/tests/api_resources/test_account.py
+++ b/tests/api_resources/test_account.py
@@ -42,7 +42,7 @@ class TestAccount(object):
         resource = account.save()
         request_mock.assert_requested(
             'post',
-            '/v1/accounts/%s' % resource.id
+            '/v1/accounts/%s' % TEST_RESOURCE_ID
         )
         assert isinstance(resource, stripe.Account)
         assert resource is account
@@ -92,13 +92,10 @@ class TestAccount(object):
 
     def test_is_deletable(self, request_mock):
         resource = stripe.Account.retrieve(TEST_RESOURCE_ID)
-        # Unfortunately stripe-mock will return a resource with a different
-        # ID, so we need to store the original ID for the request assertion
-        resource_id = resource.id
         resource.delete()
         request_mock.assert_requested(
             'delete',
-            '/v1/accounts/%s' % resource_id
+            '/v1/accounts/%s' % TEST_RESOURCE_ID
         )
         assert resource.deleted is True
 

--- a/tests/api_resources/test_apple_pay_domain.py
+++ b/tests/api_resources/test_apple_pay_domain.py
@@ -36,12 +36,9 @@ class TestApplePayDomain(object):
 
     def test_is_deletable(self, request_mock):
         resource = stripe.ApplePayDomain.retrieve(TEST_RESOURCE_ID)
-        # Unfortunately stripe-mock will return a resource with a different
-        # ID, so we need to store the original ID for the request assertion
-        resource_id = resource.id
         resource.delete()
         request_mock.assert_requested(
             'delete',
-            '/v1/apple_pay/domains/%s' % resource_id
+            '/v1/apple_pay/domains/%s' % TEST_RESOURCE_ID
         )
         assert resource.deleted is True

--- a/tests/api_resources/test_application_fee_refund.py
+++ b/tests/api_resources/test_application_fee_refund.py
@@ -17,8 +17,8 @@ class TestApplicationFeeRefund(object):
         resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/application_fees/%s/refunds/%s' % (resource.fee,
-                                                    resource.id)
+            '/v1/application_fees/%s/refunds/%s' % (TEST_APPFEE_ID,
+                                                    TEST_RESOURCE_ID)
         )
 
     def test_is_modifiable(self, request_mock):

--- a/tests/api_resources/test_bank_account.py
+++ b/tests/api_resources/test_bank_account.py
@@ -58,8 +58,7 @@ class TestBankAccountTest(object):
             'delete',
             '/v1/customers/cus_123/sources/%s' % TEST_RESOURCE_ID
         )
-        # stripe-mock does not yet correctly handle deleting customer sources
-        # assert resource.deleted is True
+        assert resource.deleted is True
 
     def test_is_verifiable(self, request_mock):
         resource = self.construct_resource(customer='cus_123')

--- a/tests/api_resources/test_charge.py
+++ b/tests/api_resources/test_charge.py
@@ -42,7 +42,7 @@ class TestCharge(object):
         resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/charges/%s' % resource.id
+            '/v1/charges/%s' % TEST_RESOURCE_ID
         )
 
     def test_is_modifiable(self, request_mock):

--- a/tests/api_resources/test_coupon.py
+++ b/tests/api_resources/test_coupon.py
@@ -43,7 +43,7 @@ class TestCoupon(object):
         resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/coupons/%s' % resource.id
+            '/v1/coupons/%s' % TEST_RESOURCE_ID
         )
 
     def test_is_modifiable(self, request_mock):
@@ -59,12 +59,9 @@ class TestCoupon(object):
 
     def test_is_deletable(self, request_mock):
         resource = stripe.Coupon.retrieve(TEST_RESOURCE_ID)
-        # Unfortunately stripe-mock will return a resource with a different
-        # ID, so we need to store the original ID for the request assertion
-        resource_id = resource.id
         resource.delete()
         request_mock.assert_requested(
             'delete',
-            '/v1/coupons/%s' % resource_id
+            '/v1/coupons/%s' % TEST_RESOURCE_ID
         )
         assert resource.deleted is True

--- a/tests/api_resources/test_customer.py
+++ b/tests/api_resources/test_customer.py
@@ -40,7 +40,7 @@ class TestCustomer(object):
         resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/customers/%s' % resource.id
+            '/v1/customers/%s' % TEST_RESOURCE_ID
         )
 
     def test_is_modifiable(self, request_mock):
@@ -56,13 +56,10 @@ class TestCustomer(object):
 
     def test_is_deletable(self, request_mock):
         resource = stripe.Customer.retrieve(TEST_RESOURCE_ID)
-        # Unfortunately stripe-mock will return a resource with a different
-        # ID, so we need to store the original ID for the request assertion
-        resource_id = resource.id
         resource.delete()
         request_mock.assert_requested(
             'delete',
-            '/v1/customers/%s' % resource_id
+            '/v1/customers/%s' % TEST_RESOURCE_ID
         )
         assert resource.deleted is True
 
@@ -71,7 +68,7 @@ class TestCustomer(object):
         resource.delete_discount()
         request_mock.assert_requested(
             'delete',
-            '/v1/customers/%s/discount' % resource.id
+            '/v1/customers/%s/discount' % TEST_RESOURCE_ID
         )
 
 

--- a/tests/api_resources/test_dispute.py
+++ b/tests/api_resources/test_dispute.py
@@ -30,7 +30,7 @@ class TestDispute(object):
         resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/disputes/%s' % resource.id
+            '/v1/disputes/%s' % TEST_RESOURCE_ID
         )
 
     def test_is_modifiable(self, request_mock):
@@ -49,5 +49,5 @@ class TestDispute(object):
         resource.close()
         request_mock.assert_requested(
             'post',
-            '/v1/disputes/%s/close' % resource.id
+            '/v1/disputes/%s/close' % TEST_RESOURCE_ID
         )

--- a/tests/api_resources/test_invoice.py
+++ b/tests/api_resources/test_invoice.py
@@ -40,7 +40,7 @@ class TestInvoice(object):
         resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/invoices/%s' % resource.id
+            '/v1/invoices/%s' % TEST_RESOURCE_ID
         )
 
     def test_is_modifiable(self, request_mock):
@@ -59,7 +59,7 @@ class TestInvoice(object):
         resource = resource.pay()
         request_mock.assert_requested(
             'post',
-            '/v1/invoices/%s/pay' % resource.id
+            '/v1/invoices/%s/pay' % TEST_RESOURCE_ID
         )
         assert isinstance(resource, stripe.Invoice)
 

--- a/tests/api_resources/test_invoice_item.py
+++ b/tests/api_resources/test_invoice_item.py
@@ -42,7 +42,7 @@ class TestInvoiceItem(object):
         resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/invoiceitems/%s' % resource.id
+            '/v1/invoiceitems/%s' % TEST_RESOURCE_ID
         )
 
     def test_is_modifiable(self, request_mock):
@@ -58,12 +58,9 @@ class TestInvoiceItem(object):
 
     def test_is_deletable(self, request_mock):
         resource = stripe.InvoiceItem.retrieve(TEST_RESOURCE_ID)
-        # Unfortunately stripe-mock will return a resource with a different
-        # ID, so we need to store the original ID for the request assertion
-        resource_id = resource.id
         resource.delete()
         request_mock.assert_requested(
             'delete',
-            '/v1/invoiceitems/%s' % resource_id
+            '/v1/invoiceitems/%s' % TEST_RESOURCE_ID
         )
         assert resource.deleted is True

--- a/tests/api_resources/test_order.py
+++ b/tests/api_resources/test_order.py
@@ -40,7 +40,7 @@ class TestOrder(object):
         resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/orders/%s' % resource.id
+            '/v1/orders/%s' % TEST_RESOURCE_ID
         )
 
     def test_is_modifiable(self, request_mock):

--- a/tests/api_resources/test_payment_intent.py
+++ b/tests/api_resources/test_payment_intent.py
@@ -55,7 +55,7 @@ class TestPaymentIntent(object):
         resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/payment_intents/%s' % resource.id,
+            '/v1/payment_intents/%s' % TEST_RESOURCE_ID,
             {'metadata': {'key': 'value'}}
         )
         assert isinstance(resource, stripe.PaymentIntent)

--- a/tests/api_resources/test_payout.py
+++ b/tests/api_resources/test_payout.py
@@ -41,7 +41,7 @@ class TestPayout(object):
         resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/payouts/%s' % resource.id
+            '/v1/payouts/%s' % TEST_RESOURCE_ID
         )
 
     def test_is_modifiable(self, request_mock):

--- a/tests/api_resources/test_plan.py
+++ b/tests/api_resources/test_plan.py
@@ -44,7 +44,7 @@ class TestPlan(object):
         resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/plans/%s' % resource.id
+            '/v1/plans/%s' % TEST_RESOURCE_ID
         )
 
     def test_is_modifiable(self, request_mock):
@@ -60,12 +60,9 @@ class TestPlan(object):
 
     def test_is_deletable(self, request_mock):
         resource = stripe.Plan.retrieve(TEST_RESOURCE_ID)
-        # Unfortunately stripe-mock will return a resource with a different
-        # ID, so we need to store the original ID for the request assertion
-        resource_id = resource.id
         resource.delete()
         request_mock.assert_requested(
             'delete',
-            '/v1/plans/%s' % resource_id
+            '/v1/plans/%s' % TEST_RESOURCE_ID
         )
         assert resource.deleted is True

--- a/tests/api_resources/test_product.py
+++ b/tests/api_resources/test_product.py
@@ -41,7 +41,7 @@ class TestProduct(object):
         resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/products/%s' % resource.id
+            '/v1/products/%s' % TEST_RESOURCE_ID
         )
 
     def test_is_modifiable(self, request_mock):
@@ -57,12 +57,9 @@ class TestProduct(object):
 
     def test_is_deletable(self, request_mock):
         resource = stripe.Product.retrieve(TEST_RESOURCE_ID)
-        # Unfortunately stripe-mock will return a resource with a different
-        # ID, so we need to store the original ID for the request assertion
-        resource_id = resource.id
         resource.delete()
         request_mock.assert_requested(
             'delete',
-            '/v1/products/%s' % resource_id
+            '/v1/products/%s' % TEST_RESOURCE_ID
         )
         assert resource.deleted is True

--- a/tests/api_resources/test_recipient.py
+++ b/tests/api_resources/test_recipient.py
@@ -41,7 +41,7 @@ class TestRecipient(object):
         resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/recipients/%s' % resource.id
+            '/v1/recipients/%s' % TEST_RESOURCE_ID
         )
 
     def test_is_modifiable(self, request_mock):
@@ -57,12 +57,9 @@ class TestRecipient(object):
 
     def test_is_deletable(self, request_mock):
         resource = stripe.Recipient.retrieve(TEST_RESOURCE_ID)
-        # Unfortunately stripe-mock will return a resource with a different
-        # ID, so we need to store the original ID for the request assertion
-        resource_id = resource.id
         resource.delete()
         request_mock.assert_requested(
             'delete',
-            '/v1/recipients/%s' % resource_id
+            '/v1/recipients/%s' % TEST_RESOURCE_ID
         )
         assert resource.deleted is True

--- a/tests/api_resources/test_refund.py
+++ b/tests/api_resources/test_refund.py
@@ -40,7 +40,7 @@ class TestRefund(object):
         resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/refunds/%s' % resource.id
+            '/v1/refunds/%s' % TEST_RESOURCE_ID
         )
 
     def test_is_modifiable(self, request_mock):

--- a/tests/api_resources/test_reversal.py
+++ b/tests/api_resources/test_reversal.py
@@ -34,8 +34,6 @@ class TestReversal(object):
         with pytest.raises(NotImplementedError):
             stripe.Reversal.retrieve(TEST_RESOURCE_ID)
 
-    # We don't use stripe-mock as the reversal returned has a transfer id that
-    # is different from the transfer used to access the reversal
     def test_is_saveable(self, request_mock):
         resource = self.construct_resource()
         resource.metadata['key'] = 'value'

--- a/tests/api_resources/test_sku.py
+++ b/tests/api_resources/test_sku.py
@@ -46,7 +46,7 @@ class TestSKU(object):
         resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/skus/%s' % resource.id
+            '/v1/skus/%s' % TEST_RESOURCE_ID
         )
 
     def test_is_modifiable(self, request_mock):
@@ -62,12 +62,9 @@ class TestSKU(object):
 
     def test_is_deletable(self, request_mock):
         resource = stripe.SKU.retrieve(TEST_RESOURCE_ID)
-        # Unfortunately stripe-mock will return a resource with a different
-        # ID, so we need to store the original ID for the request assertion
-        resource_id = resource.id
         resource.delete()
         request_mock.assert_requested(
             'delete',
-            '/v1/skus/%s' % resource_id
+            '/v1/skus/%s' % TEST_RESOURCE_ID
         )
         assert resource.deleted is True

--- a/tests/api_resources/test_source.py
+++ b/tests/api_resources/test_source.py
@@ -34,7 +34,7 @@ class TestSource(object):
         resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/sources/%s' % resource.id
+            '/v1/sources/%s' % TEST_RESOURCE_ID
         )
 
     def test_is_modifiable(self, request_mock):

--- a/tests/api_resources/test_subscription.py
+++ b/tests/api_resources/test_subscription.py
@@ -40,7 +40,7 @@ class TestSubscription(object):
         resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/subscriptions/%s' % resource.id
+            '/v1/subscriptions/%s' % TEST_RESOURCE_ID
         )
 
     def test_is_modifiable(self, request_mock):
@@ -59,7 +59,7 @@ class TestSubscription(object):
         resource.delete()
         request_mock.assert_requested(
             'delete',
-            '/v1/subscriptions/%s' % resource.id
+            '/v1/subscriptions/%s' % TEST_RESOURCE_ID
         )
         assert isinstance(resource, stripe.Subscription)
 

--- a/tests/api_resources/test_subscription.py
+++ b/tests/api_resources/test_subscription.py
@@ -112,23 +112,22 @@ class TestSubscription(object):
         )
         assert isinstance(resource, stripe.Subscription)
 
-    # TODO: Fix this test
-    # def test_is_saveable_with_items(self):
-    #    resource = stripe.Subscription.retrieve(TEST_RESOURCE_ID)
-    #    resource.items = [{"id": "si", "plan": "foo"}]
-    #    resource.save()
-    #    request_mock.assert_requested(
-    #        'post',
-    #        '/v1/subscriptions/%s' % TEST_RESOURCE_ID,
-    #        {
-    #            'items': {
-    #                "0": {
-    #                    "plan": "foo",
-    #                    "id": "si"
-    #                },
-    #            },
-    #        },
-    #    )
-    #    assert isinstance(resource, stripe.Subscription)
+    def test_is_saveable_with_items(self, request_mock):
+        resource = stripe.Subscription.retrieve(TEST_RESOURCE_ID)
+        resource.items = [{"id": "si", "plan": "foo"}]
+        resource.save()
+        request_mock.assert_requested(
+            'post',
+            '/v1/subscriptions/%s' % TEST_RESOURCE_ID,
+            {
+                'items': {
+                    "0": {
+                        "plan": "foo",
+                        "id": "si"
+                    },
+                },
+            },
+        )
+        assert isinstance(resource, stripe.Subscription)
 
     # TODO: Test serialize

--- a/tests/api_resources/test_subscription_item.py
+++ b/tests/api_resources/test_subscription_item.py
@@ -35,18 +35,17 @@ class TestSubscriptionItem(object):
         )
         assert isinstance(resource, stripe.SubscriptionItem)
 
-    # TODO: Fix this test
-    # def test_is_saveable(self):
-    #    resource = stripe.SubscriptionItem.retrieve(TEST_RESOURCE_ID)
-    #    resource.plan = 'plan'
-    #    resource.save()
-    #    request_mock.assert_requested(
-    #        'post',
-    #        '/v1/subscription_items/%s' % resource.id,
-    #        {
-    #            'plan': 'plan',
-    #        },
-    #    )
+    def test_is_saveable(self, request_mock):
+        resource = stripe.SubscriptionItem.retrieve(TEST_RESOURCE_ID)
+        resource.plan = 'plan'
+        resource.save()
+        request_mock.assert_requested(
+            'post',
+            '/v1/subscription_items/%s' % TEST_RESOURCE_ID,
+            {
+                'plan': 'plan',
+            },
+        )
 
     def test_is_modifiable(self, request_mock):
         resource = stripe.SubscriptionItem.modify(
@@ -64,12 +63,9 @@ class TestSubscriptionItem(object):
 
     def test_is_deletable(self, request_mock):
         resource = stripe.SubscriptionItem.retrieve(TEST_RESOURCE_ID)
-        # Unfortunately stripe-mock will return a resource with a different
-        # ID, so we need to store the original ID for the request assertion
-        resource_id = resource.id
         resource.delete()
         request_mock.assert_requested(
             'delete',
-            '/v1/subscription_items/%s' % resource_id
+            '/v1/subscription_items/%s' % TEST_RESOURCE_ID
         )
         assert resource.deleted is True

--- a/tests/api_resources/test_topup.py
+++ b/tests/api_resources/test_topup.py
@@ -44,7 +44,7 @@ class TestTopup(object):
         resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/topups/%s' % resource.id
+            '/v1/topups/%s' % TEST_RESOURCE_ID
         )
 
     def test_is_modifiable(self, request_mock):

--- a/tests/api_resources/test_transfer.py
+++ b/tests/api_resources/test_transfer.py
@@ -43,7 +43,7 @@ class TestTransfer(object):
         resource.save()
         request_mock.assert_requested(
             'post',
-            '/v1/transfers/%s' % resource.id
+            '/v1/transfers/%s' % TEST_RESOURCE_ID
         )
 
     def test_is_modifiable(self, request_mock):


### PR DESCRIPTION
Improve some tests after recent improvements to stripe-mock

* Properly uses the TEST_RESOURCE_ID everywhere as it is now returned by stripe-mock properly
* Properly ensure resource is deleted for BankAccount
* Removed bad comment on Reversal test

r? @ob-stripe 
cc @stripe/api-libraries 