### PR TITLE
Remove Poetry and reinstate `setup.py`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,56 @@
-/.eggs
-/build
-/dist
-/MANIFEST
-/stripe.egg-info
-.python-version
-*.pyc
-*.egg
-*.class
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
 
-# Poetry lock file
-poetry.lock
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
 
 # Unit test / coverage reports
+htmlcov/
 .tox/
+.nox/
 .coverage
+.coverage.*
 .cache
-.pytest_cache
 nosetests.xml
 coverage.xml
-htmlcov/
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# pyenv
+.python-version
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
 
 # Visual Studio Code
 .vscode/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ matrix:
 cache:
   directories:
     - stripe-mock
-    - "${HOME}/.cache/pypoetry"
   pip: true
 
 env:
@@ -38,10 +37,8 @@ before_install:
   - export PATH="${PATH}:${PWD}/stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}"
 
 install:
-  - pip install --upgrade pip
-  - curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
-  - source ${HOME}/.poetry/env
-  - poetry install -v
+  - pip install --upgrade pip virtualenv
+  - make venv
 
 script:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then make lint; fi

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include .coveragerc .flake8 CHANGELOG.md LICENSE LONG_DESCRIPTION.rst README.md VERSION pytest.ini tox.ini
+recursive-include tests *.py

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,34 @@
-test:
-	poetry run tox -p auto
+VENV_NAME?=venv
 
-ci:
-	poetry run pytest --cov=stripe
+venv: $(VENV_NAME)/bin/activate
 
-coveralls:
-	poetry run coveralls
+$(VENV_NAME)/bin/activate: setup.py
+	pip install --upgrade pip virtualenv
+	@test -d $(VENV_NAME) || python -m virtualenv --clear $(VENV_NAME)
+	${VENV_NAME}/bin/python -m pip install -U pip tox
+	${VENV_NAME}/bin/python -m pip install -e .
+	@touch $(VENV_NAME)/bin/activate
 
-fmt:
-	poetry run tox -e fmt
+test: venv
+	@${VENV_NAME}/bin/tox -p auto $(TOX_ARGS)
 
-fmtcheck:
-	poetry run tox -e fmt -- --check --verbose
+ci: venv
+	@${VENV_NAME}/bin/python setup.py test -a "-n auto --cov=stripe"
 
-lint:
-	poetry run tox -e lint
+coveralls: venv
+	@${VENV_NAME}/bin/pip install --upgrade coveralls
+	@${VENV_NAME}/bin/coveralls
+
+fmt: venv
+	@${VENV_NAME}/bin/tox -e fmt
+
+fmtcheck: venv
+	@${VENV_NAME}/bin/tox -e fmt -- --check --verbose
+
+lint: venv
+	@${VENV_NAME}/bin/tox -e lint
+
+clean:
+	@rm -rf $(VENV_NAME) build/ dist/
+
+.PHONY: venv test ci coveralls fmt fmtcheck lint clean

--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ instructions for installing via Homebrew and other methods):
     go get -u github.com/stripe/stripe-mock
     stripe-mock
 
-Install [poetry][poetry], then install all dependencies for the project:
+Run the following command to set up the development virtualenv:
 
-    poetry install
+    make init
 
 Run all tests on all supported Python versions:
 
@@ -166,19 +166,19 @@ Run all tests on all supported Python versions:
 
 Run all tests for a specific Python version (modify `-e` according to your Python target):
 
-    poetry run tox -e py27
+    TOX_ARGS="-e py27" make test
 
 Run all tests in a single file:
 
-    poetry run tox -e py27 -- tests/api_resources/abstract/test_updateable_api_resource.py
+    TOX_ARGS="-e py27 -- tests/api_resources/abstract/test_updateable_api_resource.py" make test
 
 Run a single test suite:
 
-    poetry run tox -e py27 -- tests/api_resources/abstract/test_updateable_api_resource.py::TestUpdateableAPIResource
+    TOX_ARGS="-e py27 -- tests/api_resources/abstract/test_updateable_api_resource.py::TestUpdateableAPIResource" make test
 
 Run a single test:
 
-    poetry run tox -e py27 -- tests/api_resources/abstract/test_updateable_api_resource.py::TestUpdateableAPIResource::test_save
+    TOX_ARGS="-e py27 -- tests/api_resources/abstract/test_updateable_api_resource.py::TestUpdateableAPIResource::test_save" make test
 
 Run the linter with:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
-
 [tool.black]
 line-length=79
 exclude = '''
@@ -13,58 +9,7 @@ exclude = '''
   | _build/
   | build/
   | dist/
