### PR TITLE
Python retry mechanism

### DIFF
--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -19,6 +19,7 @@ verify_ssl_certs = True
 proxy = None
 default_http_client = None
 app_info = None
+max_network_retries = 0
 
 # Set to either 'debug' or 'info', controls console logging
 log = None

--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -282,7 +282,7 @@ class APIRequestor(object):
             'Post details',
             post_data=encoded_params, api_version=self.api_version)
 
-        rbody, rcode, rheaders = self._client.request(
+        rbody, rcode, rheaders = self._client.request_with_retries(
             method, abs_url, headers, post_data)
 
         util.log_info(

--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -5,6 +5,7 @@ import datetime
 import json
 import platform
 import time
+import uuid
 
 import stripe
 from stripe import error, oauth_error, http_client, version, util, six
@@ -220,6 +221,7 @@ class APIRequestor(object):
 
         if method == 'post':
             headers['Content-Type'] = 'application/x-www-form-urlencoded'
+            headers.setdefault('Idempotency-Key', str(uuid.uuid4()))
 
         if self.api_version is not None:
             headers['Stripe-Version'] = self.api_version

--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -273,7 +273,6 @@ class APIRequestor(object):
                 'assistance.' % (method,))
 
         headers = self.request_headers(my_api_key, method)
-
         if supplied_headers is not None:
             for key, value in six.iteritems(supplied_headers):
                 headers[key] = value

--- a/stripe/error.py
+++ b/stripe/error.py
@@ -53,7 +53,11 @@ class APIError(StripeError):
 
 
 class APIConnectionError(StripeError):
-    pass
+    def __init__(self, message, http_body=None, http_status=None,
+                 json_body=None, headers=None, code=None, should_retry=False):
+        super(APIConnectionError, self).__init__(message, http_body, http_status,
+                                                 json_body, headers, code)
+        self.should_retry = should_retry
 
 
 class StripeErrorWithParamCode(StripeError):

--- a/stripe/error.py
+++ b/stripe/error.py
@@ -55,7 +55,8 @@ class APIError(StripeError):
 class APIConnectionError(StripeError):
     def __init__(self, message, http_body=None, http_status=None,
                  json_body=None, headers=None, code=None, should_retry=False):
-        super(APIConnectionError, self).__init__(message, http_body, http_status,
+        super(APIConnectionError, self).__init__(message, http_body,
+                                                 http_status,
                                                  json_body, headers, code)
         self.should_retry = should_retry
 

--- a/stripe/http_client.py
+++ b/stripe/http_client.py
@@ -206,7 +206,8 @@ class RequestsClient(HTTPClient):
 
     def _handle_request_error(self, e):
 
-        # Catch SSL error first as it belongs to ConnectionError
+        # Catch SSL error first as it belongs to ConnectionError,
+        # but we don't want to retry
         if isinstance(e, requests.exceptions.SSLError):
             msg = ("Could not verify Stripe's SSL certificate.  Please make "
                    "sure that your network is not intercepting certificates.  "
@@ -222,7 +223,7 @@ class RequestsClient(HTTPClient):
                    "support@stripe.com.")
             err = "%s: %s" % (type(e).__name__, str(e))
             should_retry = True
-        # Catch all request specific with descriptive class/messages
+        # Catch remaining request exceptions
         elif isinstance(e, requests.exceptions.RequestException):
             msg = ("Unexpected error communicating with Stripe.  "
                    "If this problem persists, let us know at "

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -221,7 +221,7 @@ class TestAPIRequestor(object):
     def mock_response(self, mocker, http_client):
         def mock_response(return_body, return_code, headers=None):
             print(return_code)
-            http_client.request = mocker.Mock(
+            http_client.request_with_retries = mocker.Mock(
                 return_value=(return_body, return_code, headers or {}))
         return mock_response
 
@@ -234,7 +234,7 @@ class TestAPIRequestor(object):
             if not headers:
                 headers = APIHeaderMatcher(request_method=method)
 
-            http_client.request.assert_called_with(
+            http_client.request_with_retries.assert_called_with(
                 method, abs_url, headers, post_data)
         return check_call
 
@@ -583,12 +583,12 @@ class TestDefaultClient(object):
         hc = mocker.Mock(stripe.http_client.HTTPClient)
         hc._verify_ssl_certs = True
         hc.name = 'mockclient'
-        hc.request = mocker.Mock(return_value=("{}", 200, {}))
+        hc.request_with_retries = mocker.Mock(return_value=("{}", 200, {}))
 
         stripe.default_http_client = hc
         stripe.Charge.list(limit=3)
 
-        hc.request.assert_called_with(
+        hc.request_with_retries.assert_called_with(
             'get',
             'https://api.stripe.com/v1/charges?limit=3',
             mocker.ANY,

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -466,6 +466,12 @@ class TestAPIRequestor(object):
         )
         check_call(meth, headers=header_matcher, post_data='')
 
+    def test_fails_without_api_key(self, requestor):
+        stripe.api_key = None
+
+        with pytest.raises(stripe.error.AuthenticationError):
+            requestor.request('get', self.valid_path, {})
+
     def test_invalid_request_error_404(self, requestor, mock_response):
         mock_response('{"error": {}}', 404)
 

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -82,7 +82,6 @@ class APIHeaderMatcher(object):
     def _idempotency_key_match(self, other):
         if self.idempotency_key is not None:
             return other['Idempotency-Key'] == self.idempotency_key
-
         return True
 
     def _x_stripe_ua_contains_app_info(self, other):
@@ -454,8 +453,8 @@ class TestAPIRequestor(object):
         )
         check_call(meth, headers=header_matcher, post_data='')
 
-    def test_create_uuid4_idempotency_key(self, requestor, mock_response,
-                                          check_call):
+    def test_uuid4_idempotency_key_when_not_given(self, requestor,
+                                                  mock_response, check_call):
         mock_response('{}', 200)
         meth = 'post'
         requestor.request(meth, self.valid_path, {})

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import datetime
 import json
 import tempfile
+import uuid
 
 import pytest
 
@@ -35,28 +36,32 @@ class APIHeaderMatcher(object):
         'User-Agent',
         'X-Stripe-Client-User-Agent',
     ]
-    METHOD_EXTRA_KEYS = {"post": ["Content-Type"]}
+    METHOD_EXTRA_KEYS = {"post": ["Content-Type", "Idempotency-Key"]}
 
     def __init__(self, api_key=None, extra={}, request_method=None,
-                 user_agent=None, app_info=None):
+                 user_agent=None, app_info=None, idempotency_key=None):
         self.request_method = request_method
         self.api_key = api_key or stripe.api_key
         self.extra = extra
         self.user_agent = user_agent
         self.app_info = app_info
+        self.idempotency_key = idempotency_key
 
     def __eq__(self, other):
         return (self._keys_match(other) and
                 self._auth_match(other) and
                 self._user_agent_match(other) and
                 self._x_stripe_ua_contains_app_info(other) and
+                self._idempotency_key_match(other) and
                 self._extra_match(other))
 
     def __repr__(self):
         return ("APIHeaderMatcher(request_method=%s, api_key=%s, extra=%s, "
-                "user_agent=%s, app_info=%s)" %
+                "user_agent=%s, app_info=%s, idempotency_key=%s)" %
                 (repr(self.request_method), repr(self.api_key),
-                 repr(self.extra), repr(self.user_agent), repr(self.app_info)))
+                 repr(self.extra), repr(self.user_agent), repr(self.app_info),
+                 repr(self.idempotency_key))
+                )
 
     def _keys_match(self, other):
         expected_keys = list(set(self.EXP_KEYS + list(self.extra.keys())))
@@ -71,6 +76,12 @@ class APIHeaderMatcher(object):
     def _user_agent_match(self, other):
         if self.user_agent is not None:
             return other['User-Agent'] == self.user_agent
+
+        return True
+
+    def _idempotency_key_match(self, other):
+        if self.idempotency_key is not None:
+            return other['Idempotency-Key'] == self.idempotency_key
 
         return True
 
@@ -127,6 +138,19 @@ class UrlMatcher(object):
 
     def __repr__(self):
         return ("UrlMatcher(exp_parts=%s)" % (repr(self.exp_parts)))
+
+
+class AnyUUID4Matcher(object):
+
+    def __eq__(self, other):
+        try:
+            uuid.UUID(other, version=4)
+        except ValueError:
+            return False
+        return True
+
+    def __repr__(self):
+        return "AnyUUID4Matcher()"
 
 
 class TestAPIRequestor(object):
@@ -417,11 +441,30 @@ class TestAPIRequestor(object):
         finally:
             stripe.app_info = old
 
-    def test_fails_without_api_key(self, requestor):
-        stripe.api_key = None
+    def test_uses_given_idempotency_key(self, requestor, mock_response,
+                                        check_call):
+        mock_response('{}', 200)
+        meth = 'post'
+        requestor.request(meth, self.valid_path, {},
+                          {'Idempotency-Key': '123abc'})
 
-        with pytest.raises(stripe.error.AuthenticationError):
-            requestor.request('get', self.valid_path, {})
+        header_matcher = APIHeaderMatcher(
+            request_method=meth,
+            idempotency_key='123abc'
+        )
+        check_call(meth, headers=header_matcher, post_data='')
+
+    def test_create_uuid4_idempotency_key(self, requestor, mock_response,
+                                          check_call):
+        mock_response('{}', 200)
+        meth = 'post'
+        requestor.request(meth, self.valid_path, {})
+
+        header_matcher = APIHeaderMatcher(
+            request_method=meth,
+            idempotency_key=AnyUUID4Matcher()
+        )
+        check_call(meth, headers=header_matcher, post_data='')
 
     def test_invalid_request_error_404(self, requestor, mock_response):
         mock_response('{"error": {}}', 404)

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -62,3 +62,12 @@ class TestStripeErrorWithParamCode(object):
             assert repr(err) == \
                 "CardError(message='öre', param='cparam', code='ccode', " \
                 "http_status=403, request_id='123')"
+
+
+class TestApiConnectionError(object):
+    def test_default_no_retry(self):
+        err = error.APIConnectionError('msg')
+        assert err.should_retry is False
+
+        err = error.APIConnectionError('msg', should_retry=True)
+        assert err.should_retry

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -288,7 +288,7 @@ class TestRequestClientRetryBehavior(TestRequestsClient):
                                      proxy='http://slap/')
         # Override sleep time to speed up tests
         client._sleep_time = lambda _: 0.001
