### PR TITLE
validate default value

### DIFF
--- a/stripe/webhook.py
+++ b/stripe/webhook.py
@@ -17,6 +17,9 @@ class Webhook(object):
     def construct_event(
         payload, sig_header, secret, tolerance=DEFAULT_TOLERANCE, api_key=None
     ):
+        if api_key is None:
+            raise ValueError("api key is None")
+
         if hasattr(payload, "decode"):
             payload = payload.decode("utf-8")
 


### PR DESCRIPTION
Raise an error if stripe api key is None in [webhook.py](https://github.com/stripe/stripe-python/blob/master/stripe/webhook.py#L18)