### PR TITLE
Add `long_description_content_type` to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     version=version_contents["VERSION"],
     description="Python bindings for the Stripe API",
     long_description=long_description,
+    long_description_content_type="text/x-rst",
     author="Stripe",
     author_email="support@stripe.com",
     url="https://github.com/stripe/stripe-python",


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

While releasing stripe-python, I noticed that `twine check` output a warning:
```
$ twine check dist/stripe-2.24.0-py2.py3-none-any.whl
Checking distribution dist/stripe-2.24.0-py2.py3-none-any.whl: warning: `long_description_content_type` missing.  defaulting to `text/x-rst`.
Passed
```

This PR fixes the warning:
```
$ twine check dist/stripe-2.24.0-py2.py3-none-any.whl
Checking distribution dist/stripe-2.24.0.tar.gz: Passed
```
