### PR TITLE
Fix failing tests

### DIFF
--- a/stripe/http_client.py
+++ b/stripe/http_client.py
@@ -257,7 +257,6 @@ class RequestsClient(HTTPClient):
 
     def close(self):
         if self._session is not None:
-            print("closing!")
             self._session.close()
 
 

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -220,7 +220,6 @@ class TestAPIRequestor(object):
     @pytest.fixture
     def mock_response(self, mocker, http_client):
         def mock_response(return_body, return_code, headers=None):
-            print(return_code)
             http_client.request_with_retries = mocker.Mock(
                 return_value=(return_body, return_code, headers or {}))
         return mock_response


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Two tests are failing because the way they create fixtures is no longer supported with the latest version of pytest. This PR fixes the failing tests.

(To be honest, the fixture setup in `test_http_client` is way too complex. I'm hoping to greatly simplify it at some point, but probably won't get around to it until we drop support for non-requests clients.)
