### PR TITLE
Update .gitignore for VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,10 @@
 nosetests.xml
 coverage.xml
 htmlcov/
+
+# Visual Studio Code
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json


### PR DESCRIPTION
Opening the projet with VSCode creates a `.vscode/tags` file that shouldn't be committed to the repo. This PR updates our `.gitignore` file with the contents of https://github.com/github/gitignore/blob/master/Global/VisualStudioCode.gitignore.
