### PR TITLE
Fix issue where StripeObjects in lists would not be converted to dicts

### DIFF
--- a/stripe/stripe_object.py
+++ b/stripe/stripe_object.py
@@ -278,11 +278,20 @@ class StripeObject(dict):
         return dict(self)
 
     def to_dict_recursive(self):
-        d = dict(self)
-        for k, v in six.iteritems(d):
-            if isinstance(v, StripeObject):
-                d[k] = v.to_dict_recursive()
-        return d
+        def maybe_to_dict_recursive(value):
+            if value is None:
+                return None
+            elif isinstance(value, StripeObject):
+                return value.to_dict_recursive()
+            else:
+                return value
+
+        return {
+            key: list(map(maybe_to_dict_recursive, value))
+            if isinstance(value, list)
+            else maybe_to_dict_recursive(value)
+            for key, value in six.iteritems(dict(self))
+        }
 
     @property
     def stripe_id(self):

--- a/tests/test_stripe_object.py
+++ b/tests/test_stripe_object.py
@@ -291,6 +291,30 @@ class TestStripeObject(object):
         # Verify that we're actually deep copying nested values.
         assert id(nested) != id(copied.nested)
 
+    def test_to_dict_recursive(self):
+        foo = stripe.stripe_object.StripeObject.construct_from(
+            {"value": "foo"}, "mykey"
+        )
+        bar = stripe.stripe_object.StripeObject.construct_from(
+            {"value": "bar"}, "mykey"
+        )
+        obj = stripe.stripe_object.StripeObject.construct_from(
+            {"empty": "", "value": "foobar", "nested": [foo, bar]}, "mykey"
+        )
+
+        d = obj.to_dict_recursive()
+        assert d == {
+            "empty": "",
+            "value": "foobar",
+            "nested": [{"value": "foo"}, {"value": "bar"}],
+        }
+        assert not isinstance(
+            d["nested"][0], stripe.stripe_object.StripeObject
+        )
+        assert not isinstance(
+            d["nested"][1], stripe.stripe_object.StripeObject
+        )
+
     def test_serialize_empty_string_unsets(self):
         class SerializeToEmptyString(stripe.stripe_object.StripeObject):
             def serialize(self, previous):


### PR DESCRIPTION
Fix issue where StripeObjects in lists would not be converted to dicts.

I updated the implementation of `StripeObject.to_dict_recursive()` to be similar to what we do in stripe-ruby and stripe-php:

https://github.com/stripe/stripe-ruby/blob/9787913b355049af915cf075b29666e55c5ab7f2/lib/stripe/stripe_object.rb#L182-L197

https://github.com/stripe/stripe-php/blob/a2ebaa272a8797b21e81afaf8d5ba0953ff15e13/lib/StripeObject.php#L427-L456

Fixes #695. Replaces #696.

r? @remi-stripe 
cc @stripe/api-libraries 
