### PR TITLE
Fix uploading files with Unicode names (Python 2.7)

### DIFF
--- a/stripe/multipart_data_generator.py
+++ b/stripe/multipart_data_generator.py
@@ -29,7 +29,7 @@ class MultipartDataGenerator(object):
                     # Convert the filename to string, just in case it's not
                     # already one. E.g. `tempfile.TemporaryFile` has a `name`
                     # attribute but it's an `int`.
-                    filename = str(value.name)
+                    filename = stripe.six.text_type(value.name)
 
                 self._write('Content-Disposition: form-data; name="')
                 self._write(key)

--- a/tests/test_multipart_data_generator.py
+++ b/tests/test_multipart_data_generator.py
@@ -86,3 +86,8 @@ class TestMultipartDataGenerator(object):
     def test_multipart_data_stringio(self):
         string = six.StringIO("foo")
         self.run_test_multipart_data_with_file(string)
+
+    def test_multipart_data_unicode_file_name(self):
+        string = six.StringIO("foo")
+        string.name = u"паспорт.png"
+        self.run_test_multipart_data_with_file(string)


### PR DESCRIPTION
It resulted in `UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-6: ordinal not in range(128)` before