### PR TITLE
Fix automatic retries of failed requests

### DIFF
--- a/stripe/http_client.py
+++ b/stripe/http_client.py
@@ -493,6 +493,7 @@ class PycurlClient(HTTPClient):
                 "https://twitter.com/stripestatus, or let us know at "
                 "support@stripe.com."
             )
+            should_retry = True
         elif e.args[0] in [pycurl.E_SSL_CACERT, pycurl.E_SSL_PEER_CERTIFICATE]:
             msg = (
                 "Could not verify Stripe's SSL certificate.  Please make "
@@ -500,14 +501,16 @@ class PycurlClient(HTTPClient):
                 "If this problem persists, let us know at "
                 "support@stripe.com."
             )
+            should_retry = False
         else:
             msg = (
                 "Unexpected error communicating with Stripe. If this "
                 "problem persists, let us know at support@stripe.com."
             )
+            should_retry = False
 
         msg = textwrap.fill(msg) + "\n\n(Network error: " + e.args[1] + ")"
-        raise error.APIConnectionError(msg)
+        raise error.APIConnectionError(msg, should_retry=should_retry)
 
     def _get_proxy(self, url):
         if self._proxy:

--- a/stripe/http_client.py
+++ b/stripe/http_client.py
@@ -119,7 +119,6 @@ class HTTPClient(object):
             request_start = _now_ms()
 
             try:
-                num_retries += 1
                 response = self.request(method, url, headers, post_data)
                 connection_error = None
             except error.APIConnectionError as e:
@@ -132,7 +131,7 @@ class HTTPClient(object):
                         "Encountered a retryable error %s"
                         % connection_error.user_message
                     )
-
+                num_retries += 1
                 sleep_time = self._sleep_time_seconds(num_retries)
                 util.log_info(
                     (

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -436,10 +436,10 @@ class TestRequestClientRetryBehavior(TestRequestsClient):
     def test_retry_codes_until_exceeded(
         self, mock_retry, response, check_call_numbers
     ):
-        mock_retry(responses=[response(code=409)] * self.max_retries())
+        mock_retry(responses=[response(code=409)] * (self.max_retries() + 1))
         _, code, _ = self.make_request()
         assert code == 409
-        check_call_numbers(self.max_retries())
+        check_call_numbers(self.max_retries() + 1)
 
     @pytest.fixture
     def connection_error(self, session):


### PR DESCRIPTION
Unless I'm missing something, the "less than" comparison here means that the request is retried `n - 1` times instead of `n` times, so setting `max_network_retries` to `1` doesn't work and setting it to `2` only retries once.