### PR TITLE
Update Python API docs inline link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ API.
 
 ## Documentation
 
-See the [Python API docs](https://stripe.com/docs/api/python#intro).
+See the [Python API docs](https://stripe.com/docs/api?lang=python).
 
 ## Installation
 


### PR DESCRIPTION
Looks like the Python API documentation link has changed slightly, proposing updating the inline link here.