-        return client.request_with_retry('GET', self.valid_url, {}, None)
+        return client.request('GET', self.valid_url, {}, None)
 
     def max_retries(self):
         return self.REQUEST_CLIENT.MAX_RETRIES

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -188,6 +188,52 @@ class TestRequestsClient(StripeClientTestCase, ClientTestBase):
         return mock_response
 
     @pytest.fixture
+    def mock_error(self, mocker, session):
+        def mock_error(mock):
+            mock.exceptions.SSLError = Exception
+            session.request.side_effect = mock.exceptions.SSLError()
+            mock.Session = mocker.MagicMock(return_value=session)
+        return mock_error
+
+    # Note that unlike other modules, we don't use the "mock" argument here
+    # because we need to run the request call against the internal mock
+    # session.
+    @pytest.fixture
+    def check_call(self, session):
+        def check_call(mock, method, url, post_data, headers, timeout=80,
+                       times=None):
+            times = times or 1
+            args = (method, url)
+            kwargs = {'headers': headers,
+                      'data': post_data,
+                      'verify': RequestsVerify(),
+                      'proxies': {"http": "http://slap/",
+                                  "https": "http://slap/"},
+                      'timeout': timeout}
+            calls = [(args, kwargs) for _ in range(times)]
+            session.request.assert_has_calls(calls)
+
+        return check_call
+
+    def make_request(self, method, url, headers, post_data, timeout=80):
+        client = self.REQUEST_CLIENT(verify_ssl_certs=True,
+                                     timeout=timeout,
+                                     proxy='http://slap/')
+        return client.request(method, url, headers, post_data)
+
+    def test_timeout(self, request_mock, mock_response, check_call):
+        headers = {'my-header': 'header val'}
+        data = ''
+        mock_response(request_mock, '{"foo": "baz"}', 200)
+        self.make_request('POST', self.valid_url,
+                          headers, data, timeout=5)
+
+        check_call(None, 'POST', self.valid_url, data, headers, timeout=5)
+
+
+class TestRetryRequestClient(TestRequestsClient):
+
+    @pytest.fixture
     def response(self, mocker):
         def response(code=200):
             result = mocker.Mock()
