### PR TITLE
Add support for listing Checkout `Session`

### DIFF
--- a/stripe/api_resources/checkout/session.py
+++ b/stripe/api_resources/checkout/session.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import CreateableAPIResource
+from stripe.api_resources.abstract import ListableAPIResource
 
 
-class Session(CreateableAPIResource):
+class Session(CreateableAPIResource, ListableAPIResource):
     OBJECT_NAME = "checkout.session"


### PR DESCRIPTION
Codegen for openapi 40a20cd (minus the `Mandate` incorrect changes)

r? @ob-stripe 
cc @stripe/api-libraries 