### PR TITLE
Add support for static deletion

### DIFF
--- a/stripe/api_resources/abstract/api_resource.py
+++ b/stripe/api_resources/abstract/api_resource.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from stripe import error, util, six
+from stripe import api_requestor, error, util, six
 from stripe.stripe_object import StripeObject
 from stripe.six.moves.urllib.parse import quote_plus
 
@@ -43,3 +43,23 @@ class APIResource(StripeObject):
         base = self.class_url()
         extn = quote_plus(id)
         return "%s/%s" % (base, extn)
+
+    @classmethod
+    def _static_request(
+        cls,
+        method,
+        url,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        requestor = api_requestor.APIRequestor(
+            api_key, api_version=stripe_version, account=stripe_account
+        )
+        headers = util.populate_headers(idempotency_key)
+        response, api_key = requestor.request(method, url, params, headers)
+        return util.convert_to_stripe_object(
+            response, api_key, stripe_version, stripe_account
+        )

--- a/stripe/api_resources/abstract/deletable_api_resource.py
+++ b/stripe/api_resources/abstract/deletable_api_resource.py
@@ -1,9 +1,17 @@
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract.api_resource import APIResource
+from stripe.six.moves.urllib.parse import quote_plus
 
 
 class DeletableAPIResource(APIResource):
+    @classmethod
+    def _cls_delete(cls, sid, **params):
+        url = "%s/%s" % (cls.class_url(), quote_plus(util.utf8(sid)))
+        return cls._static_request("delete", url, **params)
+
+    @util.class_method_variant("_cls_delete")
     def delete(self, **params):
         self.refresh_from(self.request("delete", self.instance_url(), params))
         return self

--- a/stripe/api_resources/abstract/updateable_api_resource.py
+++ b/stripe/api_resources/abstract/updateable_api_resource.py
@@ -1,34 +1,15 @@
 from __future__ import absolute_import, division, print_function
 
-from stripe import api_requestor, util
+from stripe import util
 from stripe.api_resources.abstract.api_resource import APIResource
 from stripe.six.moves.urllib.parse import quote_plus
 
 
 class UpdateableAPIResource(APIResource):
     @classmethod
-    def _modify(
-        cls,
-        url,
-        api_key=None,
-        idempotency_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        requestor = api_requestor.APIRequestor(
-            api_key, api_version=stripe_version, account=stripe_account
-        )
-        headers = util.populate_headers(idempotency_key)
-        response, api_key = requestor.request("post", url, params, headers)
-        return util.convert_to_stripe_object(
-            response, api_key, stripe_version, stripe_account
-        )
-
-    @classmethod
     def modify(cls, sid, **params):
         url = "%s/%s" % (cls.class_url(), quote_plus(util.utf8(sid)))
-        return cls._modify(url, **params)
+        return cls._static_request("post", url, **params)
 
     def save(self, idempotency_key=None):
         updated_params = self.serialize(None)

--- a/stripe/api_resources/account.py
+++ b/stripe/api_resources/account.py
@@ -35,7 +35,8 @@ class Account(
 
     @classmethod
     def modify(cls, id=None, **params):
-        return cls._modify(cls._build_instance_url(id), **params)
+        url = cls._build_instance_url(id)
+        return cls._static_request("post", url, **params)
 
     @classmethod
     def _build_instance_url(cls, sid):

--- a/stripe/api_resources/alipay_account.py
+++ b/stripe/api_resources/alipay_account.py
@@ -28,7 +28,7 @@ class AlipayAccount(UpdateableAPIResource, DeletableAPIResource):
     @classmethod
     def modify(cls, customer, id, **params):
         url = cls._build_instance_url(customer, id)
-        return cls._modify(url, **params)
+        return cls._static_request("post", url, **params)
 
     @classmethod
     def retrieve(

--- a/stripe/api_resources/application_fee_refund.py
+++ b/stripe/api_resources/application_fee_refund.py
@@ -22,7 +22,7 @@ class ApplicationFeeRefund(UpdateableAPIResource):
     @classmethod
     def modify(cls, fee, sid, **params):
         url = cls._build_instance_url(fee, sid)
-        return cls._modify(url, **params)
+        return cls._static_request("post", url, **params)
 
     def instance_url(self):
         return self._build_instance_url(self.fee, self.id)

--- a/stripe/util.py
+++ b/stripe/util.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import functools
 import hmac
 import io
 import logging
@@ -285,3 +286,23 @@ def populate_headers(idempotency_key):
     if idempotency_key is not None:
         return {"Idempotency-Key": idempotency_key}
     return None
+
+
+class class_method_variant(object):
+    def __init__(self, class_method_name):
+        self.class_method_name = class_method_name
+
+    def __call__(self, method):
+        self.method = method
+        return self
+
+    def __get__(self, obj=None, objtype=None):
+        @functools.wraps(self.method)
+        def _wrapper(*args, **kwargs):
+            if obj is not None:
+                return self.method(obj, *args, **kwargs)
+            else:
+                class_method = getattr(objtype, self.class_method_name)
+                return class_method(*args, **kwargs)
+
+        return _wrapper

--- a/tests/api_resources/abstract/test_deletable_api_resource.py
+++ b/tests/api_resources/abstract/test_deletable_api_resource.py
@@ -7,7 +7,24 @@ class TestDeletableAPIResource(object):
     class MyDeletable(stripe.api_resources.abstract.DeletableAPIResource):
         OBJECT_NAME = "mydeletable"
 
-    def test_delete(self, request_mock):
+    def test_delete_class(self, request_mock):
+        request_mock.stub_request(
+            "delete",
+            "/v1/mydeletables/mid",
+            {"id": "mid", "deleted": True},
+            rheaders={"request-id": "req_id"},
+        )
+
+        obj = self.MyDeletable.delete("mid")
+
+        request_mock.assert_requested("delete", "/v1/mydeletables/mid", {})
+        assert obj.deleted is True
+        assert obj.id == "mid"
+
+        assert obj.last_response is not None
+        assert obj.last_response.request_id == "req_id"
+
+    def test_delete_instance(self, request_mock):
         request_mock.stub_request(
             "delete",
             "/v1/mydeletables/mid",

--- a/tests/api_resources/radar/test_value_list.py
+++ b/tests/api_resources/radar/test_value_list.py
@@ -49,3 +49,10 @@ class TestValueList(object):
             "delete", "/v1/radar/value_lists/%s" % TEST_RESOURCE_ID
         )
         assert resource.deleted is True
+
+    def test_can_delete(self, request_mock):
+        resource = stripe.radar.ValueList.delete(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "delete", "/v1/radar/value_lists/%s" % TEST_RESOURCE_ID
+        )
+        assert resource.deleted is True

--- a/tests/api_resources/radar/test_value_list_item.py
+++ b/tests/api_resources/radar/test_value_list_item.py
@@ -34,3 +34,10 @@ class TestValueListItem(object):
             "delete", "/v1/radar/value_list_items/%s" % TEST_RESOURCE_ID
         )
         assert resource.deleted is True
+
+    def test_can_delete(self, request_mock):
+        resource = stripe.radar.ValueListItem.delete(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "delete", "/v1/radar/value_list_items/%s" % TEST_RESOURCE_ID
+        )
+        assert resource.deleted is True

--- a/tests/api_resources/terminal/test_location.py
+++ b/tests/api_resources/terminal/test_location.py
@@ -60,3 +60,10 @@ class TestLocation(object):
             "delete", "/v1/terminal/locations/%s" % TEST_RESOURCE_ID
         )
         assert resource.deleted is True
+
+    def test_can_delete(self, request_mock):
+        resource = stripe.terminal.Location.delete(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "delete", "/v1/terminal/locations/%s" % TEST_RESOURCE_ID
+        )
+        assert resource.deleted is True

--- a/tests/api_resources/terminal/test_reader.py
+++ b/tests/api_resources/terminal/test_reader.py
@@ -53,3 +53,10 @@ class TestReader(object):
             "delete", "/v1/terminal/readers/%s" % TEST_RESOURCE_ID
         )
         assert resource.deleted is True
+
+    def test_can_delete(self, request_mock):
+        resource = stripe.terminal.Reader.delete(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "delete", "/v1/terminal/readers/%s" % TEST_RESOURCE_ID
+        )
+        assert resource.deleted is True

--- a/tests/api_resources/test_account.py
+++ b/tests/api_resources/test_account.py
@@ -80,6 +80,13 @@ class TestAccount(object):
         )
         assert resource.deleted is True
 
