### PR TITLE
feature: support deletion without a stripe object

### DIFF
--- a/stripe/api_resources/abstract/deletable_api_resource.py
+++ b/stripe/api_resources/abstract/deletable_api_resource.py
@@ -1,9 +1,26 @@
 from __future__ import absolute_import, division, print_function
 
+from stripe import api_requestor, util
 from stripe.api_resources.abstract.api_resource import APIResource
+from stripe.six.moves.urllib.parse import quote_plus
 
 
 class DeletableAPIResource(APIResource):
+
+    @classmethod
+    def _remove(cls, url, api_key=None, stripe_version=None,
+                stripe_account=None, **params):
+        requestor = api_requestor.APIRequestor(api_key,
+                                               api_version=stripe_version,
+                                               account=stripe_account)
+        response, api_key = requestor.request('delete', url, params)
+        return util.convert_to_stripe_object(response, api_key, stripe_version,
+                                             stripe_account)
+
+    @classmethod
+    def remove(cls, sid, **params):
+        url = "%s/%s" % (cls.class_url(), quote_plus(util.utf8(sid)))
+        return cls._remove(url, **params)
 
     def delete(self, **params):
         self.refresh_from(self.request('delete', self.instance_url(), params))

--- a/tests/api_resources/abstract/test_deletable_api_resource.py
+++ b/tests/api_resources/abstract/test_deletable_api_resource.py
@@ -33,3 +33,26 @@ class TestDeletableAPIResource(object):
 
         assert obj.last_response is not None
         assert obj.last_response.request_id == 'req_id'
+
+    def test_remove(self, request_mock):
+        request_mock.stub_request(
+            'delete',
+            '/v1/mydeletables/mid',
+            {
+                'id': 'mid',
+                'deleted': True,
+            },
+            rheaders={'request-id': 'req_id'}
+        )
+
+        obj = self.MyDeletable.remove('mid')
+        request_mock.assert_requested(
+            'delete',
+            '/v1/mydeletables/mid',
+            {}
+        )
+        assert obj.deleted is True
+        assert obj.id == 'mid'
+
+        assert obj.last_response is not None
+        assert obj.last_response.request_id == 'req_id'


### PR DESCRIPTION
This is roughly the same as `modify` on `UpdatableAPIResource`.