### PR TITLE
`custom_method` decorator for defining static methods for custom API requests

### DIFF
--- a/stripe/api_resources/abstract/__init__.py
+++ b/stripe/api_resources/abstract/__init__.py
@@ -21,6 +21,8 @@ from stripe.api_resources.abstract.listable_api_resource import (
 )
 from stripe.api_resources.abstract.verify_mixin import VerifyMixin
 
+from stripe.api_resources.abstract.custom_method import custom_method
+
 from stripe.api_resources.abstract.nested_resource_class_methods import (
     nested_resource_class_methods,
 )

--- a/stripe/api_resources/abstract/custom_method.py
+++ b/stripe/api_resources/abstract/custom_method.py
@@ -1,0 +1,43 @@
+from __future__ import absolute_import, division, print_function
+
+from stripe import util
+from stripe.six.moves.urllib.parse import quote_plus
+
+
+def custom_method(name, http_verb, http_path=None):
+    if http_verb not in ["get", "post", "delete"]:
+        raise ValueError(
+            "Invalid http_verb: %s. Must be one of 'get', 'post' or 'delete'"
+            % http_verb
+        )
+    if http_path is None:
+        http_path = name
+
+    def wrapper(cls):
+        def custom_method_request(cls, sid, **params):
+            url = "%s/%s/%s" % (
+                cls.class_url(),
+                quote_plus(util.utf8(sid)),
+                http_path,
+            )
+            return cls._static_request(http_verb, url, **params)
+
+        existing_method = getattr(cls, name, None)
+        if existing_method is None:
+            setattr(cls, name, classmethod(custom_method_request))
+        else:
+            # If a method with the same name we want to use already exists on
+            # the class, we assume it's an instance method. In this case, the
+            # new class method is prefixed with `_cls_`, and the original
+            # instance method is decorated with `util.class_method_variant` so
+            # that the new class method is called when the original method is
+            # called as a class method.
+            setattr(cls, "_cls_" + name, classmethod(custom_method_request))
+            instance_method = util.class_method_variant("_cls_" + name)(
+                existing_method
+            )
+            setattr(cls, name, instance_method)
+
+        return cls
+
+    return wrapper

--- a/stripe/api_resources/account.py
+++ b/stripe/api_resources/account.py
@@ -7,10 +7,11 @@ from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import nested_resource_class_methods
-
+from stripe.api_resources.abstract import custom_method
 from stripe.six.moves.urllib.parse import quote_plus
 
 
