### PR TITLE
Enhanced support for DRF

### DIFF
--- a/stripe/webhook.py
+++ b/stripe/webhook.py
@@ -20,7 +20,10 @@ class Webhook(object):
             payload = payload.decode("utf-8")
         if api_key is None:
             api_key = stripe.api_key
-        data = json.loads(payload)
+        if isinstance(payload, dict):
+            data = payload
+        else:
+            data = json.loads(payload)
         event = stripe.Event.construct_from(data, api_key)
 
         WebhookSignature.verify_header(payload, sig_header, secret, tolerance)


### PR DESCRIPTION
The request.data obtained by the DRF is a dict type. 
Is not required to do json.loads

```python
class OrderCallBackViewSet(mixins.CreateModelMixin,
                           viewsets.GenericViewSet):
    ......
    def create(self, request, *args, **kwargs):
        # payload = request.data  => payload==dict Object
        ......
```