+    def test_can_delete(self, request_mock):
+        resource = stripe.Account.delete(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "delete", "/v1/accounts/%s" % TEST_RESOURCE_ID
+        )
+        assert resource.deleted is True
+
     def test_can_retrieve_no_id(self, request_mock):
         resource = stripe.Account.retrieve()
         request_mock.assert_requested("get", "/v1/account")

--- a/tests/api_resources/test_apple_pay_domain.py
+++ b/tests/api_resources/test_apple_pay_domain.py
@@ -32,3 +32,10 @@ class TestApplePayDomain(object):
             "delete", "/v1/apple_pay/domains/%s" % TEST_RESOURCE_ID
         )
         assert resource.deleted is True
+
+    def test_can_delete(self, request_mock):
+        resource = stripe.ApplePayDomain.delete(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "delete", "/v1/apple_pay/domains/%s" % TEST_RESOURCE_ID
+        )
+        assert resource.deleted is True

--- a/tests/api_resources/test_coupon.py
+++ b/tests/api_resources/test_coupon.py
@@ -54,3 +54,10 @@ class TestCoupon(object):
             "delete", "/v1/coupons/%s" % TEST_RESOURCE_ID
         )
         assert resource.deleted is True
+
+    def test_can_delete(self, request_mock):
+        resource = stripe.Coupon.delete(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "delete", "/v1/coupons/%s" % TEST_RESOURCE_ID
+        )
+        assert resource.deleted is True

