### PR TITLE
Fix Stripe Client Telemetry

### DIFF
--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -45,7 +45,6 @@ class APIHeaderMatcher(object):
         user_agent=None,
         app_info=None,
         idempotency_key=None,
-        client_telemetry=None,
     ):
         self.request_method = request_method
         self.api_key = api_key or stripe.api_key
@@ -53,7 +52,6 @@ class APIHeaderMatcher(object):
         self.user_agent = user_agent
         self.app_info = app_info
         self.idempotency_key = idempotency_key
-        self.client_telemetry = client_telemetry
 
     def __eq__(self, other):
         return (
@@ -63,7 +61,6 @@ class APIHeaderMatcher(object):
             and self._x_stripe_ua_contains_app_info(other)
             and self._idempotency_key_match(other)
             and self._extra_match(other)
-            and self._check_telemetry(other)
         )
 
     def __repr__(self):
@@ -87,8 +84,6 @@ class APIHeaderMatcher(object):
             and self.request_method in self.METHOD_EXTRA_KEYS
         ):
             expected_keys.extend(self.METHOD_EXTRA_KEYS[self.request_method])
-        if self.client_telemetry:
-            expected_keys.append("X-Stripe-Client-Telemetry")
         return sorted(other.keys()) == sorted(expected_keys)
 
     def _auth_match(self, other):
@@ -118,24 +113,6 @@ class APIHeaderMatcher(object):
         for k, v in six.iteritems(self.extra):
             if other[k] != v:
                 return False
-
-        return True
-
-    def _check_telemetry(self, other):
-        if not self.client_telemetry:
-            return "X-Stripe-Client-Telemetry" not in other
-
-        if "X-Stripe-Client-Telemetry" not in other:
-            return False
-
-        telemetry = json.loads(other["X-Stripe-Client-Telemetry"])
-        req_id = telemetry["last_request_metrics"]["request_id"]
-
-        if req_id != self.client_telemetry["request_id"]:
-            return False
-
-        if "request_duration_ms" not in telemetry["last_request_metrics"]:
-            return False
 
         return True
 
@@ -412,32 +389,6 @@ class TestAPIRequestor(object):
         mock_response("{}", 200)
         requestor.request("get", self.valid_path, {}, {"foo": "bar"})
         check_call("get", headers=APIHeaderMatcher(extra={"foo": "bar"}))
-
-    def test_telemetry_headers_disabled(
-        self, requestor, mock_response, check_call
-    ):
-        mock_response("{}", 200, headers={"Request-Id": 1})
-        requestor.request("get", self.valid_path, {})
-        check_call("get", headers=APIHeaderMatcher(client_telemetry=None))
-
-        mock_response("{}", 200, headers={"Request-Id": 2})
-        requestor.request("get", self.valid_path, {})
-        check_call("get", headers=APIHeaderMatcher(client_telemetry=None))
-
-    def test_telemetry_headers_enabled(
-        self, requestor, mock_response, check_call
-    ):
-        stripe.enable_telemetry = True
-
-        mock_response("{}", 200, headers={"Request-Id": 1})
-        requestor.request("get", self.valid_path, {})
-        check_call("get", headers=APIHeaderMatcher(client_telemetry=None))
-
-        mock_response("{}", 200, headers={"Request-Id": 2})
-        requestor.request("get", self.valid_path, {})
-        check_call(
-            "get", headers=APIHeaderMatcher(client_telemetry={"request_id": 1})
-        )
 
     def test_uses_instance_key(self, http_client, mock_response, check_call):
         key = "fookey"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -161,7 +161,7 @@ class TestIntegration(object):
                         assert req_id == "req_1"
                         # The first request took 31 ms, so the client perceived
                         # latency shouldn't be outside this range.