+@custom_method("reject", http_verb="post")
 @nested_resource_class_methods(
     "external_account",
     operations=["create", "retrieve", "update", "delete", "list"],

--- a/stripe/api_resources/charge.py
+++ b/stripe/api_resources/charge.py
@@ -4,8 +4,10 @@ from stripe import api_requestor, util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.abstract import custom_method
 
 
+@custom_method("capture", http_verb="post")
 class Charge(
     CreateableAPIResource, ListableAPIResource, UpdateableAPIResource
 ):

--- a/stripe/api_resources/customer.py
+++ b/stripe/api_resources/customer.py
@@ -5,9 +5,11 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.abstract import custom_method
 from stripe.api_resources.abstract import nested_resource_class_methods
 
 
+@custom_method("delete_discount", http_verb="delete", http_path="discount")
 @nested_resource_class_methods(
     "source", operations=["create", "retrieve", "update", "delete", "list"]
 )

--- a/stripe/api_resources/dispute.py
+++ b/stripe/api_resources/dispute.py
@@ -3,8 +3,10 @@ from __future__ import absolute_import, division, print_function
 from stripe import util
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.abstract import custom_method
 
 
+@custom_method("close", http_verb="post")
 class Dispute(ListableAPIResource, UpdateableAPIResource):
     OBJECT_NAME = "dispute"
 

--- a/stripe/api_resources/invoice.py
+++ b/stripe/api_resources/invoice.py
@@ -5,8 +5,14 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.abstract import custom_method
 
 
+@custom_method("finalize_invoice", http_verb="post", http_path="finalize")
+@custom_method("mark_uncollectible", http_verb="post")
+@custom_method("pay", http_verb="post")
+@custom_method("send_invoice", http_verb="post", http_path="send")
+@custom_method("void_invoice", http_verb="post", http_path="void")
 class Invoice(
     CreateableAPIResource,
     UpdateableAPIResource,

--- a/stripe/api_resources/issuing/authorization.py
+++ b/stripe/api_resources/issuing/authorization.py
@@ -3,8 +3,11 @@ from __future__ import absolute_import, division, print_function
 from stripe import util
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.abstract import custom_method
 
 
+@custom_method("approve", http_verb="post")
+@custom_method("decline", http_verb="post")
 class Authorization(ListableAPIResource, UpdateableAPIResource):
     OBJECT_NAME = "issuing.authorization"
 

--- a/stripe/api_resources/issuing/card.py
+++ b/stripe/api_resources/issuing/card.py
@@ -3,8 +3,10 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.abstract import custom_method
 
 
+@custom_method("details", http_verb="get")
 class Card(CreateableAPIResource, ListableAPIResource, UpdateableAPIResource):
     OBJECT_NAME = "issuing.card"
 

--- a/stripe/api_resources/order.py
+++ b/stripe/api_resources/order.py
@@ -4,8 +4,11 @@ from stripe import util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.abstract import custom_method
 
 
+@custom_method("pay", http_verb="post")
+@custom_method("return_order", http_verb="post", http_path="returns")
 class Order(CreateableAPIResource, UpdateableAPIResource, ListableAPIResource):
     OBJECT_NAME = "order"
 

--- a/stripe/api_resources/payment_intent.py
+++ b/stripe/api_resources/payment_intent.py
@@ -4,8 +4,12 @@ from stripe import util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.abstract import custom_method
 
 
+@custom_method("cancel", http_verb="post")
+@custom_method("capture", http_verb="post")
+@custom_method("confirm", http_verb="post")
 class PaymentIntent(
     CreateableAPIResource, UpdateableAPIResource, ListableAPIResource
 ):

--- a/stripe/api_resources/payment_method.py
+++ b/stripe/api_resources/payment_method.py
@@ -4,8 +4,11 @@ from stripe import util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.abstract import custom_method
 
 
+@custom_method("attach", http_verb="post")
+@custom_method("detach", http_verb="post")
 class PaymentMethod(
     CreateableAPIResource, ListableAPIResource, UpdateableAPIResource
 ):

--- a/stripe/api_resources/payout.py
+++ b/stripe/api_resources/payout.py
@@ -4,8 +4,10 @@ from stripe import util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.abstract import custom_method
 
 
+@custom_method("cancel", http_verb="post")
 class Payout(
     CreateableAPIResource, UpdateableAPIResource, ListableAPIResource
 ):

--- a/stripe/api_resources/review.py
+++ b/stripe/api_resources/review.py
@@ -2,8 +2,10 @@ from __future__ import absolute_import, division, print_function
 
 from stripe import util
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.abstract import custom_method
 
 
+@custom_method("approve", http_verb="post")
 class Review(ListableAPIResource):
     OBJECT_NAME = "review"
 

--- a/stripe/api_resources/subscription.py
+++ b/stripe/api_resources/subscription.py
@@ -5,8 +5,10 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.abstract import custom_method
 
 
+@custom_method("delete_discount", http_verb="delete", http_path="discount")
 class Subscription(
     CreateableAPIResource,
     DeletableAPIResource,

--- a/stripe/api_resources/subscription_schedule.py
+++ b/stripe/api_resources/subscription_schedule.py
@@ -5,8 +5,11 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import nested_resource_class_methods
+from stripe.api_resources.abstract import custom_method
 
 
+@custom_method("cancel", http_verb="post")
+@custom_method("release", http_verb="post")
 @nested_resource_class_methods("revision", operations=["retrieve", "list"])
 class SubscriptionSchedule(
     CreateableAPIResource, UpdateableAPIResource, ListableAPIResource

--- a/stripe/api_resources/topup.py
+++ b/stripe/api_resources/topup.py
@@ -4,8 +4,10 @@ from stripe import util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.abstract import custom_method
 
 
+@custom_method("cancel", http_verb="post")
 class Topup(CreateableAPIResource, ListableAPIResource, UpdateableAPIResource):
     OBJECT_NAME = "topup"
 

--- a/stripe/api_resources/transfer.py
+++ b/stripe/api_resources/transfer.py
@@ -5,8 +5,10 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import nested_resource_class_methods
+from stripe.api_resources.abstract import custom_method
 
 
+@custom_method("cancel", http_verb="post")
 @nested_resource_class_methods(
     "reversal", operations=["create", "retrieve", "update", "list"]
 )

--- a/tests/api_resources/issuing/test_authorization.py
+++ b/tests/api_resources/issuing/test_authorization.py
@@ -39,7 +39,7 @@ class TestAuthorization(object):
         assert isinstance(resource, stripe.issuing.Authorization)
         assert resource is authorization
 
-    def test_is_approveable(self, request_mock):
+    def test_can_approve(self, request_mock):
         resource = stripe.issuing.Authorization.retrieve(TEST_RESOURCE_ID)
         authorization = resource.approve()
         request_mock.assert_requested(
@@ -48,7 +48,14 @@ class TestAuthorization(object):
         assert isinstance(resource, stripe.issuing.Authorization)
         assert resource is authorization
 
-    def test_is_declineable(self, request_mock):
+    def test_can_approve_classmethod(self, request_mock):
+        resource = stripe.issuing.Authorization.approve(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "post", "/v1/issuing/authorizations/%s/approve" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.issuing.Authorization)
+
+    def test_can_decline(self, request_mock):
         resource = stripe.issuing.Authorization.retrieve(TEST_RESOURCE_ID)
         authorization = resource.decline()
         request_mock.assert_requested(
@@ -56,3 +63,10 @@ class TestAuthorization(object):
         )
         assert isinstance(resource, stripe.issuing.Authorization)
         assert resource is authorization
+
+    def test_can_decline_classmethod(self, request_mock):
+        resource = stripe.issuing.Authorization.decline(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "post", "/v1/issuing/authorizations/%s/decline" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.issuing.Authorization)

--- a/tests/api_resources/issuing/test_card.py
+++ b/tests/api_resources/issuing/test_card.py
@@ -51,3 +51,10 @@ class TestCard(object):
             "get", "/v1/issuing/cards/%s/details" % TEST_RESOURCE_ID
         )
         assert isinstance(card_details, stripe.issuing.CardDetails)
+
+    def test_can_retrieve_details_classmethod(self, request_mock):
+        card_details = stripe.issuing.Card.details(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "get", "/v1/issuing/cards/%s/details" % TEST_RESOURCE_ID
+        )
+        assert isinstance(card_details, stripe.issuing.CardDetails)

--- a/tests/api_resources/test_account.py
+++ b/tests/api_resources/test_account.py
@@ -96,10 +96,21 @@ class TestAccount(object):
         account = stripe.Account.retrieve(TEST_RESOURCE_ID)
         resource = account.reject(reason="fraud")
         request_mock.assert_requested(
-            "post", "/v1/accounts/%s/reject" % TEST_RESOURCE_ID
+            "post",
+            "/v1/accounts/%s/reject" % TEST_RESOURCE_ID,
+            {"reason": "fraud"},
         )
         assert isinstance(resource, stripe.Account)
         assert resource is account
+
+    def test_can_reject_classmethod(self, request_mock):
+        resource = stripe.Account.reject(TEST_RESOURCE_ID, reason="fraud")
+        request_mock.assert_requested(
+            "post",
+            "/v1/accounts/%s/reject" % TEST_RESOURCE_ID,
+            {"reason": "fraud"},
+        )
+        assert isinstance(resource, stripe.Account)
 
     def test_is_deauthorizable(self, request_mock):
         account = stripe.Account.retrieve(TEST_RESOURCE_ID)

--- a/tests/api_resources/test_charge.py
+++ b/tests/api_resources/test_charge.py
@@ -52,7 +52,7 @@ class TestCharge(object):
         )
         assert isinstance(resource, stripe.Charge)
 
-    def test_is_capturable(self, request_mock):
+    def test_can_capture(self, request_mock):
         charge = stripe.Charge.retrieve(TEST_RESOURCE_ID)
         resource = charge.capture()
         request_mock.assert_requested(
@@ -60,7 +60,7 @@ class TestCharge(object):
         )
         assert isinstance(resource, stripe.Charge)
 
-    def test_can_capture(self, request_mock):
+    def test_can_capture_classmethod(self, request_mock):
         resource = stripe.Charge.capture(TEST_RESOURCE_ID)
         request_mock.assert_requested(
             "post", "/v1/charges/%s/capture" % TEST_RESOURCE_ID

--- a/tests/api_resources/test_charge.py
+++ b/tests/api_resources/test_charge.py
@@ -60,6 +60,13 @@ class TestCharge(object):
         )
         assert isinstance(resource, stripe.Charge)
 
+    def test_can_capture(self, request_mock):
+        resource = stripe.Charge.capture(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "post", "/v1/charges/%s/capture" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.Charge)
+
     def test_can_update_dispute(self, request_mock):
         charge = stripe.Charge.retrieve(TEST_RESOURCE_ID)
         resource = charge.update_dispute()

--- a/tests/api_resources/test_customer.py
+++ b/tests/api_resources/test_customer.py
@@ -66,6 +66,12 @@ class TestCustomer(object):
             "delete", "/v1/customers/%s/discount" % TEST_RESOURCE_ID
         )
 
+    def test_can_delete_discount_class_method(self, request_mock):
+        stripe.Customer.delete_discount(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "delete", "/v1/customers/%s/discount" % TEST_RESOURCE_ID
+        )
+
 
 class TestCustomerSources(object):
     def test_is_creatable(self, request_mock):

--- a/tests/api_resources/test_dispute.py
+++ b/tests/api_resources/test_dispute.py
@@ -37,9 +37,17 @@ class TestDispute(object):
         )
         assert isinstance(resource, stripe.Dispute)
 
-    def test_is_closeable(self, request_mock):
+    def test_can_close(self, request_mock):
         resource = stripe.Dispute.retrieve(TEST_RESOURCE_ID)
         resource.close()
         request_mock.assert_requested(
             "post", "/v1/disputes/%s/close" % TEST_RESOURCE_ID
         )
+        assert isinstance(resource, stripe.Dispute)
+
+    def test_can_close_classmethod(self, request_mock):
+        resource = stripe.Dispute.close(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "post", "/v1/disputes/%s/close" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.Dispute)

--- a/tests/api_resources/test_invoice.py
+++ b/tests/api_resources/test_invoice.py
@@ -65,9 +65,23 @@ class TestInvoice(object):
         )
         assert isinstance(resource, stripe.Invoice)
 