@@ -195,14 +241,6 @@ class TestRequestsClient(StripeClientTestCase, ClientTestBase):
             result.status_code = code
             return result
         return response
-
-    @pytest.fixture
-    def mock_error(self, mocker, session):
-        def mock_error(mock):
-            mock.exceptions.RequestException = Exception
-            session.request.side_effect = mock.exceptions.RequestException()
-            mock.Session = mocker.MagicMock(return_value=session)
-        return mock_error
 
     @pytest.fixture
     def mock_retry(self, mocker, session, request_mock):
@@ -237,83 +275,67 @@ class TestRequestsClient(StripeClientTestCase, ClientTestBase):
 
         return mock_retry
 
-    # Note that unlike other modules, we don't use the "mock" argument here
-    # because we need to run the request call against the internal mock
-    # session.
     @pytest.fixture
-    def check_call(self, session):
-        def check_call(mock, method, url, post_data, headers, timeout=80,
-                       times=None):
-            times = times or 1
-            args = (method, url)
-            kwargs = {'headers': headers,
-                      'data': post_data,
-                      'verify': RequestsVerify(),
-                      'proxies': {"http": "http://slap/",
-                                  "https": "http://slap/"},
-                      'timeout': timeout}
-            calls = [(args, kwargs) for _ in range(times)]
-            session.request.assert_has_calls(calls)
+    def check_call_numbers(self, check_call):
+        valid_url = self.valid_url
 