--- a/tests/api_resources/test_customer.py
+++ b/tests/api_resources/test_customer.py
@@ -52,6 +52,13 @@ class TestCustomer(object):
         )
         assert resource.deleted is True
 
+    def test_can_delete(self, request_mock):
+        resource = stripe.Customer.delete(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "delete", "/v1/customers/%s" % TEST_RESOURCE_ID
+        )
+        assert resource.deleted is True
+
     def test_can_delete_discount(self, request_mock):
         resource = stripe.Customer.retrieve(TEST_RESOURCE_ID)
         resource.delete_discount()

--- a/tests/api_resources/test_ephemeral_key.py
+++ b/tests/api_resources/test_ephemeral_key.py
@@ -30,3 +30,11 @@ class TestEphemeralKey(object):
         request_mock.assert_requested(
             "delete", "/v1/ephemeral_keys/%s" % resource.id
         )
+        assert isinstance(resource, stripe.EphemeralKey)
+
+    def test_can_delete(self, request_mock):
+        resource = stripe.EphemeralKey.delete("ephkey_123")
+        request_mock.assert_requested(
+            "delete", "/v1/ephemeral_keys/ephkey_123"
+        )
+        assert isinstance(resource, stripe.EphemeralKey)

--- a/tests/api_resources/test_invoice.py
+++ b/tests/api_resources/test_invoice.py
@@ -50,6 +50,13 @@ class TestInvoice(object):
         )
         assert resource.deleted is True
 
+    def test_can_delete(self, request_mock):
+        resource = stripe.Invoice.delete(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "delete", "/v1/invoices/%s" % TEST_RESOURCE_ID
+        )
+        assert resource.deleted is True
+
     def test_can_finalize_invoice(self, request_mock):
         resource = stripe.Invoice.retrieve(TEST_RESOURCE_ID)
         resource = resource.finalize_invoice()

--- a/tests/api_resources/test_invoice_item.py
+++ b/tests/api_resources/test_invoice_item.py
@@ -35,6 +35,13 @@ class TestInvoiceItem(object):
             "post", "/v1/invoiceitems/%s" % TEST_RESOURCE_ID
         )
 
+    def test_can_delete(self, request_mock):
+        resource = stripe.InvoiceItem.delete(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "delete", "/v1/invoiceitems/%s" % TEST_RESOURCE_ID
+        )
+        assert resource.deleted is True
+
     def test_is_modifiable(self, request_mock):
         resource = stripe.InvoiceItem.modify(
             TEST_RESOURCE_ID, metadata={"key": "value"}

--- a/tests/api_resources/test_plan.py
+++ b/tests/api_resources/test_plan.py
@@ -53,3 +53,10 @@ class TestPlan(object):
             "delete", "/v1/plans/%s" % TEST_RESOURCE_ID
         )
         assert resource.deleted is True
