### PR TITLE
Allow setting `stripe.max_network_retries` to affect HTTPClients

### DIFF
--- a/stripe/http_client.py
+++ b/stripe/http_client.py
@@ -8,7 +8,7 @@ import email
 import time
 import random
 
-from stripe import error, util, six, max_network_retries
+from stripe import error, util, six
 
 # - Requests is the preferred HTTP library
 # - Google App Engine has urlfetch
@@ -139,6 +139,7 @@ class HTTPClient(object):
         return should_retry and num_retries < self._max_network_retries()
 
     def _max_network_retries(self):
+        from stripe import max_network_retries
         # Configured retries, isolated here for tests
         return max_network_retries
 


### PR DESCRIPTION
Motivation
----------

Before this patch, setting `stripe.max_network_retries` had no affect on
the following code.

```
import stripe
import sys

stripe.api_key = sys.argv[1]
stripe.max_network_retries = 5
client = stripe.http_client.RequestsClient(timeout=0.1)
stripe.default_http_client = client
stripe.log = 'info'

while True:
    try:
        charges = stripe.Charge.list()
    except stripe.error.APIConnectionError as e:
        print(e.user_message)
        break
```

```
message='Request to Stripe api' method=get path=https://api.stripe.com/v1/charges
Unexpected error communicating with Stripe.  If this problem persists,
let us know at support@stripe.com.

(Network error: ReadTimeout: HTTPSConnectionPool(host='api.stripe.com', port=443): Read timed out. (read timeout=0.1))
```

After the patch, I can utilize `stripe.max_network_retries` effectively.

```
message='Request to Stripe api' method=get path=https://api.stripe.com/v1/charges
message="Encountered a retryable error Unexpected error communicating with Stripe.  If this problem persists,\nlet us know at support@stripe.com.\n\n(Network error: ReadTimeout: HTTPSConnectionPool(host='api.stripe.com', port=443): Read timed out. (read timeout=0.1))"
message='Initiating retry 1 for request get https://api.stripe.com/v1/charges after sleeping 0.50 seconds.'
message="Encountered a retryable error Unexpected error communicating with Stripe.  If this problem persists,\nlet us know at support@stripe.com.\n\n(Network error: ReadTimeout: HTTPSConnectionPool(host='api.stripe.com', port=443): Read timed out. (read timeout=0.1))"
message='Initiating retry 2 for request get https://api.stripe.com/v1/charges after sleeping 0.98 seconds.'
message="Encountered a retryable error Unexpected error communicating with Stripe.  If this problem persists,\nlet us know at support@stripe.com.\n\n(Network error: ReadTimeout: HTTPSConnectionPool(host='api.stripe.com', port=443): Read timed out. (read timeout=0.1))"
message='Initiating retry 3 for request get https://api.stripe.com/v1/charges after sleeping 1.87 seconds.'
message="Encountered a retryable error Unexpected error communicating with Stripe.  If this problem persists,\nlet us know at support@stripe.com.\n\n(Network error: ReadTimeout: HTTPSConnectionPool(host='api.stripe.com', port=443): Read timed out. (read timeout=0.1))"
message='Initiating retry 4 for request get https://api.stripe.com/v1/charges after sleeping 1.99 seconds.'
Unexpected error communicating with Stripe.  If this problem persists,
let us know at support@stripe.com.

(Network error: ReadTimeout: HTTPSConnectionPool(host='api.stripe.com', port=443): Read timed out. (read timeout=0.1))
```

[Cross Reference][cross]

[cross]: https://github.com/stripe/stripe-python/blob/ae953fd0aa531f5b500e5e86eee5859df95a255d/stripe/api_requestor.py#L239

Workaround
----------

Until this is merged it's possible to work around this issue by directly
setting the HTTPClient's `_max_network_retries` method:

```
import stripe
import sys

stripe.api_key = sys.argv[1]
client = stripe.http_client.RequestsClient(timeout=0.1)
client._max_network_retries = lambda: 5
stripe.default_http_client = client
stripe.log = 'info'

while True:
    try:
        charges = stripe.Charge.list()
    except stripe.error.APIConnectionError as e:
        print(e.user_message)
        break
```

```
message='Request to Stripe api' method=get path=https://api.stripe.com/v1/charges
message="Encountered a retryable error Unexpected error communicating with Stripe.  If this problem persists,\nlet us know at support@stripe.com.\n\n(Network error: ReadTimeout: HTTPSConnectionPool(host='api.stripe.com', port=443): Read timed out. (read timeout=0.1))"
message='Initiating retry 1 for request get https://api.stripe.com/v1/charges after sleeping 0.50 seconds.'
message="Encountered a retryable error Unexpected error communicating with Stripe.  If this problem persists,\nlet us know at support@stripe.com.\n\n(Network error: ReadTimeout: HTTPSConnectionPool(host='api.stripe.com', port=443): Read timed out. (read timeout=0.1))"
message='Initiating retry 2 for request get https://api.stripe.com/v1/charges after sleeping 0.59 seconds.'
message="Encountered a retryable error Unexpected error communicating with Stripe.  If this problem persists,\nlet us know at support@stripe.com.\n\n(Network error: ReadTimeout: HTTPSConnectionPool(host='api.stripe.com', port=443): Read timed out. (read timeout=0.1))"
message='Initiating retry 3 for request get https://api.stripe.com/v1/charges after sleeping 1.77 seconds.'
message="Encountered a retryable error Unexpected error communicating with Stripe.  If this problem persists,\nlet us know at support@stripe.com.\n\n(Network error: ReadTimeout: HTTPSConnectionPool(host='api.stripe.com', port=443): Read timed out. (read timeout=0.1))"
message='Initiating retry 4 for request get https://api.stripe.com/v1/charges after sleeping 1.98 seconds.'
Unexpected error communicating with Stripe.  If this problem persists,
let us know at support@stripe.com.

(Network error: ReadTimeout: HTTPSConnectionPool(host='api.stripe.com', port=443): Read timed out. (read timeout=0.1))~
```