### PR TITLE
Upgrade stripe-mock to 0.30.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ cache:
 
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.26.0
+    # If changing this number, please also change it in `tests/conftest.py`.
+    - STRIPE_MOCK_VERSION=0.30.0
 
 before_install:
   # Unpack and start stripe-mock so that the test suite can talk to it

--- a/tests/api_resources/test_invoice.py
+++ b/tests/api_resources/test_invoice.py
@@ -64,7 +64,9 @@ class TestInvoice(object):
         assert isinstance(resource, stripe.Invoice)
 
     def test_can_upcoming(self, request_mock):
-        resource = stripe.Invoice.upcoming()
+        resource = stripe.Invoice.upcoming(
+            customer="cus_123"
+        )
         request_mock.assert_requested(
             'get',
             '/v1/invoices/upcoming'
@@ -73,6 +75,7 @@ class TestInvoice(object):
 
     def test_can_upcoming_and_subscription_items(self, request_mock):
         resource = stripe.Invoice.upcoming(
+            customer="cus_123",
             subscription_items=[
                 {"plan": "foo", "quantity": 3}
             ]
@@ -81,6 +84,7 @@ class TestInvoice(object):
             'get',
             '/v1/invoices/upcoming',
             {
+                'customer': 'cus_123',
                 'subscription_items': {
                     "0": {
                         "plan": "foo",

--- a/tests/api_resources/test_subscription_item.py
+++ b/tests/api_resources/test_subscription_item.py
@@ -8,10 +8,15 @@ TEST_RESOURCE_ID = 'si_123'
 
 class TestSubscriptionItem(object):
     def test_is_listable(self, request_mock):
-        resources = stripe.SubscriptionItem.list()
+        resources = stripe.SubscriptionItem.list(
+            subscription="sub_123"
+        )
         request_mock.assert_requested(
             'get',
-            '/v1/subscription_items'
+            '/v1/subscription_items',
+            {
+                'subscription': 'sub_123',
+            }
         )
         assert isinstance(resources.data, list)
         assert isinstance(resources.data[0], stripe.SubscriptionItem)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from stripe.six.moves.urllib.error import HTTPError
 from tests.request_mock import RequestMock
 
 
-MOCK_MINIMUM_VERSION = '0.26.0'
+MOCK_MINIMUM_VERSION = '0.30.0'
 MOCK_PORT = os.environ.get('STRIPE_MOCK_PORT', 12111)
 
 


### PR DESCRIPTION
Let's make sure that everything is still working on the latest version
of stripe-mock.

stripe-mock 0.30.0 brought in additional validation of query parameters,
so it caught a few places where the Python test suite wasn't making
valid requests. I've fixed up a few tests around invoices and
subscription items to add parameters that should have been there.

r? @ob-stripe
cc @stripe/api-libraries