### PR TITLE
github actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  php-cs-fixer:
+  lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -20,7 +20,7 @@ jobs:
       run: make lint
 
 
-  phpstan:
+  fmt:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -32,7 +32,6 @@ jobs:
       run: make fmtcheck
 
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,79 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 2
+      uses: actions/setup-python@v2
+      with:
+        python-version: 2.7
+    - name: lint
+      run: make lint
+
+
+  fmtcheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: fmtcheck
+      run: make fmtcheck
+
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, pypy-2.7, pypy-3.7]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        python -c "from pip._internal.locations import USER_CACHE_DIR; print('::set-output name=dir::' + USER_CACHE_DIR)"
+    - name: pip cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: docker cache
+      uses: actions/cache@v2
+      with:
+        path: /var/lib/docker
+        key: ${{ runner.os }}-docker-
+        restore-keys: |
+          ${{ runner.os }}-docker-
+
+    # Might be sensible to cache the docker image but this seems to be
+    # not fully supported by github actions yet, as of Feb 2021
+    # https://github.com/actions/cache/issues/81
+    - name: Start stripe-mock
+      run: docker run -d -p 12111-12112:12111-12112 stripemock/stripe-mock && sleep 5
+
+    - name: Test with pytest
+      run: make ci

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,6 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: Python package
 
 on:
@@ -10,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  lint:
+  php-cs-fixer:
     runs-on: ubuntu-latest
 
     steps:
@@ -23,7 +20,7 @@ jobs:
       run: make lint
 
 
-  fmtcheck:
+  phpstan:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -60,14 +57,6 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-
-    - name: docker cache
-      uses: actions/cache@v2
-      with:
-        path: /var/lib/docker
-        key: ${{ runner.os }}-docker-
-        restore-keys: |
-          ${{ runner.os }}-docker-
 
     # Might be sensible to cache the docker image but this seems to be
     # not fully supported by github actions yet, as of Feb 2021

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -65,3 +65,6 @@ jobs:
 
     - name: Test with pytest
       run: make test
+
+    - name: Coveralls
+      run: env

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -64,4 +64,4 @@ jobs:
       run: docker run -d -p 12111-12112:12111-12112 stripemock/stripe-mock && sleep 5
 
     - name: Test with pytest
-      run: make ci
+      run: make test

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,7 +44,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-
+    - name: Upgrade pip and virtualenv to latest
+      run: pip install --upgrade pip virtualenv
     - name: Get pip cache dir
       id: pip-cache
       run: |
@@ -65,6 +66,3 @@ jobs:
 
     - name: Test with pytest
       run: make test
-
-    - name: Coveralls
-      run: env


### PR DESCRIPTION
r? @ob-stripe 
Runs `make lint`, `make fmt`, and `make ci` in Github Actions.
Doesn't include support for "coveralls" but I think we've agreed to drop it.