### PR TITLE
Add support for the Reporting resources

### DIFF
--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -26,6 +26,7 @@ log = None
 # API resources
 from stripe.api_resources import *  # noqa
 from stripe.api_resources import issuing  # noqa
+from stripe.api_resources import reporting  # noqa
 from stripe.api_resources import sigma  # noqa
 
 # OAuth

--- a/stripe/api_resources/reporting/__init__.py
+++ b/stripe/api_resources/reporting/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import absolute_import, division, print_function
+
+# flake8: noqa
+
+from stripe.api_resources.reporting.report_run import ReportRun
+from stripe.api_resources.reporting.report_type import ReportType

--- a/stripe/api_resources/reporting/report_run.py
+++ b/stripe/api_resources/reporting/report_run.py
@@ -1,0 +1,8 @@
+from __future__ import absolute_import, division, print_function
+
+from stripe.api_resources.abstract import CreateableAPIResource
+from stripe.api_resources.abstract import ListableAPIResource
+
+
+class ReportRun(CreateableAPIResource, ListableAPIResource):
+    OBJECT_NAME = 'reporting.report_run'

--- a/stripe/api_resources/reporting/report_type.py
+++ b/stripe/api_resources/reporting/report_type.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import, division, print_function
+
+from stripe.api_resources.abstract import ListableAPIResource
+
+
+class ReportType(ListableAPIResource):
+    OBJECT_NAME = 'reporting.report_type'

--- a/stripe/util.py
+++ b/stripe/util.py
@@ -192,6 +192,10 @@ def load_object_classes():
         api_resources.RecipientTransfer.OBJECT_NAME:
             api_resources.RecipientTransfer,
         api_resources.Refund.OBJECT_NAME: api_resources.Refund,
+        api_resources.reporting.ReportRun.OBJECT_NAME:
+            api_resources.reporting.ReportRun,
+        api_resources.reporting.ReportType.OBJECT_NAME:
+            api_resources.reporting.ReportType,
         api_resources.Reversal.OBJECT_NAME: api_resources.Reversal,
         api_resources.sigma.ScheduledQueryRun.OBJECT_NAME:
             api_resources.sigma.ScheduledQueryRun,

--- a/tests/api_resources/reporting/test_report_run.py
+++ b/tests/api_resources/reporting/test_report_run.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import, division, print_function
+
+import stripe
+
+
+TEST_RESOURCE_ID = 'frr_123'
+
+
+class TestReportRun(object):
+    def test_is_creatable(self, request_mock):
+        resource = stripe.reporting.ReportRun.create(
+            parameters={
+                'connected_account': 'acct_123',
+            },
+            report_type='activity.summary.1',
+        )
+        request_mock.assert_requested(
+            'post',
+            '/v1/reporting/report_runs'
+        )
+        assert isinstance(resource, stripe.reporting.ReportRun)
+
+    def test_is_listable(self, request_mock):
+        resources = stripe.reporting.ReportRun.list()
+        request_mock.assert_requested(
+            'get',
+            '/v1/reporting/report_runs'
+        )
+        assert isinstance(resources.data, list)
+        assert isinstance(resources.data[0], stripe.reporting.ReportRun)
+
+    def test_is_retrievable(self, request_mock):
+        resource = stripe.reporting.ReportRun.retrieve(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            'get',
+            '/v1/reporting/report_runs/%s' % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.reporting.ReportRun)

--- a/tests/api_resources/reporting/test_report_type.py
+++ b/tests/api_resources/reporting/test_report_type.py
@@ -1,0 +1,25 @@
+from __future__ import absolute_import, division, print_function
+
+import stripe
+
+
+TEST_RESOURCE_ID = 'activity.summary.1'
+
+
+class TestReportType(object):
+    def test_is_listable(self, request_mock):
+        resources = stripe.reporting.ReportType.list()
+        request_mock.assert_requested(
+            'get',
+            '/v1/reporting/report_types'
+        )
+        assert isinstance(resources.data, list)
+        assert isinstance(resources.data[0], stripe.reporting.ReportType)
+
+    def test_is_retrievable(self, request_mock):
+        resource = stripe.reporting.ReportType.retrieve(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            'get',
+            '/v1/reporting/report_types/%s' % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.reporting.ReportType)


### PR DESCRIPTION
Adding support for the new Reporting resources. Those are in OpenAPI but not yet public but since they are starting to be used and are stable we should merge them.

It's WIP for now while I get some feedback on the implementation and the shape of the resources.

cc @stripe/api-libraries
cc @brahn-stripe