### PR TITLE
Add support for `CreditNoteLineItem`

### DIFF
--- a/stripe/api_resources/__init__.py
+++ b/stripe/api_resources/__init__.py
@@ -29,6 +29,7 @@ from stripe.api_resources.charge import Charge
 from stripe.api_resources.country_spec import CountrySpec
 from stripe.api_resources.coupon import Coupon
 from stripe.api_resources.credit_note import CreditNote
+from stripe.api_resources.credit_note_line_item import CreditNoteLineItem
 from stripe.api_resources.customer import Customer
 from stripe.api_resources.customer_balance_transaction import (
     CustomerBalanceTransaction,

--- a/stripe/api_resources/credit_note.py
+++ b/stripe/api_resources/credit_note.py
@@ -14,6 +14,12 @@ class CreditNote(
 ):
     OBJECT_NAME = "credit_note"
 
+    def void_credit_note(self, idempotency_key=None, **params):
+        url = self.instance_url() + "/void"
+        headers = util.populate_headers(idempotency_key)
+        self.refresh_from(self.request("post", url, params, headers))
+        return self
+
     @classmethod
     def preview(
         cls, api_key=None, stripe_version=None, stripe_account=None, **params
@@ -26,9 +32,3 @@ class CreditNote(
         return util.convert_to_stripe_object(
             response, api_key, stripe_version, stripe_account
         )
-
-    def void_credit_note(self, idempotency_key=None, **params):
-        url = self.instance_url() + "/void"
-        headers = util.populate_headers(idempotency_key)
-        self.refresh_from(self.request("post", url, params, headers))
-        return self

--- a/stripe/api_resources/credit_note_line_item.py
+++ b/stripe/api_resources/credit_note_line_item.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import, division, print_function
+
+from stripe.stripe_object import StripeObject
+
+
+class CreditNoteLineItem(StripeObject):
+    OBJECT_NAME = "credit_note_line_item"

--- a/stripe/object_classes.py
+++ b/stripe/object_classes.py
@@ -25,6 +25,7 @@ OBJECT_CLASSES = {
     api_resources.CountrySpec.OBJECT_NAME: api_resources.CountrySpec,
     api_resources.Coupon.OBJECT_NAME: api_resources.Coupon,
     api_resources.CreditNote.OBJECT_NAME: api_resources.CreditNote,
+    api_resources.CreditNoteLineItem.OBJECT_NAME: api_resources.CreditNoteLineItem,
     api_resources.Customer.OBJECT_NAME: api_resources.Customer,
     api_resources.CustomerBalanceTransaction.OBJECT_NAME: api_resources.CustomerBalanceTransaction,
     api_resources.Dispute.OBJECT_NAME: api_resources.Dispute,


### PR DESCRIPTION
Codegen for openapi d663cdb
No method added in Python for now to be consistent with InvoiceLineItem.

r? @ob-stripe 
cc @stripe/api-libraries 