+    def test_can_finalize_invoice_classmethod(self, request_mock):
+        resource = stripe.Invoice.finalize_invoice(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "post", "/v1/invoices/%s/finalize" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.Invoice)
+
     def test_can_mark_uncollectible(self, request_mock):
         resource = stripe.Invoice.retrieve(TEST_RESOURCE_ID)
         resource = resource.mark_uncollectible()
+        request_mock.assert_requested(
+            "post", "/v1/invoices/%s/mark_uncollectible" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.Invoice)
+
+    def test_can_mark_uncollectible_classmethod(self, request_mock):
+        resource = stripe.Invoice.mark_uncollectible(TEST_RESOURCE_ID)
         request_mock.assert_requested(
             "post", "/v1/invoices/%s/mark_uncollectible" % TEST_RESOURCE_ID
         )
@@ -81,9 +95,23 @@ class TestInvoice(object):
         )
         assert isinstance(resource, stripe.Invoice)
 
+    def test_can_pay_classmethod(self, request_mock):
+        resource = stripe.Invoice.pay(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "post", "/v1/invoices/%s/pay" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.Invoice)
+
     def test_can_send_invoice(self, request_mock):
         resource = stripe.Invoice.retrieve(TEST_RESOURCE_ID)
         resource = resource.send_invoice()
