### PR TITLE
Use OrderedDict to maintain key order

### DIFF
--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -7,6 +7,7 @@ import platform
 import time
 import uuid
 import warnings
+from collections import OrderedDict
 
 import stripe
 from stripe import error, oauth_error, http_client, version, util, six
@@ -25,7 +26,7 @@ def _encode_datetime(dttime):
 
 
 def _encode_nested_dict(key, data, fmt="%s[%s]"):
-    d = {}
+    d = OrderedDict()
     for subkey, subvalue in six.iteritems(data):
         d[fmt % (key, subkey)] = subvalue
     return d

--- a/stripe/stripe_response.py
+++ b/stripe/stripe_response.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import json
+from collections import OrderedDict
 
 
 class StripeResponse(object):
@@ -8,7 +9,7 @@ class StripeResponse(object):
         self.body = body
         self.code = code
         self.headers = headers
-        self.data = json.loads(body)
+        self.data = json.loads(body, object_pairs_hook=OrderedDict)
 
     @property
     def idempotency_key(self):

--- a/stripe/webhook.py
+++ b/stripe/webhook.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import hmac
 import json
 import time
+from collections import OrderedDict
 from hashlib import sha256
 
 import stripe
@@ -21,7 +22,7 @@ class Webhook(object):
 
         WebhookSignature.verify_header(payload, sig_header, secret, tolerance)
 
-        data = json.loads(payload)
+        data = json.loads(payload, object_pairs_hook=OrderedDict)
         event = stripe.Event.construct_from(data, api_key or stripe.api_key)
 
         return event

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -4,6 +4,7 @@ import datetime
 import json
 import tempfile
 import uuid
+from collections import OrderedDict
 
 import pytest
 
@@ -308,6 +309,25 @@ class TestAPIRequestor(object):
 
         assert key == "foo[0][bar]"
         assert value == "bat"
+
+    def test_ordereddict_encoding(self):
+        params = {
+            "ordered": OrderedDict(
+                [
+                    ("one", 1),
+                    ("two", 2),
+                    ("three", 3),
+                    ("nested", OrderedDict([("a", "a"), ("b", "b")])),
+                ]
+            )
+        }
+        encoded = list(stripe.api_requestor._api_encode(params))
+
+        assert encoded[0][0] == "ordered[one]"
+        assert encoded[1][0] == "ordered[two]"
+        assert encoded[2][0] == "ordered[three]"
+        assert encoded[3][0] == "ordered[nested][a]"
+        assert encoded[4][0] == "ordered[nested][b]"
 
     def test_url_construction(self, requestor, mock_response, check_call):
         CASES = (

--- a/tests/test_stripe_response.py
+++ b/tests/test_stripe_response.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
 import json
+from collections import OrderedDict
 
+from stripe import six
 from stripe.stripe_response import StripeResponse
 
 
@@ -28,7 +30,13 @@ class TestStripeResponse(object):
 
     def test_data(self):
         response, _, body, _ = self.mock_stripe_response()
-        assert response.data == json.loads(body)
+        deserialized = json.loads(body, object_pairs_hook=OrderedDict)
+        assert response.data == deserialized
+
+        # Previous assert does not check order, so explicitly check order here
+        assert list(six.iterkeys(response.data["metadata"])) == list(
+            six.iterkeys(deserialized["metadata"])
+        )
 
     @staticmethod
     def mock_stripe_response():
@@ -44,4 +52,15 @@ class TestStripeResponse(object):
 
     @staticmethod
     def mock_body():
-        return '{ "id": "ch_12345", "object": "charge", "amount": 1 }'
+        return """{
+    "id": "ch_12345",
+    "object": "charge",
+    "amount": 1,
+    "metadata": {
+        "one": "1",
+        "two": "2",
+        "three": "3",
+        "four": "4",
+        "five": "5"
+    }
+}"""


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Use `OrderedDict` instead of `dict` to maintain key order in API requests and responses. (This is not a breaking change because `OrderedDict` is a `dict`.)

Fixes #613.
