### PR TITLE
Add Stripe client telemetry to request headers

### DIFF
--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -21,6 +21,7 @@ verify_ssl_certs = True
 proxy = None
 default_http_client = None
 app_info = None
+enable_telemetry = False
 max_network_retries = 0
 ca_bundle_path = os.path.join(
     os.path.dirname(__file__), 'data/ca-certificates.crt')

--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -11,6 +11,7 @@ import stripe
 from stripe import error, oauth_error, http_client, version, util, six
 from stripe.multipart_data_generator import MultipartDataGenerator
 from stripe.six.moves.urllib.parse import urlencode, urlsplit, urlunsplit
+from stripe.request_metrics import RequestMetrics
 from stripe.stripe_response import StripeResponse
 
 
@@ -28,6 +29,10 @@ def _encode_nested_dict(key, data, fmt='%s[%s]'):
     for subkey, subvalue in six.iteritems(data):
         d[fmt % (key, subkey)] = subvalue
     return d
+
+
+def _now_ms():
+    return int(round(time.time() * 1000))
 
 
 def _api_encode(data):
@@ -79,6 +84,8 @@ class APIRequestor(object):
         self._client = client or stripe.default_http_client or \
             http_client.new_default_http_client(
                 verify_ssl_certs=verify, proxy=proxy)
+
+        self._last_request_metrics = None
 
     @classmethod
     def format_app_info(cls, info):
@@ -226,6 +233,11 @@ class APIRequestor(object):
         if self.api_version is not None:
             headers['Stripe-Version'] = self.api_version
 
+        if stripe.enable_telemetry and self._last_request_metrics:
+            headers['X-Stripe-Client-Telemetry'] = json.dumps({
+                'last_request_metrics': self._last_request_metrics.payload()
+            })
+
         return headers
 
     def request_raw(self, method, url, params=None, supplied_headers=None):
@@ -287,15 +299,24 @@ class APIRequestor(object):
             'Post details',
             post_data=encoded_params, api_version=self.api_version)
 
+        request_start = _now_ms()
+
         rbody, rcode, rheaders = self._client.request_with_retries(
             method, abs_url, headers, post_data)
 
         util.log_info(
             'Stripe API response', path=abs_url, response_code=rcode)
         util.log_debug('API response body', body=rbody)
+
         if 'Request-Id' in rheaders:
+            request_id = rheaders['Request-Id']
             util.log_debug('Dashboard link for request',
-                           link=util.dashboard_link(rheaders['Request-Id']))
+                           link=util.dashboard_link(request_id))
+            if stripe.enable_telemetry:
+                request_duration_ms = _now_ms() - request_start
+                self._last_request_metrics = RequestMetrics(
+                        request_id, request_duration_ms)
+
         return rbody, rcode, rheaders, my_api_key
 
     def interpret_response(self, rbody, rcode, rheaders):

--- a/stripe/request_metrics.py
+++ b/stripe/request_metrics.py
@@ -1,0 +1,13 @@
+from __future__ import absolute_import, division, print_function
+
+
+class RequestMetrics(object):
+    def __init__(self, request_id, request_duration_ms):
+        self.request_id = request_id
+        self.request_duration_ms = request_duration_ms
+
+    def payload(self):
+        return {
+            'request_id': self.request_id,
+            'request_duration_ms': self.request_duration_ms,
+        }


### PR DESCRIPTION
Follows https://github.com/stripe/stripe-ruby/pull/696 and https://github.com/stripe/stripe-php/pull/549 in adding telemetry metadata to request headers. 

The telemetry is disabled by default, and can be enabled like so:
```python
stripe.enable_telemetry = True
```