### PR TITLE
Don't URL-encode square brackets

### DIFF
--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -251,6 +251,11 @@ class APIRequestor(object):
 
         encoded_params = urlencode(list(_api_encode(params or {})))
 
+        # Don't use strict form encoding by changing the square bracket control
+        # characters back to their literals. This is fine by the server, and
+        # makes these parameter strings easier to read.
+        encoded_params = encoded_params.replace('%5B', '[').replace('%5D', ']')
+
         if method == 'get' or method == 'delete':
             if params:
                 abs_url = _build_api_url(abs_url, encoded_params)

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -346,8 +346,8 @@ class TestAPIRequestor(object):
                 'adict': {'frobble': 'bits'},
                 'adatetime': datetime.datetime(2013, 1, 1, tzinfo=GMT1())
             }
-            encoded = ('adict%5Bfrobble%5D=bits&adatetime=1356994800&'
-                       'alist%5B0%5D=1&alist%5B1%5D=2&alist%5B2%5D=3')
+            encoded = ('adict[frobble]=bits&adatetime=1356994800&'
+                       'alist[0]=1&alist[1]=2&alist[2]=3')
 
             resp, key = requestor.request(method, self.valid_path, params)
             assert isinstance(resp, StripeResponse)


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Don't URL-encode square brackets. Most of our other libraries already do this.
