### PR TITLE
[codegen] Add `SubscriptionItem.create_usage_record` method

### DIFF
--- a/stripe/api_resources/subscription_item.py
+++ b/stripe/api_resources/subscription_item.py
@@ -4,8 +4,10 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.abstract import nested_resource_class_methods
 
 
+@nested_resource_class_methods("usage_record", operations=["create"])
 class SubscriptionItem(
     CreateableAPIResource,
     DeletableAPIResource,

--- a/tests/api_resources/test_subscription_item.py
+++ b/tests/api_resources/test_subscription_item.py
@@ -64,3 +64,18 @@ class TestSubscriptionItem(object):
             "delete", "/v1/subscription_items/%s" % TEST_RESOURCE_ID
         )
         assert resource.deleted is True
+
+
+class TestUsageRecords(object):
+    def test_is_creatable(self, request_mock):
+        resource = stripe.SubscriptionItem.create_usage_record(
+            TEST_RESOURCE_ID,
+            quantity=5000,
+            timestamp=1524182400,
+            action="increment",
+        )
+        request_mock.assert_requested(
+            "post",
+            "/v1/subscription_items/%s/usage_records" % TEST_RESOURCE_ID,
+        )
+        assert isinstance(resource, stripe.UsageRecord)


### PR DESCRIPTION
r? @rattrayalex-stripe 
cc @stripe/api-libraries

- [x] Sanity check for correctness.
- [x] Ensure appropriate test coverage (ie; write tests).
