### PR TITLE
Allow failures on Pypy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,16 @@ matrix:
     - python: "pypy"
     - python: "pypy3"
 
+  # There's a Pipenv issue that currently prevents stripe-python from building
+  # properly on Pypy3:
+  #
+  #     https://github.com/pypa/pipenv/pull/3322
+  #
+  # Olivier patched it, but we're still waiting on the Pipenv project for a new
+  # release. When that happens, we can remove this `allow_failures` section.
+  allow_failures:
+    - python: "pypy3"
+
 cache:
   directories:
     - stripe-mock


### PR DESCRIPTION
Pypy3's been breaking pretty regularly due to an import error:

    ImportError: cannot import name 'pythonapi'
    make: *** [init] Error 1

Here we (temporarily) allow it to fail in the build matrix so that we
can get the general build back to green.

r? @ob-stripe This is obviously not great, but a failing master build
isn't either :) What do you think about bringing this in temporarily and
trying to get the Pypy3 build fixed later? It's not too obvious to me
why it's failing -- I'd have to spend some time digging in.