### PR TITLE
Update proxy.py

### DIFF
--- a/examples/proxy.py
+++ b/examples/proxy.py
@@ -9,20 +9,20 @@ stripe.api_key = os.environ.get("STRIPE_SECRET_KEY")
 
 print("Attempting charge...")
 
-stripe.proxy = {
+proxy = {
     "http": "http://<user>:<pass>@<proxy>:<port>",
     "https": "http://<user>:<pass>@<proxy>:<port>",
 }
 
 clients = (
     stripe.http_client.RequestsClient(
-        verify_ssl_certs=stripe.verify_ssl_certs, proxy=stripe.proxy
+        verify_ssl_certs=stripe.verify_ssl_certs, proxy=proxy
     ),
     stripe.http_client.PycurlClient(
-        verify_ssl_certs=stripe.verify_ssl_certs, proxy=stripe.proxy
+        verify_ssl_certs=stripe.verify_ssl_certs, proxy=proxy
     ),
     stripe.http_client.Urllib2Client(
-        verify_ssl_certs=stripe.verify_ssl_certs, proxy=stripe.proxy
+        verify_ssl_certs=stripe.verify_ssl_certs, proxy=proxy
     ),
 )
 


### PR DESCRIPTION
if using stripe.proxy api requestor show warning "UserWarning: stripe.proxy was updated after sending a request - this is a no-op. To use a different proxy, set stripe.default_http_client to a new client configured with the proxy."