-        return check_call
+        def check_call_numbers(times):
+            check_call(None, 'GET', valid_url, None, {}, times=times)
+        return check_call_numbers
 
-    def make_request(self, method, url, headers, post_data, timeout=80):
+    def make_request(self):
         client = self.REQUEST_CLIENT(verify_ssl_certs=True,
-                                     timeout=timeout,
+                                     timeout=80,
                                      proxy='http://slap/')
         client._sleep_time = lambda _: 0.001
-        return client.request_with_retry(method, url, headers, post_data)
-
-    def test_timeout(self, request_mock, mock_response, check_call):
-        headers = {'my-header': 'header val'}
-        data = ''
-        mock_response(request_mock, '{"foo": "baz"}', 200)
-        self.make_request('POST', self.valid_url,
-                          headers, data, timeout=5)
-
-        check_call(None, 'POST', self.valid_url, data, headers, timeout=5)
-
-    def test_exception(self, request_mock, mock_error):
-        pass
+        return client.request_with_retry('GET', self.valid_url, {}, None)
 
     def max_retries(self):
         return self.REQUEST_CLIENT.MAX_RETRIES
 
     def test_retry_error_until_response(self, mock_retry, response,
-                                        check_call):
+                                        check_call_numbers):
         mock_retry(retry_error_num=1, responses=[response(code=202)])
-        _, code, _ = self.make_request('GET', self.valid_url, {}, None)
+        _, code, _ = self.make_request()
         assert code == 202
-        check_call(None, 'GET', self.valid_url, None, {}, times=2)
+        check_call_numbers(2)
 
     def test_retry_error_until_exceeded(self, mock_retry, response,
-                                        check_call):
+                                        check_call_numbers):
         mock_retry(retry_error_num=3)
         with pytest.raises(stripe.error.APIConnectionError):
-            self.make_request('GET', self.valid_url, {}, None)
+            self.make_request()
 