+        request_mock.assert_requested(
+            "post", "/v1/invoices/%s/send" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.Invoice)
+
+    def test_can_send_invoice_classmethod(self, request_mock):
+        resource = stripe.Invoice.send_invoice(TEST_RESOURCE_ID)
         request_mock.assert_requested(
             "post", "/v1/invoices/%s/send" % TEST_RESOURCE_ID
         )
@@ -97,6 +125,13 @@ class TestInvoice(object):
     def test_can_void_invoice(self, request_mock):
         resource = stripe.Invoice.retrieve(TEST_RESOURCE_ID)
         resource = resource.void_invoice()
+        request_mock.assert_requested(
+            "post", "/v1/invoices/%s/void" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.Invoice)
+
+    def test_can_void_invoice_classmethod(self, request_mock):
+        resource = stripe.Invoice.void_invoice(TEST_RESOURCE_ID)
         request_mock.assert_requested(
             "post", "/v1/invoices/%s/void" % TEST_RESOURCE_ID
         )

--- a/tests/api_resources/test_order.py
+++ b/tests/api_resources/test_order.py
@@ -42,19 +42,37 @@ class TestOrder(object):
         )
         assert isinstance(resource, stripe.Order)
 
-    def test_is_payable(self, request_mock):
+    def test_can_pay(self, request_mock):
         order = stripe.Order.retrieve(TEST_RESOURCE_ID)
         resource = order.pay(source="src_123")
         request_mock.assert_requested(
-            "post", "/v1/orders/%s/pay" % order.id, {"source": "src_123"}
+            "post",
+            "/v1/orders/%s/pay" % TEST_RESOURCE_ID,
+            {"source": "src_123"},
         )
         assert isinstance(resource, stripe.Order)
         assert resource is order
 
