### PR TITLE
Update to stripe-mock v0.107.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `tests/conftest.py`.
-    - STRIPE_MOCK_VERSION=0.106.0
+    - STRIPE_MOCK_VERSION=0.107.0
 
 before_install:
   # Unpack and start stripe-mock so that the test suite can talk to it

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from tests.stripe_mock import StripeMock
 
 
 # When changing this number, don't forget to change it in `.travis.yml` too.
-MOCK_MINIMUM_VERSION = "0.106.0"
+MOCK_MINIMUM_VERSION = "0.107.0"
 
 # Starts stripe-mock if an OpenAPI spec override is found in `openapi/`, and
 # otherwise fall back to `STRIPE_MOCK_PORT` or 12111.


### PR DESCRIPTION
Bump up stripe-mock to https://github.com/stripe/stripe-mock/releases/tag/v0.107.0.

