### PR TITLE
Support stripe.File.create(stripe_version='...')

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `tests/conftest.py`.
-    - STRIPE_MOCK_VERSION=0.90.0
+    - STRIPE_MOCK_VERSION=0.93.0
 
 before_install:
   # Unpack and start stripe-mock so that the test suite can talk to it

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 VENV_NAME?=venv
+PIP?=pip
+PYTHON?=python
 
 venv: $(VENV_NAME)/bin/activate
 
 $(VENV_NAME)/bin/activate: setup.py
-	pip install --upgrade pip virtualenv
-	@test -d $(VENV_NAME) || python -m virtualenv --clear $(VENV_NAME)
+	$(PIP) install --upgrade pip virtualenv
+	@test -d $(VENV_NAME) || $(PYTHON) -m virtualenv --clear $(VENV_NAME)
 	${VENV_NAME}/bin/python -m pip install -U pip tox
 	${VENV_NAME}/bin/python -m pip install -e .
 	@touch $(VENV_NAME)/bin/activate
@@ -16,7 +18,7 @@ ci: venv
 	@${VENV_NAME}/bin/python setup.py test -a "-n auto --cov=stripe"
 
 coveralls: venv
-	@${VENV_NAME}/bin/pip install --upgrade coveralls
+	@${VENV_NAME}/bin/$(PIP) install --upgrade coveralls
 	@${VENV_NAME}/bin/coveralls
 
 fmt: venv

--- a/stripe/api_resources/file.py
+++ b/stripe/api_resources/file.py
@@ -21,12 +21,19 @@ class File(ListableAPIResource):
 
     @classmethod
     def create(
-        cls, api_key=None, api_version=None, stripe_account=None, **params
+        # 'api_version' is deprecated, please use 'stripe_version'
+        cls,
+        api_key=None,
+        api_version=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
     ):
+        version = api_version or stripe_version
         requestor = api_requestor.APIRequestor(
             api_key,
             api_base=stripe.upload_api_base,
-            api_version=api_version,
+            api_version=version,
             account=stripe_account,
         )
         url = cls.class_url()
@@ -35,7 +42,7 @@ class File(ListableAPIResource):
             "post", url, params=params, headers=supplied_headers
         )
         return util.convert_to_stripe_object(
-            response, api_key, api_version, stripe_account
+            response, api_key, version, stripe_account
         )
 
 

--- a/tests/api_resources/test_account_link.py
+++ b/tests/api_resources/test_account_link.py
@@ -7,8 +7,8 @@ class TestAccountLink(object):
     def test_is_creatable(self, request_mock):
         resource = stripe.AccountLink.create(
             account="acct_123",
-            failure_url="https://stripe.com/failure",
-            success_url="https://stripe.com/success",
+            refresh_url="https://stripe.com/failure",
+            return_url="https://stripe.com/success",
             type="custom_account_verification",
         )
         request_mock.assert_requested("post", "/v1/account_links")

--- a/tests/api_resources/test_file.py
+++ b/tests/api_resources/test_file.py
@@ -50,6 +50,26 @@ class TestFile(object):
         )
         assert isinstance(resource, stripe.File)
 
+    def test_create_respects_stripe_version(self, setup_upload_api_base, request_mock):
+        test_file = tempfile.TemporaryFile()
+        stripe.File.create(
+            purpose="dispute_evidence",
+            file=test_file,
+            stripe_version="foo"
+        )
+        request_mock.assert_api_version("foo")
+
+    # You can use api_version instead of stripe_version
+    # in File.create. We preserve it for backwards compatibility
+    def test_create_respects_api_version(self, setup_upload_api_base, request_mock):
+        test_file = tempfile.TemporaryFile()
+        stripe.File.create(
+            purpose="dispute_evidence",
+            file=test_file,
+            api_version="foo"
+        )
+        request_mock.assert_api_version("foo")
+
     def test_deserializes_from_file(self):
         obj = stripe.util.convert_to_stripe_object({"object": "file"})
         assert isinstance(obj, stripe.File)

--- a/tests/api_resources/test_file.py
+++ b/tests/api_resources/test_file.py
@@ -50,23 +50,23 @@ class TestFile(object):
         )
         assert isinstance(resource, stripe.File)
 
-    def test_create_respects_stripe_version(self, setup_upload_api_base, request_mock):
+    def test_create_respects_stripe_version(
+        self, setup_upload_api_base, request_mock
+    ):
         test_file = tempfile.TemporaryFile()
         stripe.File.create(
-            purpose="dispute_evidence",
-            file=test_file,
-            stripe_version="foo"
+            purpose="dispute_evidence", file=test_file, stripe_version="foo"
         )
         request_mock.assert_api_version("foo")
 
     # You can use api_version instead of stripe_version
     # in File.create. We preserve it for backwards compatibility
-    def test_create_respects_api_version(self, setup_upload_api_base, request_mock):
+    def test_create_respects_api_version(
+        self, setup_upload_api_base, request_mock
+    ):
         test_file = tempfile.TemporaryFile()
         stripe.File.create(
-            purpose="dispute_evidence",
-            file=test_file,
-            api_version="foo"
+            purpose="dispute_evidence", file=test_file, api_version="foo"
         )
         request_mock.assert_api_version("foo")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from tests.stripe_mock import StripeMock
 
 
 # When changing this number, don't forget to change it in `.travis.yml` too.
-MOCK_MINIMUM_VERSION = "0.90.0"
+MOCK_MINIMUM_VERSION = "0.93.0"
 
 # Starts stripe-mock if an OpenAPI spec override is found in `openapi/`, and
 # otherwise fall back to `STRIPE_MOCK_PORT` or 12111.


### PR DESCRIPTION
r? @ob-stripe

As reported in #663, in order to override the version in `File.create` you had to `stripe.File.create(api_version="...")` which is inconsistent with other methods, which call the version parameter `stripe_version`.

This PR adds support for `stripe_version`, but support for `api_version` is retained in order to avoid a breaking change. `api_
version` will trump `stripe_version` when both are provided.

I also made a change to the `Makefile` that lets you specify a path to the python and pip binaries (but only for the invocations of these outside of the virtualenv). This was helpful for me because I couldn't get `make venv` to work when pointing to the mac default python 2.7 and had to explicitly point it to the python3 I installed using brew. 