### PR TITLE
Detect custom OpenAPI spec and fixtures and start stripe-mock from test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_install:
   - |
     stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}/stripe-mock > /dev/null &
     STRIPE_MOCK_PID=$!
+  - export PATH="${PATH}:${PWD}/stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}"
 
 install:
   - make init

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ test:
 	pipenv run tox -p auto
 
 ci:
-	pipenv run pytest --cov=stripe -n 8
+	pipenv run pytest --cov=stripe
 
 coveralls:
 	pipenv run coveralls

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import atexit
 import os
 import sys
 from distutils.version import StrictVersion
@@ -11,10 +12,23 @@ from stripe.six.moves.urllib.request import urlopen
 from stripe.six.moves.urllib.error import HTTPError
 
 from tests.request_mock import RequestMock
+from tests.stripe_mock import StripeMock
 
 
+# When changing this number, don't forget to change it in `.travis.yml` too.
 MOCK_MINIMUM_VERSION = '0.40.0'
-MOCK_PORT = os.environ.get('STRIPE_MOCK_PORT', 12111)
+
+# Starts stripe-mock if an OpenAPI spec override is found in `openapi/`, and
+# otherwise fall back to `STRIPE_MOCK_PORT` or 12111.
+if StripeMock.start():
+    MOCK_PORT = StripeMock.port()
+else:
+    MOCK_PORT = os.environ.get('STRIPE_MOCK_PORT', 12111)
+
+
+@atexit.register
+def stop_stripe_mock():
+    StripeMock.stop()
 
 
 try:

--- a/tests/openapi/README.md
+++ b/tests/openapi/README.md
@@ -1,0 +1,9 @@
+## Using custom OpenAPI specification and fixtures files
+
+You can place custom OpenAPI specification and fixtures files in this
+directory. The files must be in JSON format, and must be named `spec3.json`
+and `fixtures3.json` respectively.
+
+If those files are present, the test suite will start its own stripe-mock
+process on a random available port. In order for this to work, `stripe-mock`
+must be on the `PATH` in the environment used to run the test suite.

--- a/tests/stripe_mock.py
+++ b/tests/stripe_mock.py
@@ -1,0 +1,79 @@
+from __future__ import absolute_import, division, print_function
+
+import os
+import socket
+import subprocess
+import sys
+import time
+
+
+class StripeMock(object):
+    PATH_SPEC = os.path.dirname(os.path.realpath(__file__)) \
+        + "/openapi/spec3.json"
+    PATH_FIXTURES = os.path.dirname(os.path.realpath(__file__)) \
+        + "/openapi/fixtures3.json"
+
+    _port = -1
+    _process = None
+
+    @classmethod
+    def start(cls):
+        if not os.path.isfile(cls.PATH_SPEC):
+            return False
+
+        if cls._process is not None:
+            print("stripe-mock already running on port %s" % cls._port)
+            return True
+
+        cls._port = cls.find_available_port()
+
+        print("Starting stripe-mock on port %s..." % cls._port)
+
+        cls._process = subprocess.Popen(
+            [
+                "stripe-mock",
+                "-http-port",
+                str(cls._port),
+                "-spec",
+                cls.PATH_SPEC,
+                "-fixtures",
+                cls.PATH_FIXTURES,
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+
+        time.sleep(1)
+
+        if cls._process.poll() is None:
+            print("Started stripe-mock, PID = %d" % cls._process.pid)
+        else:
+            print("stripe-mock terminated early: %d" % cls._process.returncode)
+            sys.exit(1)
+
+        return True
+
+    @classmethod
+    def stop(cls):
+        if cls._process is None:
+            return
+
+        print("Stopping stripe-mock...")
+        cls._process.terminate()
+        cls._process.wait()
+        cls._process = None
+        cls._port = -1
+        print("Stopped stripe-mock")
+
+    @classmethod
+    def port(cls):
+        return cls._port
+
+    @staticmethod
+    def find_available_port():
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.bind(("localhost", 0))
+        s.listen(1)
+        port = s.getsockname()[1]
+        s.close()
+        return port


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Like https://github.com/stripe/stripe-ruby/pull/715, for Python.
