### PR TITLE
Fix multipart encoding of nested parameters

### DIFF
--- a/stripe/multipart_data_generator.py
+++ b/stripe/multipart_data_generator.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import random
 import io
 
-from stripe import six
+import stripe
 
 
 class MultipartDataGenerator(object):
@@ -14,7 +14,10 @@ class MultipartDataGenerator(object):
         self.chunk_size = chunk_size
 
     def add_params(self, params):
-        for key, value in six.iteritems(params):
+        # Flatten parameters first
+        params = dict(stripe.api_requestor._api_encode(params))
+
+        for key, value in stripe.six.iteritems(params):
             if value is None:
                 continue
 
@@ -45,7 +48,7 @@ class MultipartDataGenerator(object):
                 self._write('"')
                 self._write(self.line_break)
                 self._write(self.line_break)
-                self._write(value)
+                self._write(str(value))
 
             self._write(self.line_break)
 
@@ -58,9 +61,9 @@ class MultipartDataGenerator(object):
         return self.data.getvalue()
 
     def _write(self, value):
-        if isinstance(value, six.binary_type):
+        if isinstance(value, stripe.six.binary_type):
             array = bytearray(value)
-        elif isinstance(value, six.text_type):
+        elif isinstance(value, stripe.six.text_type):
             array = bytearray(value, encoding="utf-8")
         else:
             raise TypeError(

--- a/tests/api_resources/test_file.py
+++ b/tests/api_resources/test_file.py
@@ -36,7 +36,9 @@ class TestFile(object):
         )
         test_file = tempfile.TemporaryFile()
         resource = stripe.File.create(
-            purpose="dispute_evidence", file=test_file
+            purpose="dispute_evidence",
+            file=test_file,
+            file_link_data={"create": True},
         )
         request_mock.assert_api_base(stripe.upload_api_base)
         request_mock.assert_requested(

--- a/tests/api_resources/test_file_upload.py
+++ b/tests/api_resources/test_file_upload.py
@@ -36,7 +36,9 @@ class TestFileUpload(object):
         )
         test_file = tempfile.TemporaryFile()
         resource = stripe.FileUpload.create(
-            purpose="dispute_evidence", file=test_file
+            purpose="dispute_evidence",
+            file=test_file,
+            file_link_data={"create": True},
         )
         request_mock.assert_api_base(stripe.upload_api_base)
         request_mock.assert_requested(

--- a/tests/test_multipart_data_generator.py
+++ b/tests/test_multipart_data_generator.py
@@ -14,6 +14,13 @@ class TestMultipartDataGenerator(object):
             "key1": b"ASCII value",
             "key2": u"Üñìçôdé value",
             "key3": test_file,
+            "key4": {
+                "string": "Hello!",
+                "int": 234,
+                "float": 3.14159,
+                "bool": True,
+                "dict": {"foo": "bar"},
+            },
         }
         generator = MultipartDataGenerator()
         generator.add_params(params)
@@ -36,6 +43,29 @@ class TestMultipartDataGenerator(object):
             http_body,
         )
         assert re.search(r"Content-Type: application/octet-stream", http_body)
+        assert re.search(
+            r"Content-Disposition: form-data; name=\"key4\[string\]\"",
+            http_body,
+        )
+        assert re.search(r"Hello!", http_body)
+        assert re.search(
+            r"Content-Disposition: form-data; name=\"key4\[int\]\"", http_body
+        )
+        assert re.search(r"234", http_body)
+        assert re.search(
+            r"Content-Disposition: form-data; name=\"key4\[float\]\"",
+            http_body,
+        )
+        assert re.search(r"3.14159", http_body)
+        assert re.search(
+            r"Content-Disposition: form-data; name=\"key4\[bool\]\"", http_body
+        )
+        assert re.search(r"True", http_body)
+        assert re.search(
+            r"Content-Disposition: form-data; name=\"key4\[dict\]\[foo\]\"",
+            http_body,
+        )
+        assert re.search(r"bar", http_body)
 
         test_file.seek(0)
         file_contents = test_file.read()


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

This one was a bit tricky. stripe-python rolls its own multipart encoder, which only supported two types of values: file-like (i.e. an object that has a `read` attribute) or strings. All other types caused an exception to be raised.

So there were actually two different issues to fix:
1. the parameters need to be flattened (which solves the problem for compound types -- lists and dicts are gone after this step)
2. handle non-string scalar types (booleans, integers, etc.)

The first issue was easily solved by calling `api_requestor._api_encode()` in `MultipartDataGenerator` to flatten the parameters.

~To solve the second issue, I changed `util.utf_8()` to stringify all non-file-like values. This could potentially have side effects for regular form-encoding, but I'm fairly sure that's not the case: form-encoding works by passing the dictionary of flattened params to `urlencode` which would stringify non-string values anyway.~

The second issue is solved by stringifying non-file-like values before adding them to the multipart buffer.
