### PR TITLE
Add support for header parameters in `ListObject` request methods

### DIFF
--- a/stripe/api_resources/list_object.py
+++ b/stripe/api_resources/list_object.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from stripe import util
+from stripe import api_requestor, util
 from stripe.stripe_object import StripeObject
 
 from stripe.six.moves.urllib.parse import quote_plus
@@ -9,8 +9,19 @@ from stripe.six.moves.urllib.parse import quote_plus
 class ListObject(StripeObject):
     OBJECT_NAME = "list"
 
-    def list(self, **params):
-        return self.request("get", self["url"], params)
+    def list(
+        self, api_key=None, stripe_version=None, stripe_account=None, **params
+    ):
+        requestor = api_requestor.APIRequestor(
+            api_key, api_version=stripe_version, account=stripe_account
+        )
+        url = self.get("url")
+        response, api_key = requestor.request("get", url, params)
+        stripe_object = util.convert_to_stripe_object(
+            response, api_key, stripe_version, stripe_account
+        )
+        stripe_object._retrieve_params = params
+        return stripe_object
 
     def auto_paging_iter(self):
         page = self
@@ -28,17 +39,40 @@ class ListObject(StripeObject):
             params["starting_after"] = item_id
             page = self.list(**params)
 
-    def create(self, idempotency_key=None, **params):
+    def create(
+        self,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        requestor = api_requestor.APIRequestor(
+            api_key, api_version=stripe_version, account=stripe_account
+        )
+        url = self.get("url")
         headers = util.populate_headers(idempotency_key)
-        return self.request("post", self["url"], params, headers)
+        response, api_key = requestor.request("post", url, params, headers)
+        return util.convert_to_stripe_object(
+            response, api_key, stripe_version, stripe_account
+        )
 
-    def retrieve(self, id, **params):
-        base = self.get("url")
-        id = util.utf8(id)
-        extn = quote_plus(id)
-        url = "%s/%s" % (base, extn)
-
-        return self.request("get", url, params)
+    def retrieve(
+        self,
+        id,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        requestor = api_requestor.APIRequestor(
+            api_key, api_version=stripe_version, account=stripe_account
+        )
+        url = "%s/%s" % (self.get("url"), quote_plus(util.utf8(id)))
+        response, api_key = requestor.request("get", url, params)
+        return util.convert_to_stripe_object(
+            response, api_key, stripe_version, stripe_account
+        )
 
     def __iter__(self):
         return getattr(self, "data", []).__iter__()

--- a/tests/api_resources/test_list_object.py
+++ b/tests/api_resources/test_list_object.py
@@ -14,10 +14,6 @@ class TestListObject(object):
             {"object": "list", "url": "/my/path", "data": ["foo"]}, "mykey"
         )
 
-    def assert_response(self, res):
-        assert isinstance(res[0], stripe.Charge)
-        assert res[0].foo == "bar"
-
     def test_for_loop(self, list_object):
         seen = []
 
@@ -28,40 +24,51 @@ class TestListObject(object):
 
     def test_list(self, request_mock, list_object):
         request_mock.stub_request(
-            "get", "/my/path", [{"object": "charge", "foo": "bar"}]
+            "get",
+            "/my/path",
+            {"object": "list", "data": [{"object": "charge", "foo": "bar"}]},
         )
 
-        res = list_object.list(myparam="you")
+        res = list_object.list(myparam="you", stripe_account="acct_123")
 
         request_mock.assert_requested(
             "get", "/my/path", {"myparam": "you"}, None
         )
-        self.assert_response(res)
+        assert isinstance(res, stripe.ListObject)
+        assert res.stripe_account == "acct_123"
+        assert isinstance(res.data, list)
+        assert isinstance(res.data[0], stripe.Charge)
+        assert res.data[0].foo == "bar"
 
     def test_create(self, request_mock, list_object):
         request_mock.stub_request(
-            "post", "/my/path", [{"object": "charge", "foo": "bar"}]
+            "post", "/my/path", {"object": "charge", "foo": "bar"}
         )
 
-        res = list_object.create(myparam="eter")
+        res = list_object.create(myparam="eter", stripe_account="acct_123")
 
         request_mock.assert_requested(
             "post", "/my/path", {"myparam": "eter"}, None
         )
-        self.assert_response(res)
+        assert isinstance(res, stripe.Charge)
+        assert res.foo == "bar"
+        assert res.stripe_account == "acct_123"
 
     def test_retrieve(self, request_mock, list_object):
         request_mock.stub_request(
-            "get", "/my/path/myid", [{"object": "charge", "foo": "bar"}]
+            "get", "/my/path/myid", {"object": "charge", "foo": "bar"}
         )
 
-        res = list_object.retrieve("myid", myparam="cow")
+        res = list_object.retrieve(
+            "myid", myparam="cow", stripe_account="acct_123"
+        )
 
         request_mock.assert_requested(
             "get", "/my/path/myid", {"myparam": "cow"}, None
         )
-
-        self.assert_response(res)
+        assert isinstance(res, stripe.Charge)
+        assert res.foo == "bar"
+        assert res.stripe_account == "acct_123"
 
     def test_len(self, list_object):
         assert len(list_object) == 1


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

`ListObject` provides three instance methods for issuing API requests on the list: `create`, `retrieve` and `list`.

Previously none of these supported "special" parameters for headers: `api_key`, `stripe_account`, `stripe_version`, and `idempotency_key` (for `create` only as the other two are GET requests). This PR fixes that.

The code is very much not DRY, but it's consistent with the rest of the library. The requestor layer in stripe-python is starting to show its age, we should refactor it at some point.

Fixes #609.