### PR TITLE
Fix quality issues reported by DeepSource

### DIFF
--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -368,7 +368,7 @@ class APIRequestor(object):
                 rcode,
                 rheaders,
             )
-        if not (200 <= rcode < 300):
+        if not 200 <= rcode < 300:
             self.handle_error_response(rbody, rcode, resp.data, rheaders)
 
         return resp

--- a/stripe/http_client.py
+++ b/stripe/http_client.py
@@ -412,7 +412,7 @@ class PycurlClient(HTTPClient):
         if self._proxy:
             # now that we have the parser, get the proxy url pieces
             proxy = self._proxy
-            for scheme, value in proxy.items():
+            for scheme, value in six.iteritems(proxy):
                 proxy[scheme] = urlparse(value)
 
     def parse_headers(self, data):

--- a/stripe/http_client.py
+++ b/stripe/http_client.py
@@ -285,8 +285,9 @@ class RequestsClient(HTTPClient):
             err = "%s: %s" % (type(e).__name__, str(e))
             should_retry = False
         # Retry only timeout and connect errors; similar to urllib3 Retry
-        elif isinstance(e, requests.exceptions.Timeout) or isinstance(
-            e, requests.exceptions.ConnectionError
+        elif isinstance(
+            e,
+            (requests.exceptions.Timeout, requests.exceptions.ConnectionError),
         ):
             msg = (
                 "Unexpected error communicating with Stripe.  "
@@ -411,8 +412,8 @@ class PycurlClient(HTTPClient):
         if self._proxy:
             # now that we have the parser, get the proxy url pieces
             proxy = self._proxy
-            for scheme in proxy:
-                proxy[scheme] = urlparse(proxy[scheme])
+            for scheme, value in proxy.items():
+                proxy[scheme] = urlparse(value)
 
     def parse_headers(self, data):
         if "\r\n" not in data:
@@ -514,11 +515,7 @@ class PycurlClient(HTTPClient):
             proxy = self._proxy
             scheme = url.split(":")[0] if url else None
             if scheme:
-                if scheme in proxy:
-                    return proxy[scheme]
-                scheme = scheme[0:-1]
-                if scheme in proxy:
-                    return proxy[scheme]
+                return proxy.get(scheme, proxy.get(scheme[0:-1]))
         return None
 
     def close(self):

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -581,7 +581,7 @@ class TestUrllib2Client(StripeClientTestCase, ClientTestBase):
             mock.Request.assert_called_with(url, post_data, headers)
 
             if self.client._proxy:
-                assert type(self.client._proxy) is dict
+                assert isinstance(self.client._proxy, dict)
                 mock.ProxyHandler.assert_called_with(self.client._proxy)
                 mock.build_opener.open.assert_called_with(self.request_object)
                 assert not mock.urlopen.called

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -242,7 +242,7 @@ class TestIntegration(object):
             stripe.Balance.retrieve()
             stripe.Balance.retrieve()
 
-        threads = [Thread(target=work) for i in range(10)]
+        threads = [Thread(target=work) for _ in range(10)]
         for t in threads:
             t.start()
         for t in threads:

--- a/tests/test_stripe_response.py
+++ b/tests/test_stripe_response.py
@@ -7,27 +7,27 @@ from stripe.stripe_response import StripeResponse
 
 class TestStripeResponse(object):
     def test_idempotency_key(self):
-        response, headers, body, code = self.mock_stripe_response()
+        response, headers, _, _ = self.mock_stripe_response()
         assert response.idempotency_key == headers["idempotency-key"]
 
     def test_request_id(self):
-        response, headers, body, code = self.mock_stripe_response()
+        response, headers, _, _ = self.mock_stripe_response()
         assert response.request_id == headers["request-id"]
 
     def test_code(self):
-        response, headers, body, code = self.mock_stripe_response()
+        response, _, _, code = self.mock_stripe_response()
         assert response.code == code
 
     def test_headers(self):
-        response, headers, body, code = self.mock_stripe_response()
+        response, headers, _, _ = self.mock_stripe_response()
         assert response.headers == headers
 
     def test_body(self):
-        response, headers, body, code = self.mock_stripe_response()
+        response, _, body, _ = self.mock_stripe_response()
         assert response.body == body
 
     def test_data(self):
-        response, headers, body, code = self.mock_stripe_response()
+        response, _, body, _ = self.mock_stripe_response()
         assert response.data == json.loads(body)
 
     @staticmethod

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -141,13 +141,13 @@ class TestUtil(object):
         }
 
         obj = util.convert_to_stripe_object(resp)
-        assert type(obj) == stripe.Balance
+        assert isinstance(obj, stripe.Balance)
         assert type(obj.available) == list
-        assert type(obj.available[0]) == stripe.stripe_object.StripeObject
+        assert isinstance(obj.available[0], stripe.stripe_object.StripeObject)
 
         d = util.convert_to_dict(obj)
-        assert type(d) == dict
-        assert type(d["available"]) == list
-        assert type(d["available"][0]) == dict
+        assert isinstance(d, dict)
+        assert isinstance(d["available"], list)
+        assert isinstance(d["available"][0], dict)
 
         assert d == resp


### PR DESCRIPTION
Fixes:
- PYL-W0612: Rename unused variable to `_`
- PYL-C0123: Use `isinstance()` for checking type
- PAP-W0011: Use `dict.items()` to iterate over a dictionary
- PAP-W0012: Use `dict.get()` to access value from dictionary instead of an `if` query to check whether the key exists
- PYL-C0325: Remove superfluous brackets `()`
- PYL-R1701: Merge multiple consecutive `isinstance()` calls into one