### PR TITLE
Add convert_to_dict method

### DIFF
--- a/stripe/util.py
+++ b/stripe/util.py
@@ -260,6 +260,26 @@ def convert_to_stripe_object(
         return resp
 
 
+def convert_to_dict(obj):
+    """Converts a StripeObject back to a regular dict.
+
+    Nested StripeObjects are also converted back to regular dicts.
+
+    :param obj: The StripeObject to convert.
+
+    :returns: The StripeObject as a dict.
+    """
+    if isinstance(obj, list):
+        return [convert_to_dict(i) for i in obj]
+    # This works by virtue of the fact that StripeObjects _are_ dicts. The dict
+    # comprehension returns a regular dict and recursively applies the
+    # conversion to each value.
+    elif isinstance(obj, dict):
+        return {k: convert_to_dict(v) for k, v in six.iteritems(obj)}
+    else:
+        return obj
+
+
 def populate_headers(idempotency_key):
     if idempotency_key is not None:
         return {"Idempotency-Key": idempotency_key}

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import sys
 from collections import namedtuple
 
+import stripe
 from stripe import util
 from stripe.six.moves import builtins
 
@@ -125,3 +126,28 @@ class TestUtil(object):
         for case in cases:
             result = util.logfmt(case.props)
             assert result == case.expected
+
+    def test_convert_to_stripe_object_and_back(self):
+        resp = {
+            "object": "balance",
+            "available": [
+                {
+                    "amount": 234,
+                    "currency": "usd",
+                    "source_types": {"card": 234},
+                }
+            ],
+            "livemode": False,
+        }
+
+        obj = util.convert_to_stripe_object(resp)
+        assert type(obj) == stripe.Balance
+        assert type(obj.available) == list
+        assert type(obj.available[0]) == stripe.stripe_object.StripeObject
+
+        d = util.convert_to_dict(obj)
+        assert type(d) == dict
+        assert type(d["available"]) == list
+        assert type(d["available"][0]) == dict
+
+        assert d == resp


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Adds a `stripe.util.convert_to_dict` method that recursively converts `StripeObject` instances to `dict`s.

Partial fix for #219.
