### PR TITLE
Various dev things

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 [run]
+branch = true
 source = stripe
 omit =
     stripe/six.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 
+dist: xenial
+
 language: python
 
 matrix:
@@ -9,9 +11,11 @@ matrix:
     - python: "3.5"
     - python: "3.6"
     - python: "3.7"
-      dist: xenial
-    - python: "pypy"
-    - python: "pypy3"
+    - python: "3.8-dev"
+    - python: "pypy2.7-6.0"
+    - python: "pypy3.5-6.0"
+  allow_failures:
+    - python: "3.8-dev"
 
 cache:
   directories:

--- a/tox.ini
+++ b/tox.ini
@@ -23,9 +23,11 @@ description = run code formatting using black
 basepython = python3.7
 deps = black
 commands = black . {posargs}
+skip_install = true
 
 [testenv:lint]
 description = run static analysis and style check using flake8
 basepython = python2.7
 deps = flake8
 commands = python -m flake8 --show-source stripe tests setup.py {posargs}
+skip_install = true


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Fixes a few things I noticed while working on #583 but wanted to keep separate:
- Enable [branch coverage measurement](https://coverage.readthedocs.io/en/v4.5.x/branch.html)
- No need to install the `stripe` package in the `fmt` and `lint` Tox environments, since those are only used to check/format the source code
- Travis changes:
    - Use Xenial dist for all builds
    - Start testing Python the development version of Python 3.8 (but allow failures)
    - Test the latest PyPy versions
