### PR TITLE
Various dev fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,13 @@ matrix:
     - python: "3.6"
     - python: "3.7"
       dist: xenial
-      sudo: true # workaround for https://github.com/travis-ci/travis-ci/issues/9815
     - python: "pypy"
     - python: "pypy3"
 
 cache:
   directories:
     - stripe-mock
-  pip: false
+  pip: true
 
 env:
   global:

--- a/Pipfile
+++ b/Pipfile
@@ -7,10 +7,10 @@ name = "pypi"
 stripe = {path = ".",editable = true}
 
 [dev-packages]
-pytest = ">=3.4"
-pytest-mock = ">=1.7"
-pytest-xdist = ">=1.22"
-pytest-cov = ">=2.5"
+pytest = ">=4.4"
+pytest-mock = ">=1.10"
+pytest-xdist = ">=1.28"
+pytest-cov = ">=2.6"
 tox = "*"
 "flake8" = "*"
 coveralls = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "aab328d0784bbc72b43036bad75d8637ea32594d8718d1bebb53ac66c18b54d6"
+            "sha256": "805accae6e0ceae4d4c06bae20982b72dfe9ff094a7293b4ec49a9670e6c7f62"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -298,10 +298,10 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:6aebaf4dd2568a0094225ebbca987859e369e3e5c22dc7d52e5406d504890417",
-                "sha256:984d7e607b0a5d1329425dd8845bd971b957424b5ba664729fab51ab8c11bc39"
+                "sha256:15ee248d13e4001a691d9583948ad3947bcb8a289775102e4c4aa98a8b7a6d73",
+                "sha256:bfc98bb9b42a3029ee41b96dc00a34c2f254cbf7716bec824477b2c82741a5c4"
             ],
-            "version": "==16.4.3"
+            "version": "==16.5.0"
         }
     }
 }

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = -p no:warnings

--- a/tests/api_resources/test_ephemeral_key.py
+++ b/tests/api_resources/test_ephemeral_key.py
@@ -18,7 +18,7 @@ class TestEphemeralKey(object):
 
     def test_is_not_creatable_without_an_explicit_api_version(self):
         with pytest.raises(
-            ValueError, message="stripe_version must be specified"
+            ValueError, match="stripe_version must be specified"
         ):
             stripe.EphemeralKey.create(customer="cus_123")
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -81,8 +81,7 @@ class TestWebhookSignature(object):
         header = "i'm not even a real signature header"
         with pytest.raises(
             stripe.error.SignatureVerificationError,
-            message="Unable to extract timestamp and signatures from "
-            "header",
+            match="Unable to extract timestamp and signatures from header",
         ):
             stripe.WebhookSignature.verify_header(
                 DUMMY_WEBHOOK_PAYLOAD, header, DUMMY_WEBHOOK_SECRET
@@ -92,7 +91,7 @@ class TestWebhookSignature(object):
         header = generate_header(scheme="v0")
         with pytest.raises(
             stripe.error.SignatureVerificationError,
-            message="No signatures found with expected scheme v1",
+            match="No signatures found with expected scheme v1",
         ):
             stripe.WebhookSignature.verify_header(
                 DUMMY_WEBHOOK_PAYLOAD, header, DUMMY_WEBHOOK_SECRET
@@ -102,8 +101,7 @@ class TestWebhookSignature(object):
         header = generate_header(signature="bad_signature")
         with pytest.raises(
             stripe.error.SignatureVerificationError,
-            message="No signatures found matching the expected signature "
-            "for payload",
+            match="No signatures found matching the expected signature for payload",
         ):
             stripe.WebhookSignature.verify_header(
                 DUMMY_WEBHOOK_PAYLOAD, header, DUMMY_WEBHOOK_SECRET
@@ -113,7 +111,7 @@ class TestWebhookSignature(object):
         header = generate_header(timestamp=int(time.time()) - 15)
         with pytest.raises(
             stripe.error.SignatureVerificationError,
-            message="Timestamp outside the tolerance zone",
+            match="Timestamp outside the tolerance zone",
         ):
             stripe.WebhookSignature.verify_header(
                 DUMMY_WEBHOOK_PAYLOAD,


### PR DESCRIPTION
r? @brandur-stripe 

Various development-related fixes:
- no longer ignore warnings in tests
- update calls to `pytest.raises` to use `match` instead of `message`
- bump minimum versions of `pytest` and related packages
- remove the `sudo: true` workaround for Python 3.7 in Travis (no longer necessary)
- enable caching for pip in Travis