-    def test_is_returnable(self, request_mock):
+    def test_can_pay_classmethod(self, request_mock):
+        resource = stripe.Order.pay(TEST_RESOURCE_ID, source="src_123")
+        request_mock.assert_requested(
+            "post",
+            "/v1/orders/%s/pay" % TEST_RESOURCE_ID,
+            {"source": "src_123"},
+        )
+        assert isinstance(resource, stripe.Order)
+
+    def test_can_return(self, request_mock):
         order = stripe.Order.retrieve(TEST_RESOURCE_ID)
         resource = order.return_order()
         request_mock.assert_requested(
-            "post", "/v1/orders/%s/returns" % order.id
+            "post", "/v1/orders/%s/returns" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.OrderReturn)
+
+    def test_can_return_classmethod(self, request_mock):
+        resource = stripe.Order.return_order(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "post", "/v1/orders/%s/returns" % TEST_RESOURCE_ID
         )
         assert isinstance(resource, stripe.OrderReturn)

--- a/tests/api_resources/test_payment_intent.py
+++ b/tests/api_resources/test_payment_intent.py
@@ -52,8 +52,14 @@ class TestPaymentIntent(object):
 
     def test_can_cancel(self, request_mock):
         resource = stripe.PaymentIntent.retrieve(TEST_RESOURCE_ID)
-
         resource.cancel()
+        request_mock.assert_requested(
+            "post", "/v1/payment_intents/%s/cancel" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.PaymentIntent)
+
+    def test_can_cancel_classmethod(self, request_mock):
+        resource = stripe.PaymentIntent.cancel(TEST_RESOURCE_ID)
         request_mock.assert_requested(
             "post", "/v1/payment_intents/%s/cancel" % TEST_RESOURCE_ID
         )