-                        assert 30 < duration_ms < 60
+                        assert 30 < duration_ms < 300
                     else:
                         assert False, (
                             "Should not have reached request %d" % req_num

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import sys
 from threading import Thread
 import json
@@ -141,16 +143,13 @@ class TestIntegration(object):
                     req_num = self.__class__.num_requests
                     if req_num == 1:
                         time.sleep(31 / 1000)  # 31 ms
-                        assert (
+                        assert not self.headers.get(
                             "X-Stripe-Client-Telemetry"
-                            not in self.headers.keys()
                         )
                     elif req_num == 2:
-                        assert (
-                            "X-Stripe-Client-Telemetry" in self.headers.keys()
-                        )
+                        assert self.headers.get("X-Stripe-Client-Telemetry")
                         telemetry = json.loads(
-                            self.headers["X-Stripe-Client-Telemetry"]
+                            self.headers.get("x-stripe-client-telemetry")
                         )
                         assert "last_request_metrics" in telemetry
                         req_id = telemetry["last_request_metrics"][

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import sys
-from threading import Thread
+from threading import Thread, Lock
 import json
 import warnings
 import time
@@ -31,18 +31,21 @@ class TestIntegration(object):
             "api_key": stripe.api_key,
             "default_http_client": stripe.default_http_client,
             "enable_telemetry": stripe.enable_telemetry,
+            "max_network_retries": stripe.max_network_retries,
             "proxy": stripe.proxy,
         }
         stripe.api_base = "http://localhost:12111"  # stripe-mock
         stripe.api_key = "sk_test_123"
         stripe.default_http_client = None
         stripe.enable_telemetry = False
+        stripe.max_network_retries = 3
         stripe.proxy = None
         yield
         stripe.api_base = orig_attrs["api_base"]
         stripe.api_key = orig_attrs["api_key"]
         stripe.default_http_client = orig_attrs["default_http_client"]
         stripe.enable_telemetry = orig_attrs["enable_telemetry"]
+        stripe.max_network_retries = orig_attrs["max_network_retries"]
         stripe.proxy = orig_attrs["proxy"]
 
     def setup_mock_server(self, handler):
@@ -202,3 +205,48 @@ class TestIntegration(object):
         stripe.Balance.retrieve()
         stripe.Balance.retrieve()
         assert MockServerRequestHandler.num_requests == 2
+
+    def test_uses_thread_local_client_telemetry(self):
+        class MockServerRequestHandler(BaseHTTPRequestHandler):
+            num_requests = 0
+            seen_metrics = set()
+            stats_lock = Lock()
+
+            def do_GET(self):
+                with self.__class__.stats_lock:
+                    self.__class__.num_requests += 1
+                    req_num = self.__class__.num_requests
+
+                if self.headers.get("X-Stripe-Client-Telemetry"):
+                    telemetry = json.loads(
+                        self.headers.get("X-Stripe-Client-Telemetry")
+                    )
+                    req_id = telemetry["last_request_metrics"]["request_id"]
+                    with self.__class__.stats_lock:
+                        self.__class__.seen_metrics.add(req_id)
+
+                self.send_response(200)
+                self.send_header(
+                    "Content-Type", "application/json; charset=utf-8"
+                )
+                self.send_header("Request-Id", "req_%d" % req_num)
+                self.end_headers()
+                self.wfile.write(json.dumps({}).encode("utf-8"))
+
+        self.setup_mock_server(MockServerRequestHandler)
+        stripe.api_base = "http://localhost:%s" % self.mock_server_port
+        stripe.enable_telemetry = True
+        stripe.default_http_client = stripe.http_client.RequestsClient()
+
+        def work():
+            stripe.Balance.retrieve()
+            stripe.Balance.retrieve()
+
+        threads = [Thread(target=work) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert MockServerRequestHandler.num_requests == 20
+        assert len(MockServerRequestHandler.seen_metrics) == 10


### PR DESCRIPTION
In #518 I erroneously stored request metrics on the `APIRequestor`, as a new instance of `APIRequestor` is created on each request. This PR moves the tracking of request metrics to the base `HTTPClient`, so that metrics can be stored between requests.

This PR depended on #526, which changed the client to reuse the `HTTPClient` between requests in the default case.

r? @ob-stripe @brandur-stripe 
cc @dcarney-stripe @akropp-stripe 