### PR TITLE
Update .lgtm.yml

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,5 +1,3 @@
-extraction:
-  python:
-    index:
-      exclude:
-        - stripe/six.py
+path_classifiers:
+  library:
+    - stripe/six.py


### PR DESCRIPTION
Updates `.lgtm.yml` to classify `six.py` as a third-party library rather than excluding it entirely.
