### PR TITLE
Add cancel support for topups

### DIFF
--- a/stripe/api_resources/topup.py
+++ b/stripe/api_resources/topup.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
@@ -7,3 +8,9 @@ from stripe.api_resources.abstract import ListableAPIResource
 
 class Topup(CreateableAPIResource, ListableAPIResource, UpdateableAPIResource):
     OBJECT_NAME = 'topup'
+
+    def cancel(self, idempotency_key=None, **params):
+        url = self.instance_url() + '/cancel'
+        headers = util.populate_headers(idempotency_key)
+        self.refresh_from(self.request('post', url, params, headers))
+        return self

--- a/tests/api_resources/test_topup.py
+++ b/tests/api_resources/test_topup.py
@@ -57,3 +57,12 @@ class TestTopup(object):
             '/v1/topups/%s' % TEST_RESOURCE_ID
         )
         assert isinstance(resource, stripe.Topup)
+
+    def test_is_cancelable(self, request_mock):
+        topup = stripe.Topup.retrieve(TEST_RESOURCE_ID)
+        resource = topup.cancel()
+        request_mock.assert_requested(
+            'post',
+            '/v1/topups/%s/cancel' % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.Topup)


### PR DESCRIPTION
Add support for the new `cancel` topup endpoint

r? @miguel-stripe @kenneth-stripe @kimberly-stripe
r? @stripe/api-libraries