### PR TITLE
Make StripeResponse a new-style class

### DIFF
--- a/stripe/stripe_response.py
+++ b/stripe/stripe_response.py
@@ -3,8 +3,7 @@ from __future__ import absolute_import, division, print_function
 import json
 
 
-class StripeResponse:
-
+class StripeResponse(object):
     def __init__(self, body, code, headers):
         self.body = body
         self.code = code


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Make `StripeResponse` a [new-style class](https://docs.python.org/2/glossary.html#term-new-style-class). This ensures that the `@property` decorators work as expected with Python 2.7. (Python 3 doesn't have old-style classes at all so isn't affected.)
