### PR TITLE
Add support for the `PromotionCode` resource and APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `tests/conftest.py`.
-    - STRIPE_MOCK_VERSION=0.93.0
+    - STRIPE_MOCK_VERSION=0.95.0
 
 before_install:
   # Unpack and start stripe-mock so that the test suite can talk to it

--- a/stripe/api_resources/__init__.py
+++ b/stripe/api_resources/__init__.py
@@ -58,6 +58,7 @@ from stripe.api_resources.person import Person
 from stripe.api_resources.plan import Plan
 from stripe.api_resources.price import Price
 from stripe.api_resources.product import Product
+from stripe.api_resources.promotion_code import PromotionCode
 from stripe.api_resources.recipient import Recipient
 from stripe.api_resources.recipient_transfer import RecipientTransfer
 from stripe.api_resources.refund import Refund

--- a/stripe/api_resources/promotion_code.py
+++ b/stripe/api_resources/promotion_code.py
@@ -1,0 +1,11 @@
+from __future__ import absolute_import, division, print_function
+
+from stripe.api_resources.abstract import CreateableAPIResource
+from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.abstract import UpdateableAPIResource
+
+
+class PromotionCode(
+    CreateableAPIResource, ListableAPIResource, UpdateableAPIResource
+):
+    OBJECT_NAME = "promotion_code"

--- a/stripe/object_classes.py
+++ b/stripe/object_classes.py
@@ -58,6 +58,7 @@ OBJECT_CLASSES = {
     api_resources.Plan.OBJECT_NAME: api_resources.Plan,
     api_resources.Price.OBJECT_NAME: api_resources.Price,
     api_resources.Product.OBJECT_NAME: api_resources.Product,
+    api_resources.PromotionCode.OBJECT_NAME: api_resources.PromotionCode,
     api_resources.radar.EarlyFraudWarning.OBJECT_NAME: api_resources.radar.EarlyFraudWarning,
     api_resources.radar.ValueList.OBJECT_NAME: api_resources.radar.ValueList,
     api_resources.radar.ValueListItem.OBJECT_NAME: api_resources.radar.ValueListItem,

--- a/tests/api_resources/test_account_link.py
+++ b/tests/api_resources/test_account_link.py
@@ -9,7 +9,7 @@ class TestAccountLink(object):
             account="acct_123",
             refresh_url="https://stripe.com/failure",
             return_url="https://stripe.com/success",
-            type="custom_account_verification",
+            type="account_onboarding",
         )
         request_mock.assert_requested("post", "/v1/account_links")
         assert isinstance(resource, stripe.AccountLink)

--- a/tests/api_resources/test_promotion_code.py
+++ b/tests/api_resources/test_promotion_code.py
@@ -1,0 +1,43 @@
+from __future__ import absolute_import, division, print_function
+
+import stripe
+
+
+TEST_RESOURCE_ID = "promo_123"
+
+
+class TestPromotionCode(object):
+    def test_is_listable(self, request_mock):
+        resources = stripe.PromotionCode.list()
+        request_mock.assert_requested("get", "/v1/promotion_codes")
+        assert isinstance(resources.data, list)
+        assert isinstance(resources.data[0], stripe.PromotionCode)
+
+    def test_is_retrievable(self, request_mock):
+        resource = stripe.PromotionCode.retrieve(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "get", "/v1/promotion_codes/%s" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.PromotionCode)
+
+    def test_is_creatable(self, request_mock):
+        resource = stripe.PromotionCode.create(coupon="co_123", code="MYCODE")
+        request_mock.assert_requested("post", "/v1/promotion_codes")
+        assert isinstance(resource, stripe.PromotionCode)
+
+    def test_is_saveable(self, request_mock):
+        resource = stripe.PromotionCode.retrieve(TEST_RESOURCE_ID)
+        resource.metadata["key"] = "value"
+        resource.save()
+        request_mock.assert_requested(
+            "post", "/v1/promotion_codes/%s" % TEST_RESOURCE_ID
+        )
+
+    def test_is_modifiable(self, request_mock):
+        resource = stripe.PromotionCode.modify(
+            TEST_RESOURCE_ID, metadata={"key": "value"}
+        )
+        request_mock.assert_requested(
+            "post", "/v1/promotion_codes/%s" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.PromotionCode)

--- a/tests/api_resources/test_subscription_item.py
+++ b/tests/api_resources/test_subscription_item.py
@@ -24,29 +24,29 @@ class TestSubscriptionItem(object):
 
     def test_is_creatable(self, request_mock):
         resource = stripe.SubscriptionItem.create(
-            plan="plan", subscription="sub_123"
+            price="price_123", subscription="sub_123"
         )
         request_mock.assert_requested("post", "/v1/subscription_items")
         assert isinstance(resource, stripe.SubscriptionItem)
 
     def test_is_saveable(self, request_mock):
         resource = stripe.SubscriptionItem.retrieve(TEST_RESOURCE_ID)
-        resource.plan = "plan"
+        resource.price = "price_123"
         resource.save()
         request_mock.assert_requested(
             "post",
             "/v1/subscription_items/%s" % TEST_RESOURCE_ID,
-            {"plan": "plan"},
+            {"price": "price_123"},
         )
 
     def test_is_modifiable(self, request_mock):
         resource = stripe.SubscriptionItem.modify(
-            TEST_RESOURCE_ID, plan="plan"
+            TEST_RESOURCE_ID, price="price_123"
         )
         request_mock.assert_requested(
             "post",
             "/v1/subscription_items/%s" % TEST_RESOURCE_ID,
-            {"plan": "plan"},
+            {"price": "price_123"},
         )
         assert isinstance(resource, stripe.SubscriptionItem)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from tests.stripe_mock import StripeMock
 
 
 # When changing this number, don't forget to change it in `.travis.yml` too.
-MOCK_MINIMUM_VERSION = "0.93.0"
+MOCK_MINIMUM_VERSION = "0.95.0"
 
 # Starts stripe-mock if an OpenAPI spec override is found in `openapi/`, and
 # otherwise fall back to `STRIPE_MOCK_PORT` or 12111.


### PR DESCRIPTION
Codegen for openapi f71053e but I had to manually remove the changes to `File` as master is different from what we codegen today

r? @cjavilla-stripe
cc @stripe/api-libraries