### PR TITLE
Check that `error` is a dict before trying to use it to create a `StripeError`

### DIFF
--- a/stripe/error.py
+++ b/stripe/error.py
@@ -59,7 +59,11 @@ class StripeError(Exception):
         )
 
     def construct_error_object(self):
-        if self.json_body is None or "error" not in self.json_body:
+        if (
+            self.json_body is None
+            or "error" not in self.json_body
+            or not isinstance(self.json_body["error"], dict)
+        ):
             return None
 
         return stripe.api_resources.error_object.ErrorObject.construct_from(

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -60,6 +60,10 @@ class TestStripeError(object):
         assert err.error.code == "some_error"
         assert err.error.charge is None
 
+    def test_error_object_not_dict(self):
+        err = error.StripeError("message", json_body={"error": "not a dict"})
+        assert err.error is None
+
 
 class TestStripeErrorWithParamCode(object):
     def test_repr(self):


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Check that `error` in the JSON data is a dict before trying to use it to initialize the `StripeError` instance. (This should never happen in production, but can happen in unit tests where `StripeError`s are manually constructed.)

Addresses this comment from @thieman: https://github.com/stripe/stripe-python/pull/619#discussion_r328761227

