### PR TITLE
Fix CustomerBalanceTransaction to deserialize properly

### DIFF
--- a/stripe/object_classes.py
+++ b/stripe/object_classes.py
@@ -26,6 +26,7 @@ OBJECT_CLASSES = {
     api_resources.Coupon.OBJECT_NAME: api_resources.Coupon,
     api_resources.CreditNote.OBJECT_NAME: api_resources.CreditNote,
     api_resources.Customer.OBJECT_NAME: api_resources.Customer,
+    api_resources.CustomerBalanceTransaction.OBJECT_NAME: api_resources.CustomerBalanceTransaction,
     api_resources.Dispute.OBJECT_NAME: api_resources.Dispute,
     api_resources.EphemeralKey.OBJECT_NAME: api_resources.EphemeralKey,
     api_resources.Event.OBJECT_NAME: api_resources.Event,

--- a/tests/api_resources/test_customer.py
+++ b/tests/api_resources/test_customer.py
@@ -115,12 +115,13 @@ class TestCustomerSources(object):
 
 class TestCustomerTaxIds(object):
     def test_is_creatable(self, request_mock):
-        stripe.Customer.create_tax_id(
+        resource = stripe.Customer.create_tax_id(
             TEST_RESOURCE_ID, type="eu_vat", value="11111"
         )
         request_mock.assert_requested(
             "post", "/v1/customers/%s/tax_ids" % TEST_RESOURCE_ID
         )
+        assert isinstance(resource, stripe.TaxId)
 
     def test_is_retrievable(self, request_mock):
         stripe.Customer.retrieve_tax_id(TEST_RESOURCE_ID, TEST_TAX_ID_ID)
@@ -146,12 +147,13 @@ class TestCustomerTaxIds(object):
 
 class TestCustomerTransactions(object):
     def test_is_creatable(self, request_mock):
-        stripe.Customer.create_balance_transaction(
+        resource = stripe.Customer.create_balance_transaction(
             TEST_RESOURCE_ID, amount=1234, currency="usd"
         )
         request_mock.assert_requested(
             "post", "/v1/customers/%s/balance_transactions" % TEST_RESOURCE_ID
         )
+        assert isinstance(resource, stripe.CustomerBalanceTransaction)
 
     def test_is_retrievable(self, request_mock):
         stripe.Customer.retrieve_balance_transaction(


### PR DESCRIPTION
I forgot to add this object to the list of objects to be deserialized when I rebased on master, this fixes it.

r? @rattrayalex-stripe @ob-stripe 
cc @stripe/api-libraries 