### PR TITLE
Use ListObject properties as default values in request methods

### DIFF
--- a/tests/api_resources/test_list_object.py
+++ b/tests/api_resources/test_list_object.py
@@ -54,6 +54,23 @@ class TestListObject(object):
         assert res.foo == "bar"
         assert res.stripe_account == "acct_123"
 
+    def test_create_maintains_list_properties(self, request_mock, list_object):
+        # Testing with real requests because our mock makes it impossible to
+        # test otherwise
+        customer = stripe.Customer.retrieve(
+            "cus_123", api_key="sk_test_custom"
+        )
+
+        res = customer.sources.create(source="tok_123")
+
+        request_mock.assert_requested(
+            "post",
+            "/v1/customers/cus_123/sources",
+            {"source": "tok_123"},
+            None,
+        )
+        assert res.api_key == "sk_test_custom"
+
     def test_retrieve(self, request_mock, list_object):
         request_mock.stub_request(
             "get", "/my/path/myid", {"object": "charge", "foo": "bar"}


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

I caused a regression in #610. Previously, when calling a request method on a `ListObject`, the `ListObject`'s properties for headers (`api_key`, `stripe_account`, `stripe_version`) would be used.

In #610, I added parameters for headers to request methods, but if the parameters are not passed, we would default to `None` instead of using the `ListObject`'s properties for the headers.

This PR fixes this by using the parameter if provided, and falling back to the `ListObject` properties if not.

Fixes #611.