@@ -61,8 +67,14 @@ class TestPaymentIntent(object):
 
     def test_can_capture(self, request_mock):
         resource = stripe.PaymentIntent.retrieve(TEST_RESOURCE_ID)
-
         resource.capture()
+        request_mock.assert_requested(
+            "post", "/v1/payment_intents/%s/capture" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.PaymentIntent)
+
+    def test_can_capture_classmethod(self, request_mock):
+        resource = stripe.PaymentIntent.capture(TEST_RESOURCE_ID)
         request_mock.assert_requested(
             "post", "/v1/payment_intents/%s/capture" % TEST_RESOURCE_ID
         )
@@ -70,8 +82,14 @@ class TestPaymentIntent(object):
 
     def test_can_confirm(self, request_mock):
         resource = stripe.PaymentIntent.retrieve(TEST_RESOURCE_ID)
-
         resource.confirm()
+        request_mock.assert_requested(
+            "post", "/v1/payment_intents/%s/confirm" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.PaymentIntent)
+
+    def test_can_confirm_classmethod(self, request_mock):
+        resource = stripe.PaymentIntent.confirm(TEST_RESOURCE_ID)
         request_mock.assert_requested(
             "post", "/v1/payment_intents/%s/confirm" % TEST_RESOURCE_ID
         )

--- a/tests/api_resources/test_payment_method.py
+++ b/tests/api_resources/test_payment_method.py
@@ -52,9 +52,27 @@ class TestPaymentMethod(object):
         )
         assert isinstance(resource, stripe.PaymentMethod)
 
+    def test_can_attach_classmethod(self, request_mock):
+        resource = stripe.PaymentMethod.attach(
+            TEST_RESOURCE_ID, customer="cus_123"
+        )
+        request_mock.assert_requested(
+            "post",
+            "/v1/payment_methods/%s/attach" % TEST_RESOURCE_ID,
+            {"customer": "cus_123"},
+        )
+        assert isinstance(resource, stripe.PaymentMethod)
+
     def test_can_detach(self, request_mock):
         resource = stripe.PaymentMethod.retrieve(TEST_RESOURCE_ID)
         resource = resource.detach()
+        request_mock.assert_requested(
+            "post", "/v1/payment_methods/%s/detach" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.PaymentMethod)
+
+    def test_can_detach_classmethod(self, request_mock):
+        resource = stripe.PaymentMethod.detach(TEST_RESOURCE_ID)
         request_mock.assert_requested(
             "post", "/v1/payment_methods/%s/detach" % TEST_RESOURCE_ID
         )

--- a/tests/api_resources/test_payout.py
+++ b/tests/api_resources/test_payout.py
@@ -49,3 +49,10 @@ class TestPayout(object):
             "post", "/v1/payouts/%s/cancel" % TEST_RESOURCE_ID
         )
         assert isinstance(resource, stripe.Payout)
+
+    def test_can_cancel_classmethod(self, request_mock):
+        resource = stripe.Payout.cancel(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "post", "/v1/payouts/%s/cancel" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.Payout)

--- a/tests/api_resources/test_review.py
+++ b/tests/api_resources/test_review.py
@@ -20,9 +20,16 @@ class TestReview(object):
         )
         assert isinstance(resource, stripe.Review)
 
-    def test_is_approveable(self, request_mock):
+    def test_can_approve(self, request_mock):
         resource = stripe.Review.retrieve(TEST_RESOURCE_ID)
         resource.approve()
+        request_mock.assert_requested(
+            "post", "/v1/reviews/%s/approve" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.Review)
+
+    def test_can_approve_classmethod(self, request_mock):
+        resource = stripe.Review.approve(TEST_RESOURCE_ID)
         request_mock.assert_requested(
             "post", "/v1/reviews/%s/approve" % TEST_RESOURCE_ID
         )

--- a/tests/api_resources/test_subscription.py
+++ b/tests/api_resources/test_subscription.py
@@ -63,3 +63,9 @@ class TestSubscription(object):
         request_mock.assert_requested(
             "delete", "/v1/subscriptions/%s/discount" % sub.id
         )
