### PR TITLE
Use stripe-mock for FileUpload tests

### DIFF
--- a/stripe/multipart_data_generator.py
+++ b/stripe/multipart_data_generator.py
@@ -21,7 +21,12 @@ class MultipartDataGenerator(object):
             self._write(self.param_header())
             self._write(self.line_break)
             if hasattr(value, 'read'):
-                filename = value.name if hasattr(value, 'name') else "blob"
+                filename = "blob"
+                if hasattr(value, 'name'):
+                    # Convert the filename to string, just in case it's not
+                    # already one. E.g. `tempfile.TemporaryFile` has a `name`
+                    # attribute but it's an `int`.
+                    filename = str(value.name)
 
                 self._write("Content-Disposition: form-data; name=\"")
                 self._write(key)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,18 +43,21 @@ def setup_stripe():
         'api_key': stripe.api_key,
         'client_id': stripe.client_id,
         'default_http_client': stripe.default_http_client,
+        'upload_api_base': stripe.upload_api_base,
     }
     http_client = stripe.http_client.new_default_http_client()
     stripe.api_base = 'http://localhost:%s' % MOCK_PORT
     stripe.api_key = 'sk_test_123'
     stripe.client_id = 'ca_123'
     stripe.default_http_client = http_client
+    stripe.upload_api_base = 'http://localhost:%s' % MOCK_PORT
     yield
     http_client.close()
     stripe.api_base = orig_attrs['api_base']
     stripe.api_key = orig_attrs['api_key']
     stripe.client_id = orig_attrs['client_id']
     stripe.default_http_client = orig_attrs['default_http_client']
+    stripe.upload_api_base = orig_attrs['upload_api_base']
 
 
 @pytest.fixture


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Updates the `FileUpload` tests to use stripe-mock instead of stubbing requests.
