### PR TITLE
Fix session initialization for multi-threaded environments

### DIFF
--- a/stripe/http_client.py
+++ b/stripe/http_client.py
@@ -194,7 +194,6 @@ class RequestsClient(HTTPClient):
     def __init__(self, timeout=80, session=None, **kwargs):
         super(RequestsClient, self).__init__(**kwargs)
         self._timeout = timeout
-        self._thread_local.session = session or requests.Session()
 
     def request(self, method, url, headers, post_data=None):
         kwargs = {}
@@ -205,6 +204,9 @@ class RequestsClient(HTTPClient):
 
         if self._proxy:
             kwargs["proxies"] = self._proxy
+
+        if getattr(self._thread_local, "session", None) is None:
+            self._thread_local.session = requests.Session()
 
         try:
             try:
@@ -288,7 +290,7 @@ class RequestsClient(HTTPClient):
         raise error.APIConnectionError(msg, should_retry=should_retry)
 
     def close(self):
-        if self._thread_local.session is not None:
+        if getattr(self._thread_local, "session", None) is not None:
             self._thread_local.session.close()
 
 

--- a/stripe/http_client.py
+++ b/stripe/http_client.py
@@ -193,6 +193,7 @@ class RequestsClient(HTTPClient):
 
     def __init__(self, timeout=80, session=None, **kwargs):
         super(RequestsClient, self).__init__(**kwargs)
+        self._session = session
         self._timeout = timeout
 
     def request(self, method, url, headers, post_data=None):
@@ -206,7 +207,7 @@ class RequestsClient(HTTPClient):
             kwargs["proxies"] = self._proxy
 
         if getattr(self._thread_local, "session", None) is None:
-            self._thread_local.session = requests.Session()
+            self._thread_local.session = self._session or requests.Session()
 
         try:
             try:


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Fixes #533.

In #531, we initialized the session in a thread-local store in `RequestsClient`'s constructor. However, a single client instance is initialized for all threads, so only the first thread (that initializes the client) gets a session, and all other threads crash when trying to make a request because `self._thread_local.session` doesn't exist.

This PR fixes this issue by moving the session initialization in the `request()` method. A new session is only initialized if one doesn't already exist in the thread-local store. This way, each thread gets a session the first time it tries to make a request.

We should probably have an automated test for this, but in the meantime I've tested this with a trivial script:
```python
import threading

import stripe


stripe.api_key = "sk_test_..."

def worker():
    print(stripe.Account.retrieve().id)
    return

threads = []
for i in range(5):
    t = threading.Thread(target=worker)
    threads.append(t)
    t.start()
```