+
+    def test_can_delete_discount_classmethod(self, request_mock):
+        stripe.Subscription.delete_discount(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "delete", "/v1/subscriptions/%s/discount" % TEST_RESOURCE_ID
+        )

--- a/tests/api_resources/test_subscription_schedule.py
+++ b/tests/api_resources/test_subscription_schedule.py
@@ -51,9 +51,23 @@ class TestSubscriptionScheduleSchedule(object):
         )
         assert isinstance(resource, stripe.SubscriptionSchedule)
 
+    def test_can_cancel_classmethod(self, request_mock):
+        resource = stripe.SubscriptionSchedule.cancel(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "post", "/v1/subscription_schedules/%s/cancel" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.SubscriptionSchedule)
+
     def test_can_release(self, request_mock):
         resource = stripe.SubscriptionSchedule.retrieve(TEST_RESOURCE_ID)
         resource = resource.release()
+        request_mock.assert_requested(
+            "post", "/v1/subscription_schedules/%s/release" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.SubscriptionSchedule)
+
+    def test_can_release_classmethod(self, request_mock):
+        resource = stripe.SubscriptionSchedule.release(TEST_RESOURCE_ID)
         request_mock.assert_requested(
             "post", "/v1/subscription_schedules/%s/release" % TEST_RESOURCE_ID
         )

--- a/tests/api_resources/test_topup.py
+++ b/tests/api_resources/test_topup.py
@@ -48,9 +48,16 @@ class TestTopup(object):
         )
         assert isinstance(resource, stripe.Topup)
 
-    def test_is_cancelable(self, request_mock):
-        topup = stripe.Topup.retrieve(TEST_RESOURCE_ID)
-        resource = topup.cancel()
+    def test_can_cancel(self, request_mock):
+        resource = stripe.Topup.retrieve(TEST_RESOURCE_ID)
+        resource = resource.cancel()
+        request_mock.assert_requested(
+            "post", "/v1/topups/%s/cancel" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.Topup)
+
+    def test_can_cancel_classmethod(self, request_mock):
+        resource = stripe.Topup.cancel(TEST_RESOURCE_ID)
         request_mock.assert_requested(
             "post", "/v1/topups/%s/cancel" % TEST_RESOURCE_ID
         )

--- a/tests/api_resources/test_transfer.py
+++ b/tests/api_resources/test_transfer.py
@@ -45,7 +45,7 @@ class TestTransfer(object):
         )
         assert isinstance(resource, stripe.Transfer)
 
-    def test_is_cancelable(self, request_mock):
+    def test_can_cancel(self, request_mock):
         # stripe-mock does not handle this anymore as it was on an old
         # API version so we stub instead.
         request_mock.stub_request(
@@ -66,6 +66,20 @@ class TestTransfer(object):
             "post", "/v1/transfers/%s/cancel" % TEST_RESOURCE_ID
         )
         assert isinstance(transfer_canceled, stripe.Transfer)
+
+    def test_can_cancel_classmethod(self, request_mock):
+        # stripe-mock does not handle this anymore as it was on an old
+        # API version so we stub instead.
+        request_mock.stub_request(
+            "post",
+            "/v1/transfers/%s/cancel" % TEST_RESOURCE_ID,
+            {"id": "%s" % TEST_RESOURCE_ID, "object": "transfer"},
+        )
+        transfer = stripe.Transfer.cancel(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "post", "/v1/transfers/%s/cancel" % TEST_RESOURCE_ID
+        )
+        assert isinstance(transfer, stripe.Transfer)
 
 
 class TestTransferReversals:


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

This is similar to https://github.com/stripe/stripe-ruby/pull/754. This PR defines a new `custom_method` decorator that can be applied to resource classes to automatically define class methods for custom (non-CRUDL) API requests.

The decorator checks if a method with the target name already exists, and if so it uses the new decorator `util.class_method_variant` from #543 to avoid overwriting the existing method (that we assume to be an instance method).
