### PR TITLE
Add support for passing full objects instead of IDs to custom methods

### DIFF
--- a/stripe/util.py
+++ b/stripe/util.py
@@ -213,12 +213,20 @@ class class_method_variant(object):
         self.method = method
         return self
 
-    def __get__(self, obj=None, objtype=None):
+    def __get__(self, obj, objtype=None):
         @functools.wraps(self.method)
         def _wrapper(*args, **kwargs):
             if obj is not None:
+                # Method was called as an instance method, e.g.
+                # instance.method(...)
                 return self.method(obj, *args, **kwargs)
+            elif len(args) > 0 and isinstance(args[0], objtype):
+                # Method was called as a class method with the instance as the
+                # first argument, e.g. Class.method(instance, ...) which in
+                # Python is the same thing as calling an instance method
+                return self.method(args[0], *args[1:], **kwargs)
             else:
+                # Method was called as a class method, e.g. Class.method(...)
                 class_method = getattr(objtype, self.class_method_name)
                 return class_method(*args, **kwargs)
 

--- a/tests/api_resources/abstract/test_custom_method.py
+++ b/tests/api_resources/abstract/test_custom_method.py
@@ -1,0 +1,65 @@
+from __future__ import absolute_import, division, print_function
+
+import stripe
+from stripe import util
+
+
+class TestCustomMethod(object):
+    @stripe.api_resources.abstract.custom_method(
+        "do_stuff", http_verb="post", http_path="do_the_thing"
+    )
+    class MyResource(stripe.api_resources.abstract.APIResource):
+        OBJECT_NAME = "myresource"
+
+        def do_stuff(self, idempotency_key=None, **params):
+            url = self.instance_url() + "/do_the_thing"
+            headers = util.populate_headers(idempotency_key)
+            self.refresh_from(self.request("post", url, params, headers))
+            return self
+
+    def test_call_custom_method_class(self, request_mock):
+        request_mock.stub_request(
+            "post",
+            "/v1/myresources/mid/do_the_thing",
+            {"id": "mid", "thing_done": True},
+            rheaders={"request-id": "req_id"},
+        )
+
+        obj = self.MyResource.do_stuff("mid", foo="bar")
+
+        request_mock.assert_requested(
+            "post", "/v1/myresources/mid/do_the_thing", {"foo": "bar"}
+        )
+        assert obj.thing_done is True
+
+    def test_call_custom_method_class_with_object(self, request_mock):
+        request_mock.stub_request(
+            "post",
+            "/v1/myresources/mid/do_the_thing",
+            {"id": "mid", "thing_done": True},
+            rheaders={"request-id": "req_id"},
+        )
+
+        obj = self.MyResource.construct_from({"id": "mid"}, "mykey")
+        self.MyResource.do_stuff(obj, foo="bar")
+
+        request_mock.assert_requested(
+            "post", "/v1/myresources/mid/do_the_thing", {"foo": "bar"}
+        )
+        assert obj.thing_done is True
+
+    def test_call_custom_method_instance(self, request_mock):
+        request_mock.stub_request(
+            "post",
+            "/v1/myresources/mid/do_the_thing",
+            {"id": "mid", "thing_done": True},
+            rheaders={"request-id": "req_id"},
+        )
+
+        obj = self.MyResource.construct_from({"id": "mid"}, "mykey")
+        obj.do_stuff(foo="bar")
+
+        request_mock.assert_requested(
+            "post", "/v1/myresources/mid/do_the_thing", {"foo": "bar"}
+        )
+        assert obj.thing_done is True

--- a/tests/api_resources/abstract/test_deletable_api_resource.py
+++ b/tests/api_resources/abstract/test_deletable_api_resource.py
@@ -24,6 +24,25 @@ class TestDeletableAPIResource(object):
         assert obj.last_response is not None
         assert obj.last_response.request_id == "req_id"
 
+    def test_delete_class_with_object(self, request_mock):
+        request_mock.stub_request(
+            "delete",
+            "/v1/mydeletables/mid",
+            {"id": "mid", "deleted": True},
+            rheaders={"request-id": "req_id"},
+        )
+
+        obj = self.MyDeletable.construct_from({"id": "mid"}, "mykey")
+
+        self.MyDeletable.delete(obj)
+
+        request_mock.assert_requested("delete", "/v1/mydeletables/mid", {})
+        assert obj.deleted is True
+        assert obj.id == "mid"
+
+        assert obj.last_response is not None
+        assert obj.last_response.request_id == "req_id"
+
     def test_delete_instance(self, request_mock):
         request_mock.stub_request(
             "delete",


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

See my comment [here](https://github.com/stripe/stripe-python/issues/597#issuecomment-517727704) for context around the issue this fixes.

In Python, instance methods are really functions that accept the instance as their first argument, e.g.:

```python
class Foo(object):
    def do(self):
        print("Hi!")

foo = Foo()

# the following are equivalent
foo.do()
Foo.do(foo)
```

The hack we introduced in #543 to support declaring instance methods and class methods with the same name broke support for the second syntax. This PR restores support for the second syntax by explicitly checking if the method was invoked with an instance as its first argument.
 
Fixes #597.