-        check_call(None, 'GET', self.valid_url, None, {},
-                   times=self.max_retries())
+        check_call_numbers(self.max_retries())
 
-    def test_no_retry_error(self, mock_retry, response, check_call):
+    def test_no_retry_error(self, mock_retry, response, check_call_numbers):
         mock_retry(no_retry_error_num=3)
         with pytest.raises(stripe.error.APIConnectionError):
-            self.make_request('GET', self.valid_url, {}, None)
-        check_call(None, 'GET', self.valid_url, None, {}, times=1)
+            self.make_request()
+        check_call_numbers(1)
 
-    def test_retry_codes(self, mock_retry, response, check_call):
+    def test_retry_codes(self, mock_retry, response, check_call_numbers):
         mock_retry(responses=[response(code=409), response(code=202)])
-        _, code, _ = self.make_request('GET', self.valid_url, {}, None)
+        _, code, _ = self.make_request()
         assert code == 202
-        check_call(None, 'GET', self.valid_url, None, {}, times=2)
+        check_call_numbers(2)
 
     def test_retry_codes_until_exceeded(self, mock_retry, response,
-                                        check_call):
+                                        check_call_numbers):
         mock_retry(responses=[response(code=409)] * 3)
-        _, code, _ = self.make_request('GET', self.valid_url, {}, None)
+        _, code, _ = self.make_request()
         assert code == 409
-        check_call(None, 'GET', self.valid_url, None, {},
-                   times=self.max_retries())
+        check_call_numbers(self.max_retries())
+
+    # Basic requests client behavior tested in TestRequestsClient
+    def test_request(self, request_mock, mock_response, check_call):
+        pass
+
+    def test_exception(self, request_mock, mock_error):
+        pass
+
+    def test_timeout(self, request_mock, mock_response, check_call):
+        pass
 
 
 class TestUrlFetchClient(StripeClientTestCase, ClientTestBase):

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -57,7 +57,8 @@ class TestRetrySleepTimeDefaultHttpClient(StripeClientTestCase):
 
     def assert_sleep_times(self, client, expected):
         until = len(expected)
-        actual = list(map(lambda i: client._sleep_time(i+1), range(until)))
+        actual = list(
+            map(lambda i: client._sleep_time_seconds(i + 1), range(until)))
         assert expected == actual
 
     @contextmanager


### PR DESCRIPTION
Summary:
- Implement retry mechanism at abstract HTTPClient class, and use delegated request call to each client implementation.   
- Only consider errors from `requests` http-client, but not others due to overwhelming majority of our clients. This design allows future extension the support to other http-clients. (As opposed to urllib3 `Retry` that is coupled at the execution invocation.
- Retry conditions follow other language implementations (Ruby[0]/Go[1]) 
  - Retry on 409 resource conflict (both)
  - Retry on timeout/connection (only Ruby) 
- Exponential backoff delay follows other language implementations (Ruby[2]/Go[3])
- Added idempotency key only for POST method, and when it is not given in the header

Concerns:
- Not sure where's best to put delay constants in config. Currently made as static class var
- I'm not sure how to access the actual `requests` module from within test, and that results in mocking kinds of exception classes that we want to handle (existing tests also rely on the similar mechanism)

Motivation:
- Issue https://github.com/stripe/stripe-python/issues/464 and from conversation in PR https://github.com/stripe/stripe-python/pull/466 

[0] Ruby retry conditions
https://github.com/stripe/stripe-ruby/blob/ec66c3f0f44274f885de8d13de5dce2657932121/lib/stripe/stripe_client.rb#L61
[1] Go retry conditions
https://github.com/stripe/stripe-go/blob/442690c3856640e4913163f506f0070561f3368d/stripe.go#L495
[2] Ruby sleep
https://github.com/stripe/stripe-ruby/blob/ec66c3f0f44274f885de8d13de5dce2657932121/lib/stripe/stripe_client.rb#L80
[3] Go sleep
https://github.com/stripe/stripe-go/blob/442690c3856640e4913163f506f0070561f3368d/stripe.go#L511

