### PR TITLE
Fix argument name conflict

### DIFF
--- a/stripe/api_resources/abstract/api_resource.py
+++ b/stripe/api_resources/abstract/api_resource.py
@@ -44,11 +44,13 @@ class APIResource(StripeObject):
         extn = quote_plus(id)
         return "%s/%s" % (base, extn)
 
+    # The `method_` and `url_` arguments are suffixed with an underscore to
+    # avoid conflicting with actual request parameters in `params`.
     @classmethod
     def _static_request(
         cls,
-        method,
-        url,
+        method_,
+        url_,
         api_key=None,
         idempotency_key=None,
         stripe_version=None,
@@ -59,7 +61,7 @@ class APIResource(StripeObject):
             api_key, api_version=stripe_version, account=stripe_account
         )
         headers = util.populate_headers(idempotency_key)
-        response, api_key = requestor.request(method, url, params, headers)
+        response, api_key = requestor.request(method_, url_, params, headers)
         return util.convert_to_stripe_object(
             response, api_key, stripe_version, stripe_account
         )

--- a/tests/api_resources/test_webhook_endpoint.py
+++ b/tests/api_resources/test_webhook_endpoint.py
@@ -37,7 +37,9 @@ class TestWebhookEndpoint(object):
 
     def test_is_modifiable(self, request_mock):
         resource = stripe.WebhookEndpoint.modify(
-            TEST_RESOURCE_ID, enabled_events=["charge.succeeded"]
+            TEST_RESOURCE_ID,
+            enabled_events=["charge.succeeded"],
+            url="https://stripe.com",
         )
         request_mock.assert_requested(
             "post", "/v1/webhook_endpoints/%s" % TEST_RESOURCE_ID


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

The `APIResource._static_request` method defines some regular arguments plus the catch-all `**params` as the dictionary of actual parameters for the API request. The issue is that one cannot pass an API parameter with the same name as a regular argument.

This PR renames the `method` and `url` arguments to `method_` and `url_` respectively to avoid conflicting with actual API parameters.

Fixes #591.
