### PR TITLE
Add link to YouTube playlist from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ API.
 
 See the [Python API docs](https://stripe.com/docs/api?lang=python).
 
+See [video demonstrations][youtube-playlist] covering how to use the library.
+
+
 ## Installation
 
 You don't need this source code unless you want to modify the package. If you just
@@ -247,6 +250,7 @@ make fmt
 [poetry]: https://github.com/sdispater/poetry
 [stripe-mock]: https://github.com/stripe/stripe-mock
 [idempotency-keys]: https://stripe.com/docs/api/idempotent_requests?lang=python
+[youtube-playlist]: https://www.youtube.com/playlist?list=PLy1nL-pvL2M55YVn0mGoQ5r-39A1-ZypO
 
 <!--
 # vim: set tw=79:


### PR DESCRIPTION
5 of 8 videos are now live covering how to use features of stripe-python. The remaining videos will be released over the coming weeks. 

This adds a link to the YouTube playlist into the readme. Once we have all episodes live, I plan to add a description of each and links to the specific timestamps as part of the Wiki.

r? @ctrudeau-stripe 
cc @stripe/api-libraries 