+  | venv/
   | stripe/six.py
 )
 '''
-
-[tool.poetry]
-name = "stripe"
-version = "2.29.3"
-description = "Python bindings for the Stripe API"
-
-license = "MIT"
-
-authors = [
-    "Stripe <support@stripe.com>"
-]
-
-readme = 'LONG_DESCRIPTION.rst'
-
-repository = "https://github.com/stripe/stripe-python"
-homepage = "https://github.com/stripe/stripe-python"
-documentation = "https://stripe.com/docs/api?lang=python"
-
-keywords = ['stripe', 'api', 'payments']
-
-include = [
-  "data/ca-certificates.crt",
-  "stripe/**/*.py",
-  "tests/**/*.py",
-  ".coveragerc",
-  ".flake8",
-  "CHANGELOG.md",
-  "LICENSE",
-  "LONG_DESCRIPTION.rst",
-  "README.md",
-  "VERSION",
-  "pyproject.toml",
-  "pytest.ini",
-  "tox.ini"
-]
-
-[tool.poetry.dependencies]
-python = "~2.7 || ^3.4"
-requests = [
-  { version = "^2.20", python = "~2.7", extras = [ "security" ] },
-  { version = "^2.20", python = "^3.4" }
-]
-toml = "^0.9"
-
-[tool.poetry.dev-dependencies]
-coveralls = "^1.7"
-flake8 = "^3.7"
-pytest = "^4.4"
-pytest-cov = "^2.6"
-pytest-mock = "^1.10"
-pytest-xdist = "^1.28"
-tox = "^3.9"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,88 @@
+import os
+import sys
+from codecs import open
+from setuptools import setup, find_packages
+from setuptools.command.test import test as TestCommand
+
+
+class PyTest(TestCommand):
+    user_options = [("pytest-args=", "a", "Arguments to pass to pytest")]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = "-n auto"
+
+    def run_tests(self):
+        import shlex
+
+        # import here, cause outside the eggs aren't loaded
+        import pytest
+
+        errno = pytest.main(shlex.split(self.pytest_args))
+        sys.exit(errno)
+
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+os.chdir(here)
+
+with open(
+    os.path.join(here, "LONG_DESCRIPTION.rst"), "r", encoding="utf-8"
+) as fp:
+    long_description = fp.read()
+
+version_contents = {}
+with open(os.path.join(here, "stripe", "version.py"), encoding="utf-8") as f:
+    exec(f.read(), version_contents)
+
+setup(
+    name="stripe",
+    version=version_contents["VERSION"],
+    description="Python bindings for the Stripe API",
+    long_description=long_description,
+    long_description_content_type="text/x-rst",
+    author="Stripe",
+    author_email="support@stripe.com",
+    url="https://github.com/stripe/stripe-python",
+    license="MIT",
+    keywords="stripe api payments",
+    packages=find_packages(exclude=["tests", "tests.*"]),
+    package_data={"stripe": ["data/ca-certificates.crt"]},
+    zip_safe=False,
+    install_requires=[
+        'requests >= 2.20; python_version >= "3.0"',
+        'requests[security] >= 2.20; python_version < "3.0"',
+    ],
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+    tests_require=[
+        "pytest >= 4.6.2, < 4.7",
+        "pytest-mock >= 1.10.4",
+        "pytest-xdist >= 1.28.0",
+        "pytest-cov >= 2.7.1",
+        # coverage 5.0 pre-releases don't work, and setuptools doesn't ignore
+        # pre-releases (cf. https://github.com/pypa/setuptools/issues/855)
+        "coverage >= 4.5.3, < 5",
+    ],
+    cmdclass={"test": PyTest},
+    project_urls={
+        "Bug Tracker": "https://github.com/stripe/stripe-python/issues",
+        "Documentation": "https://stripe.com/docs/api/python",
+        "Source Code": "https://github.com/stripe/stripe-python",
+    },
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: Implementation :: PyPy",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
+)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import platform
 import sys
 from threading import Thread, Lock
 import json
@@ -8,6 +9,9 @@ import time
 
 import stripe
 import pytest
+
+if platform.python_implementation() == "PyPy":
+    pytest.skip("skip integration tests with PyPy", allow_module_level=True)
 
 if sys.version_info[0] < 3:
     from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ envlist = py27,
           pypy,
           pypy3,
           lint
-isolated_build = true
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Poetry has a bad bug that prevents building packages from sources (https://github.com/sdispater/poetry/issues/760), and some environments cannot use prebuilt wheels and must build from source. So we cannot use Poetry 😭 

I don't want to revert to using pipenv which is also broken in different ways, so I've instead reverted to the pre-2.0 state of not using a dependency manager at all. Sad, but until a Python dependency manager that actually works emerges I think this is the best course of action.

@remi-stripe I know this is typically the sort of PRs where you'd defer to Brandur, but he's on vacation and I think we need a rapid resolution here. I'll add some comments to the PR but lmk if you have any questions.

I've verified that the source distributions for 2.29.1 (last version using pipenv) and this branch are ~identical minus the expected changes (changes to the source code in #579, version number).

Fixes #582.
