### PR TITLE
Add support for the `LineItem` resource and APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `tests/conftest.py`.
-    - STRIPE_MOCK_VERSION=0.89.0
+    - STRIPE_MOCK_VERSION=0.90.0
 
 before_install:
   # Unpack and start stripe-mock so that the test suite can talk to it

--- a/stripe/api_resources/__init__.py
+++ b/stripe/api_resources/__init__.py
@@ -46,6 +46,7 @@ from stripe.api_resources.invoice import Invoice
 from stripe.api_resources.invoice_item import InvoiceItem
 from stripe.api_resources.invoice_line_item import InvoiceLineItem
 from stripe.api_resources.issuer_fraud_record import IssuerFraudRecord
+from stripe.api_resources.line_item import LineItem
 from stripe.api_resources.login_link import LoginLink
 from stripe.api_resources.mandate import Mandate
 from stripe.api_resources.order import Order

--- a/stripe/api_resources/checkout/session.py
+++ b/stripe/api_resources/checkout/session.py
@@ -2,7 +2,9 @@ from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.abstract import nested_resource_class_methods
 
 
+@nested_resource_class_methods("line_item", operations=["list"])
 class Session(CreateableAPIResource, ListableAPIResource):
     OBJECT_NAME = "checkout.session"

--- a/stripe/api_resources/line_item.py
+++ b/stripe/api_resources/line_item.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import, division, print_function
+
+from stripe.api_resources.abstract import APIResource
+
+
+class LineItem(APIResource):
+    OBJECT_NAME = "item"

--- a/stripe/object_classes.py
+++ b/stripe/object_classes.py
@@ -46,6 +46,7 @@ OBJECT_CLASSES = {
     api_resources.issuing.Cardholder.OBJECT_NAME: api_resources.issuing.Cardholder,
     api_resources.issuing.Dispute.OBJECT_NAME: api_resources.issuing.Dispute,
     api_resources.issuing.Transaction.OBJECT_NAME: api_resources.issuing.Transaction,
+    api_resources.LineItem.OBJECT_NAME: api_resources.LineItem,
     api_resources.LoginLink.OBJECT_NAME: api_resources.LoginLink,
     api_resources.Mandate.OBJECT_NAME: api_resources.Mandate,
     api_resources.Order.OBJECT_NAME: api_resources.Order,

--- a/tests/api_resources/checkout/test_session.py
+++ b/tests/api_resources/checkout/test_session.py
@@ -34,3 +34,13 @@ class TestSession(object):
             "get", "/v1/checkout/sessions/%s" % TEST_RESOURCE_ID
         )
         assert isinstance(resource, stripe.checkout.Session)
+
+
+class TestSessionLineItems(object):
+    def test_is_listable(self, request_mock):
+        resources = stripe.checkout.Session.list_line_items(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "get", "/v1/checkout/sessions/%s/line_items" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resources.data, list)
+        assert isinstance(resources.data[0], stripe.LineItem)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from tests.stripe_mock import StripeMock
 
 
 # When changing this number, don't forget to change it in `.travis.yml` too.
-MOCK_MINIMUM_VERSION = "0.89.0"
+MOCK_MINIMUM_VERSION = "0.90.0"
 
 # Starts stripe-mock if an OpenAPI spec override is found in `openapi/`, and
 # otherwise fall back to `STRIPE_MOCK_PORT` or 12111.


### PR DESCRIPTION
Based on codegen for openapi 72527e3 but manually making changes as we don't yet support nested resources in python codegen

r? @richardm-stripe 
cc @stripe/api-libraries 