### PR TITLE
[WIP] Test each client for thread safety

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
   global:
     # If changing this number, please also change it in `tests/conftest.py`.
     - STRIPE_MOCK_VERSION=0.60.0
+    - PYCURL_SSL_LIBRARY=openssl
 
 before_install:
   # Unpack and start stripe-mock so that the test suite can talk to it
@@ -43,6 +44,8 @@ before_install:
 install:
   - pip install --upgrade pip virtualenv
   - make venv
+  - source venv/bin/activate
+  - pip install pycurl
 
 script:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then make lint; fi


### PR DESCRIPTION
In light of #533, I think it might be useful to have a smoke test for testing the thread safety of our clients. This PR adds a test to check that each client can be reused across multiple threads without throwing exceptions.