### PR TITLE
add new test target to skip stripe-mock dependent tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ $(VENV_NAME)/bin/activate: setup.py
 test: venv
 	@${VENV_NAME}/bin/tox -p auto $(TOX_ARGS)
 
+test-nomock: venv
+	@${VENV_NAME}/bin/tox -p auto -- --nomock $(TOX_ARGS)
+
 ci: venv
 	@${VENV_NAME}/bin/python setup.py test -a "-n auto --cov=stripe"
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,8 @@ setup(
     ],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     tests_require=[
-        "pytest >= 4.6.2, < 4.7",
+        'pytest >= 4.6.2, < 4.7; python_version < "3.5"',
+        'pytest >= 6.0.0; python_version >= "3.5"',
         "pytest-mock >= 2.0.0",
         "pytest-xdist >= 1.31.0",
         "pytest-cov >= 2.8.1",

--- a/tests/api_resources/test_source.py
+++ b/tests/api_resources/test_source.py
@@ -53,7 +53,7 @@ class TestSource(object):
             "delete", "/v1/customers/cus_123/sources/%s" % TEST_RESOURCE_ID
         )
 
-    def test_is_not_detachable_when_unattached(self):
+    def test_is_not_detachable_when_unattached(self, request_mock):
         resource = stripe.Source.retrieve(TEST_RESOURCE_ID)
         with pytest.raises(stripe.error.InvalidRequestError):
             resource.detach()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,17 +52,26 @@ def pytest_configure(config):
         except Exception:
             sys.exit(
                 "Couldn't reach stripe-mock at `localhost:%s`. Is "
-                "it running? Please see README for setup instructions." % MOCK_PORT
+                "it running? Please see README for setup instructions."
+                % MOCK_PORT
             )
 
 
 def pytest_addoption(parser):
-    parser.addoption("--nomock", action="store_true", help="only run tests that don't need stripe-mock")
+    parser.addoption(
+        "--nomock",
+        action="store_true",
+        help="only run tests that don't need stripe-mock",
+    )
 
 
 def pytest_runtest_setup(item):
-    if 'request_mock' in item.fixturenames and item.config.getoption("--nomock"):
-        pytest.skip("run stripe-mock locally and remove --nomock flag to run skipped tests")
+    if "request_mock" in item.fixturenames and item.config.getoption(
+        "--nomock"
+    ):
+        pytest.skip(
+            "run stripe-mock locally and remove --nomock flag to run skipped tests"
+        )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,27 +31,38 @@ def stop_stripe_mock():
     StripeMock.stop()
 
 
-try:
-    resp = urlopen("http://localhost:%s/" % MOCK_PORT)
-    info = resp.info()
-except HTTPError as e:
-    info = e.info()
-except Exception:
-    sys.exit(
-        "Couldn't reach stripe-mock at `localhost:%s`. Is "
-        "it running? Please see README for setup instructions." % MOCK_PORT
-    )
+def pytest_configure(config):
+    if not config.getoption("--nomock"):
+        try:
+            resp = urlopen("http://localhost:%s/" % MOCK_PORT)
+            info = resp.info()
+            version = info.get("Stripe-Mock-Version")
+            if version != "master" and StrictVersion(version) < StrictVersion(
+                MOCK_MINIMUM_VERSION
+            ):
+                sys.exit(
+                    "Your version of stripe-mock (%s) is too old. The minimum "
+                    "version to run this test suite is %s. Please "
+                    "see its repository for upgrade instructions."
+                    % (version, MOCK_MINIMUM_VERSION)
+                )
 
-version = info.get("Stripe-Mock-Version")
-if version != "master" and StrictVersion(version) < StrictVersion(
-    MOCK_MINIMUM_VERSION
-):
-    sys.exit(
-        "Your version of stripe-mock (%s) is too old. The minimum "
-        "version to run this test suite is %s. Please "
-        "see its repository for upgrade instructions."
-        % (version, MOCK_MINIMUM_VERSION)
-    )
+        except HTTPError as e:
+            info = e.info()
+        except Exception:
+            sys.exit(
+                "Couldn't reach stripe-mock at `localhost:%s`. Is "
+                "it running? Please see README for setup instructions." % MOCK_PORT
+            )
+
+
+def pytest_addoption(parser):
+    parser.addoption("--nomock", action="store_true", help="only run tests that don't need stripe-mock")
+
+
+def pytest_runtest_setup(item):
+    if 'request_mock' in item.funcargnames and item.config.getoption("--nomock"):
+        pytest.skip("run stripe-mock locally and remove --nomock flag to run skipped tests")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,7 @@ def pytest_addoption(parser):
 
 
 def pytest_runtest_setup(item):
-    if 'request_mock' in item.funcargnames and item.config.getoption("--nomock"):
+    if 'request_mock' in item.fixturenames and item.config.getoption("--nomock"):
         pytest.skip("run stripe-mock locally and remove --nomock flag to run skipped tests")
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -36,5 +36,5 @@ skip_install = true
 description = run static analysis and style check using flake8
 basepython = python2.7
 deps = flake8
-commands = python -m flake8 --show-source stripe tests setup.py {posargs}
+commands = python -m flake8 --show-source stripe tests setup.py
 skip_install = true


### PR DESCRIPTION
:wave:
this PR proposes a workaround for #670 

**TLDR:** anyone wishing to run basic test coverage on this codebase without having to install and run stripe-mock can run `make test-nomock`. This will run all tests which do not depend on stripe-mock.

A summary of the changes:

- the original make test target `make test` is unchanged
- a new `make test-nomock` target has been added
- this new test command runs only the tests that do not rely on stripe-mock as a dependency
- adds a new flag for `pytest --nomock` in order to skip tests that need stripe-mock
- 136 tests can still be run without stripe-mock vs 483 which do require stripe-mock ∴ around ~22% of our tests.