+
+    def test_can_delete(self, request_mock):
+        resource = stripe.Plan.delete(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "delete", "/v1/plans/%s" % TEST_RESOURCE_ID
+        )
+        assert resource.deleted is True

--- a/tests/api_resources/test_product.py
+++ b/tests/api_resources/test_product.py
@@ -49,3 +49,10 @@ class TestProduct(object):
             "delete", "/v1/products/%s" % TEST_RESOURCE_ID
         )
         assert resource.deleted is True
+
+    def test_can_delete(self, request_mock):
+        resource = stripe.Product.delete(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "delete", "/v1/products/%s" % TEST_RESOURCE_ID
+        )
+        assert resource.deleted is True

--- a/tests/api_resources/test_recipient.py
+++ b/tests/api_resources/test_recipient.py
@@ -49,3 +49,10 @@ class TestRecipient(object):
             "delete", "/v1/recipients/%s" % TEST_RESOURCE_ID
         )
         assert resource.deleted is True
+
+    def test_can_delete(self, request_mock):
+        resource = stripe.Recipient.delete(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "delete", "/v1/recipients/%s" % TEST_RESOURCE_ID
+        )
+        assert resource.deleted is True

--- a/tests/api_resources/test_sku.py
+++ b/tests/api_resources/test_sku.py
@@ -48,3 +48,10 @@ class TestSKU(object):
             "delete", "/v1/skus/%s" % TEST_RESOURCE_ID
         )
         assert resource.deleted is True
+
+    def test_can_delete(self, request_mock):
+        resource = stripe.SKU.delete(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "delete", "/v1/skus/%s" % TEST_RESOURCE_ID
+        )
+        assert resource.deleted is True

--- a/tests/api_resources/test_subscription.py
+++ b/tests/api_resources/test_subscription.py
@@ -50,6 +50,13 @@ class TestSubscription(object):
         )
         assert isinstance(resource, stripe.Subscription)
 
+    def test_can_delete(self, request_mock):
+        resource = stripe.Subscription.delete(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "delete", "/v1/subscriptions/%s" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.Subscription)
+
     def test_can_delete_discount(self, request_mock):
         sub = stripe.Subscription.retrieve(TEST_RESOURCE_ID)
         sub.delete_discount()

--- a/tests/api_resources/test_subscription_item.py
+++ b/tests/api_resources/test_subscription_item.py
@@ -57,3 +57,10 @@ class TestSubscriptionItem(object):
             "delete", "/v1/subscription_items/%s" % TEST_RESOURCE_ID
         )
         assert resource.deleted is True
+
+    def test_can_delete(self, request_mock):
+        resource = stripe.SubscriptionItem.delete(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "delete", "/v1/subscription_items/%s" % TEST_RESOURCE_ID
+        )
+        assert resource.deleted is True

--- a/tests/api_resources/test_webhook_endpoint.py
+++ b/tests/api_resources/test_webhook_endpoint.py
@@ -51,3 +51,10 @@ class TestWebhookEndpoint(object):
             "delete", "/v1/webhook_endpoints/%s" % TEST_RESOURCE_ID
         )
         assert resource.deleted is True
+
+    def test_can_delete(self, request_mock):
+        resource = stripe.WebhookEndpoint.delete(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "delete", "/v1/webhook_endpoints/%s" % TEST_RESOURCE_ID
+        )
+        assert resource.deleted is True


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 

A very hacky and experimental way of adding support for static deletion on deletable resource classes.

Normally, Python doesn't allow you to have both a class and instance method with the same name. This PR works around this limitation by defining a special `class_or_instance_method` decorator. The decorator is defined as a [non-data descriptor](https://docs.python.org/3/howto/descriptor.html). Descriptors receive both the instance and the class as arguments in their `__get__` method. The method checks if the instance variable (`obj`) is `None` or not to decide whether the method should be called as a class method (with the type variable `objtype` as the first argument) or as an instance method (with the instance variable `obj` as the first argument).

The actual "class or instance method" can then check if its first argument is a type or not to decide whether it was called from a class or from an instance and behave appropriately.

Tagged as WIP because this is rather hacky and I want to get your thoughts on it first. If we're comfortable with this approach, I'll add some safeguards around arguments (right now if you call e.g. `stripe.Customer.delete()` without any arguments, you get a very unclear "tuple index out of range" error because the code tries to access `args[0]` to get the ID) and write additional tests.