### PR TITLE
Deprecate `python setup.py test`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,11 @@
+[paths]
+source =
+    stripe
+    */site-packages
+
 [run]
 branch = true
+parallel = true
 source = stripe
 omit =
     stripe/six.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 
-dist: xenial
+dist: focal
 
 language: python
 
@@ -8,14 +8,15 @@ matrix:
   include:
     - python: "2.7"
     - python: "3.4"
+      dist: xenial
     - python: "3.5"
     - python: "3.6"
     - python: "3.7"
     - python: "3.8"
     - python: "3.9"
     - python: "3.10-dev"
-    - python: "pypy2.7-6.0"
-    - python: "pypy3.5-6.0"
+    - python: "pypy2"
+    - python: "pypy3"
   allow_failures:
     - python: "3.10-dev"
 
@@ -48,7 +49,7 @@ install:
 
 script:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then make lint; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.8' ]]; then make fmtcheck; fi
-  - make ci
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.9' ]]; then make fmtcheck; fi
+  - make test-travis
 
 after_success: make coveralls

--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,12 @@ test: venv
 test-nomock: venv
 	@${VENV_NAME}/bin/tox -p auto -- --nomock $(TOX_ARGS)
 
-ci: venv
-	@${VENV_NAME}/bin/python setup.py test -a "-n auto --cov=stripe"
+test-travis: venv
+	${VENV_NAME}/bin/python -m pip install -U tox-travis
+	@${VENV_NAME}/bin/tox -p auto $(TOX_ARGS)
 
 coveralls: venv
-	@${VENV_NAME}/bin/$(PIP) install --upgrade coveralls
-	@${VENV_NAME}/bin/coveralls
+	@${VENV_NAME}/bin/tox -e coveralls
 
 fmt: venv
 	@${VENV_NAME}/bin/tox -e fmt
@@ -34,6 +34,6 @@ lint: venv
 	@${VENV_NAME}/bin/tox -e lint
 
 clean:
-	@rm -rf $(VENV_NAME) build/ dist/
+	@rm -rf $(VENV_NAME) .coverage .coverage.* build/ dist/ htmlcov/
 
-.PHONY: venv test ci coveralls fmt fmtcheck lint clean
+.PHONY: venv test test-nomock test-travis coveralls fmt fmtcheck lint clean

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,6 @@
 import os
-import sys
 from codecs import open
 from setuptools import setup, find_packages
-from setuptools.command.test import test as TestCommand
-
-
-class PyTest(TestCommand):
-    user_options = [("pytest-args=", "a", "Arguments to pass to pytest")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = "-n auto"
-
-    def run_tests(self):
-        import shlex
-
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-
-        errno = pytest.main(shlex.split(self.pytest_args))
-        sys.exit(errno)
 
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -54,16 +35,6 @@ setup(
         'requests[security] >= 2.20; python_version < "3.0"',
     ],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
-    tests_require=[
-        'pytest >= 4.6.2, < 4.7; python_version < "3.5"',
-        'pytest >= 6.0.0; python_version >= "3.5"',
-        "pytest-mock >= 2.0.0",
-        "pytest-xdist >= 1.31.0",
-        "pytest-cov >= 2.8.1, < 2.11.0",
-        # TODO: upgrade to coverage 5 when we drop support for Python 3.4
-        "coverage >= 4.5.3, < 5",
-    ],
-    cmdclass={"test": PyTest},
     project_urls={
         "Bug Tracker": "https://github.com/stripe/stripe-python/issues",
         "Documentation": "https://stripe.com/docs/api/python",

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -12,7 +12,7 @@ import stripe
 from stripe import six
 from stripe.stripe_response import StripeResponse
 
-from six.moves.urllib.parse import urlsplit
+from stripe.six.moves.urllib.parse import urlsplit
 
 
 VALID_API_METHODS = ("get", "post", "delete")

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from six.moves.urllib.parse import parse_qs, urlparse
+from stripe.six.moves.urllib.parse import parse_qs, urlparse
 
 import stripe
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,20 +4,29 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27,
-          py34,
-          py35,
-          py36,
-          py37,
-          py38,
-          pypy,
-          pypy3,
-          lint
+envlist =
+    fmt
+    lint
+    py{310,39,38,37,36,35,34,27,py3,py2}
 skip_missing_interpreters = true
+
+[tool:pytest]
+testpaths = tests
+addopts =
+    --cov-report=term-missing
 
 [testenv]
 description = run the unit tests under {basepython}
-commands = python setup.py test -a "{posargs:-n auto}"
+setenv =
+    COVERAGE_FILE = {toxworkdir}/.coverage.{envname}
+deps =
+    coverage >= 4.5.3, < 5 # TODO: upgrade to coverage 5 when we drop support for Python 3.4
+    py{310,39,38,37,36,35,py3}: pytest >= 6.0.0
+    py{34,27,py2}: pytest >= 4.6.2, < 4.7
+    pytest-cov >= 2.8.1, < 2.11.0
+    pytest-mock >= 2.0.0
+    pytest-xdist >= 1.31.0
+commands = pytest --cov {posargs:-n auto}
 # compilation flags can be useful when prebuilt wheels cannot be used, e.g.
 # PyPy 2 needs to compile the `cryptography` module. On macOS this can be done
 # by passing the following flags:
@@ -27,7 +36,7 @@ passenv = LDFLAGS CFLAGS
 
 [testenv:fmt]
 description = run code formatting using black
-basepython = python3.8
+basepython = python3.9
 deps = black==19.3b0
 commands = black . {posargs}
 skip_install = true
@@ -38,3 +47,19 @@ basepython = python2.7
 deps = flake8
 commands = python -m flake8 --show-source stripe tests setup.py
 skip_install = true
+
+[testenv:coveralls]
+description = upload coverage to coveralls.io
+skip_install = true
+setenv =
+    COVERAGE_FILE = {toxworkdir}/.coverage
+passenv =
+    TRAVIS
+    TRAVIS_*
+deps =
+    coverage >= 4.5.3, < 5 # TODO: upgrade to coverage 5 when we drop support for Python 3.4
+    coveralls
+commands =
+    coverage combine
+    coveralls
+depends = py{310,39,38,37,36,35,34,27,py3,py2}


### PR DESCRIPTION
r? @richardm-stripe 

Using `python setup.py test` is deprecated and produces this warning:
```
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
```

This PR removes support for `python setup.py test` and instead uses tox as the test entry point as recommended by the warning.