### PR TITLE
Add .lgtm.yml file

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,5 @@
+extraction:
+  python:
+    index:
+      exclude:
+        - stripe/six.py


### PR DESCRIPTION
I've been playing around with LGTM.com to try and improve code quality. This configuration files should instruct LGTM.com to exclude `six.py` from its analysis. We already exclude it from our linting and code coverage.
