### PR TITLE
Pin pip to 18.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@ init:
 	# Pin pipenv to 2018.10.13 because further releases are incompatible with
 	# PyPy3. The issue was fixed in https://github.com/pypa/pipenv/pull/3322
 	# but no new version has been released yet.
-	pip install --upgrade pipenv==2018.10.13
+	# Also pin pip to 18.x because with more recent versions, we'd need to
+	# pass `--no-use-pep517`, which pipenv doesn't let us do. Cf.
+	# https://github.com/pypa/pipenv/issues/3651
+	pip install --upgrade pip~=18.0 pipenv==2018.10.13
 	pipenv install --dev --skip-lock
 
 test:


### PR DESCRIPTION
r? @brandur-stripe 
cc @remi-stripe 

Temporary workaround to make the builds green again.

The issue is caused by a combination of unfortunate factors:
- we have a `pyproject.toml` file, which is a sort of new Python thing ([PEP 518](https://www.python.org/dev/peps/pep-0518/)) to replace older ways of specifying dependencies. But we only use it to configure Black (the code formatter)
- recent pip versions will no longer let you install a package in editable mode if there is a `pyproject.toml` without a `build-backend` (cf. https://github.com/pypa/pip/pull/6331). You can disable this behavior by passing `--no-use-pep517`, but...
- pipenv doesn't have a way to do this (cf. https://github.com/pypa/pipenv/issues/3651)

For now, we can just downgrade pip to 18.x to avoid the issue.

Mid/long term, we should probably:
- fully replace `setup.py` with `pyproject.toml`
- get rid of pipenv
