### PR TITLE
Support streaming requests, which return an IO object rather than par…

### DIFF
--- a/stripe/api_resources/abstract/api_resource.py
+++ b/stripe/api_resources/abstract/api_resource.py
@@ -65,3 +65,23 @@ class APIResource(StripeObject):
         return util.convert_to_stripe_object(
             response, api_key, stripe_version, stripe_account
         )
+
+    # The `method_` and `url_` arguments are suffixed with an underscore to
+    # avoid conflicting with actual request parameters in `params`.
+    @classmethod
+    def _static_request_stream(
+        cls,
+        method_,
+        url_,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        requestor = api_requestor.APIRequestor(
+            api_key, api_version=stripe_version, account=stripe_account
+        )
+        headers = util.populate_headers(idempotency_key)
+        response, _ = requestor.request_stream(method_, url_, params, headers)
+        return response

--- a/stripe/api_resources/abstract/custom_method.py
+++ b/stripe/api_resources/abstract/custom_method.py
@@ -4,7 +4,7 @@ from stripe import util
 from stripe.six.moves.urllib.parse import quote_plus
 
 
-def custom_method(name, http_verb, http_path=None):
+def custom_method(name, http_verb, http_path=None, is_streaming=False):
     if http_verb not in ["get", "post", "delete"]:
         raise ValueError(
             "Invalid http_verb: %s. Must be one of 'get', 'post' or 'delete'"
@@ -22,9 +22,22 @@ def custom_method(name, http_verb, http_path=None):
             )
             return cls._static_request(http_verb, url, **params)
 
+        def custom_method_request_stream(cls, sid, **params):
+            url = "%s/%s/%s" % (
+                cls.class_url(),
+                quote_plus(util.utf8(sid)),
+                http_path,
+            )
+            return cls._static_request_stream(http_verb, url, **params)
+
+        if is_streaming:
+            class_method_impl = classmethod(custom_method_request_stream)
+        else:
+            class_method_impl = classmethod(custom_method_request)
+
         existing_method = getattr(cls, name, None)
         if existing_method is None:
-            setattr(cls, name, classmethod(custom_method_request))
+            setattr(cls, name, class_method_impl)
         else:
             # If a method with the same name we want to use already exists on
             # the class, we assume it's an instance method. In this case, the
@@ -32,7 +45,7 @@ def custom_method(name, http_verb, http_path=None):
             # instance method is decorated with `util.class_method_variant` so
             # that the new class method is called when the original method is
             # called as a class method.
-            setattr(cls, "_cls_" + name, classmethod(custom_method_request))
+            setattr(cls, "_cls_" + name, class_method_impl)
             instance_method = util.class_method_variant("_cls_" + name)(
                 existing_method
             )

--- a/stripe/stripe_object.py
+++ b/stripe/stripe_object.py
@@ -246,6 +246,19 @@ class StripeObject(dict):
             response, api_key, self.stripe_version, self.stripe_account
         )
 
+    def request_stream(self, method, url, params=None, headers=None):
+        if params is None:
+            params = self._retrieve_params
+        requestor = api_requestor.APIRequestor(
+            key=self.api_key,
+            api_base=self.api_base(),
+            api_version=self.stripe_version,
+            account=self.stripe_account,
+        )
+        response, _ = requestor.request_stream(method, url, params, headers)
+
+        return response
+
     def __repr__(self):
         ident_parts = [type(self).__name__]
 

--- a/stripe/stripe_response.py
+++ b/stripe/stripe_response.py
@@ -4,12 +4,10 @@ import json
 from collections import OrderedDict
 
 
-class StripeResponse(object):
-    def __init__(self, body, code, headers):
-        self.body = body
+class StripeResponseBase(object):
+    def __init__(self, code, headers):
         self.code = code
         self.headers = headers
-        self.data = json.loads(body, object_pairs_hook=OrderedDict)
 
     @property
     def idempotency_key(self):
@@ -24,3 +22,16 @@ class StripeResponse(object):
             return self.headers["request-id"]
         except KeyError:
             return None
+
+
+class StripeResponse(StripeResponseBase):
+    def __init__(self, body, code, headers):
+        StripeResponseBase.__init__(self, code, headers)
+        self.body = body
+        self.data = json.loads(body, object_pairs_hook=OrderedDict)
+
+
+class StripeStreamResponse(StripeResponseBase):
+    def __init__(self, io, code, headers):
+        StripeResponseBase.__init__(self, code, headers)
+        self.io = io

--- a/tests/api_resources/abstract/test_custom_method.py
+++ b/tests/api_resources/abstract/test_custom_method.py
@@ -8,6 +8,12 @@ class TestCustomMethod(object):
     @stripe.api_resources.abstract.custom_method(
         "do_stuff", http_verb="post", http_path="do_the_thing"
     )
+    @stripe.api_resources.abstract.custom_method(
+        "do_stream_stuff",
+        http_verb="post",
+        http_path="do_the_stream_thing",
+        is_streaming=True,
+    )
     class MyResource(stripe.api_resources.abstract.APIResource):
         OBJECT_NAME = "myresource"
 
@@ -16,6 +22,11 @@ class TestCustomMethod(object):
             headers = util.populate_headers(idempotency_key)
             self.refresh_from(self.request("post", url, params, headers))
             return self
+
+        def do_stream_stuff(self, idempotency_key=None, **params):
+            url = self.instance_url() + "/do_the_stream_thing"
+            headers = util.populate_headers(idempotency_key)
+            return self.request_stream("post", url, params, headers)
 
     def test_call_custom_method_class(self, request_mock):
         request_mock.stub_request(
@@ -31,6 +42,26 @@ class TestCustomMethod(object):
             "post", "/v1/myresources/mid/do_the_thing", {"foo": "bar"}
         )
         assert obj.thing_done is True
+
+    def test_call_custom_stream_method_class(self, request_mock):
+        request_mock.stub_request_stream(
+            "post",
+            "/v1/myresources/mid/do_the_stream_thing",
+            "response body",
+            rheaders={"request-id": "req_id"},
+        )
+
+        resp = self.MyResource.do_stream_stuff("mid", foo="bar")
+
+        request_mock.assert_requested_stream(
+            "post", "/v1/myresources/mid/do_the_stream_thing", {"foo": "bar"}
+        )
+
+        body_content = resp.io.read()
+        if hasattr(body_content, "decode"):
+            body_content = body_content.decode("utf-8")
+
+        assert body_content == "response body"
 
     def test_call_custom_method_class_with_object(self, request_mock):
         request_mock.stub_request(
@@ -48,6 +79,27 @@ class TestCustomMethod(object):
         )
         assert obj.thing_done is True
 
+    def test_call_custom_stream_method_class_with_object(self, request_mock):
+        request_mock.stub_request_stream(
+            "post",
+            "/v1/myresources/mid/do_the_stream_thing",
+            "response body",
+            rheaders={"request-id": "req_id"},
+        )
+
+        obj = self.MyResource.construct_from({"id": "mid"}, "mykey")
+        resp = self.MyResource.do_stream_stuff(obj, foo="bar")
+
+        request_mock.assert_requested_stream(
+            "post", "/v1/myresources/mid/do_the_stream_thing", {"foo": "bar"}
+        )
+
+        body_content = resp.io.read()
+        if hasattr(body_content, "decode"):
+            body_content = body_content.decode("utf-8")
+
+        assert body_content == "response body"
+
     def test_call_custom_method_instance(self, request_mock):
         request_mock.stub_request(
             "post",
@@ -63,3 +115,24 @@ class TestCustomMethod(object):
             "post", "/v1/myresources/mid/do_the_thing", {"foo": "bar"}
         )
         assert obj.thing_done is True
+
+    def test_call_custom_stream_method_instance(self, request_mock):
+        request_mock.stub_request_stream(
+            "post",
+            "/v1/myresources/mid/do_the_stream_thing",
+            "response body",
+            rheaders={"request-id": "req_id"},
+        )
+
+        obj = self.MyResource.construct_from({"id": "mid"}, "mykey")
+        resp = obj.do_stream_stuff(foo="bar")
+
+        request_mock.assert_requested_stream(
+            "post", "/v1/myresources/mid/do_the_stream_thing", {"foo": "bar"}
+        )
+
+        body_content = resp.io.read()
+        if hasattr(body_content, "decode"):
+            body_content = body_content.decode("utf-8")
+
+        assert body_content == "response body"

--- a/tests/request_mock.py
+++ b/tests/request_mock.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import, division, print_function
 import json
 
 import stripe
-from stripe import six
-from stripe.stripe_response import StripeResponse
+from stripe import six, util
+from stripe.stripe_response import StripeResponse, StripeStreamResponse
 
 
 class RequestMock(object):
@@ -12,6 +12,9 @@ class RequestMock(object):
         self._mocker = mocker
 
         self._real_request = stripe.api_requestor.APIRequestor.request
+        self._real_request_stream = (
+            stripe.api_requestor.APIRequestor.request_stream
+        )
         self._stub_request_handler = StubRequestHandler()
 
         self.constructor_patcher = self._mocker.patch(
@@ -26,16 +29,42 @@ class RequestMock(object):
             autospec=True,
         )
 
+        self.request_stream_patcher = self._mocker.patch(
+            "stripe.api_requestor.APIRequestor.request_stream",
+            side_effect=self._patched_request_stream,
+            autospec=True,
+        )
+
     def _patched_request(self, requestor, method, url, *args, **kwargs):
-        response = self._stub_request_handler.get_response(method, url)
+        response = self._stub_request_handler.get_response(
+            method, url, expect_stream=False
+        )
         if response is not None:
             return response, stripe.api_key
 
         return self._real_request(requestor, method, url, *args, **kwargs)
 
+    def _patched_request_stream(self, requestor, method, url, *args, **kwargs):
+        response = self._stub_request_handler.get_response(
+            method, url, expect_stream=True
+        )
+        if response is not None:
+            return response, stripe.api_key
+
+        return self._real_request_stream(
+            requestor, method, url, *args, **kwargs
+        )
+
     def stub_request(self, method, url, rbody={}, rcode=200, rheaders={}):
         self._stub_request_handler.register(
-            method, url, rbody, rcode, rheaders
+            method, url, rbody, rcode, rheaders, is_streaming=False
+        )
+
+    def stub_request_stream(
+        self, method, url, rbody={}, rcode=200, rheaders={}
+    ):
+        self._stub_request_handler.register(
+            method, url, rbody, rcode, rheaders, is_streaming=True
         )
 
     def assert_api_base(self, expected_api_base):
@@ -84,6 +113,16 @@ class RequestMock(object):
             raise AssertionError(msg)
 
     def assert_requested(self, method, url, params=None, headers=None):
+        self.assert_requested_internal(
+            self.request_patcher, method, url, params, headers
+        )
+
+    def assert_requested_stream(self, method, url, params=None, headers=None):
+        self.assert_requested_internal(
+            self.request_stream_patcher, method, url, params, headers
+        )
+
+    def assert_requested_internal(self, patcher, method, url, params, headers):
         params = params or self._mocker.ANY
         headers = headers or self._mocker.ANY
         called = False
@@ -99,7 +138,7 @@ class RequestMock(object):
 
         for args in possible_called_args:
             try:
-                self.request_patcher.assert_called_with(*args)
+                patcher.assert_called_with(*args)
             except AssertionError as e:
                 exception = e
             else:
@@ -117,23 +156,45 @@ class RequestMock(object):
             )
             raise AssertionError(msg)
 
+    def assert_no_request_stream(self):
+        if self.request_stream_patcher.call_count != 0:
+            msg = (
+                "Expected 'request_stream' to not have been called. "
+                "Called %s times." % (self.request_stream_patcher.call_count)
+            )
+            raise AssertionError(msg)
+
     def reset_mock(self):
         self.request_patcher.reset_mock()
+        self.request_stream_patcher.reset_mock()
 
 
 class StubRequestHandler(object):
     def __init__(self):
         self._entries = {}
 
-    def register(self, method, url, rbody={}, rcode=200, rheaders={}):
-        self._entries[(method, url)] = (rbody, rcode, rheaders)
+    def register(
+        self, method, url, rbody={}, rcode=200, rheaders={}, is_streaming=False
+    ):
+        self._entries[(method, url)] = (rbody, rcode, rheaders, is_streaming)
 
-    def get_response(self, method, url):
+    def get_response(self, method, url, expect_stream=False):
         if (method, url) in self._entries:
-            rbody, rcode, rheaders = self._entries.pop((method, url))
+            rbody, rcode, rheaders, is_streaming = self._entries.pop(
+                (method, url)
+            )
+
+            if expect_stream != is_streaming:
+                return None
+
             if not isinstance(rbody, six.string_types):
                 rbody = json.dumps(rbody)
-            stripe_response = StripeResponse(rbody, rcode, rheaders)
+            if is_streaming:
+                stripe_response = StripeStreamResponse(
+                    util.io.BytesIO(str.encode(rbody)), rcode, rheaders
+                )
+            else:
+                stripe_response = StripeResponse(rbody, rcode, rheaders)
             return stripe_response
 
         return None

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -9,11 +9,12 @@ from collections import OrderedDict
 import pytest
 
 import stripe
-from stripe import six
-from stripe.stripe_response import StripeResponse
+from stripe import six, util
+from stripe.stripe_response import StripeResponse, StripeStreamResponse
 
 from stripe.six.moves.urllib.parse import urlsplit
 
+import urllib3
 
 VALID_API_METHODS = ("get", "post", "delete")
 
@@ -245,14 +246,20 @@ class TestAPIRequestor(object):
 
     @pytest.fixture
     def check_call(self, http_client):
-        def check_call(method, abs_url=None, headers=None, post_data=None):
+        def check_call(
+            method,
+            abs_url=None,
+            headers=None,
+            post_data=None,
+            request_options=None,
+        ):
             if not abs_url:
                 abs_url = "%s%s" % (stripe.api_base, self.valid_path)
             if not headers:
                 headers = APIHeaderMatcher(request_method=method)
 
             http_client.request_with_retries.assert_called_with(
-                method, abs_url, headers, post_data
+                method, abs_url, headers, post_data, request_options
             )
 
         return check_call
@@ -294,13 +301,17 @@ class TestAPIRequestor(object):
     def test_param_encoding(self, requestor, mock_response, check_call):
         mock_response("{}", 200)
 
-        requestor.request("get", "", self.ENCODE_INPUTS)
+        requestor.request(
+            "get", "", self.ENCODE_INPUTS, request_options={"stream": True}
+        )
 
         expectation = []
         for type_, values in six.iteritems(self.ENCODE_EXPECTATIONS):
             expectation.extend([(k % (type_,), str(v)) for k, v in values])
 
-        check_call("get", QueryMatcher(expectation))
+        check_call(
+            "get", QueryMatcher(expectation), request_options={"stream": True}
+        )
 
     def test_dictionary_list_encoding(self):
         params = {"foo": {"0": {"bar": "bat"}}}
@@ -370,6 +381,28 @@ class TestAPIRequestor(object):
             assert resp.data == {}
             assert resp.data == json.loads(resp.body)
 
+    def test_empty_methods_streaming_response(
+        self, requestor, mock_response, check_call
+    ):
+        for meth in VALID_API_METHODS:
+            mock_response(util.io.BytesIO(b"thisisdata"), 200)
+
+            resp, key = requestor.request(
+                meth,
+                self.valid_path,
+                {},
+            )
+
+            if meth == "post":
+                post_data = ""
+            else:
+                post_data = None
+
+            check_call(meth, post_data=post_data)
+            assert isinstance(resp, StripeStreamResponse)
+
+            assert resp.io.getvalue() == b"thisisdata"
+
     def test_methods_with_params_and_response(
         self, requestor, mock_response, check_call
     ):
@@ -404,6 +437,50 @@ class TestAPIRequestor(object):
                     encoded,
                 )
                 check_call(method, abs_url=UrlMatcher(abs_url))
+
+    def test_methods_with_params_and_streaming_response(
+        self, requestor, mock_response, check_call
+    ):
+        for method in VALID_API_METHODS:
+            mock_response(util.io.BytesIO(b'{"foo": "bar", "baz": 6}'), 200)
+
+            params = {
+                "alist": [1, 2, 3],
+                "adict": {"frobble": "bits"},
+                "adatetime": datetime.datetime(2013, 1, 1, tzinfo=GMT1()),
+            }
+            encoded = (
+                "adict[frobble]=bits&adatetime=1356994800&"
+                "alist[0]=1&alist[1]=2&alist[2]=3"
+            )
+
+            resp, key = requestor.request(
+                method,
+                self.valid_path,
+                params,
+                request_options={"stream": True},
+            )
+            assert isinstance(resp, StripeStreamResponse)
+
+            assert resp.io.getvalue() == b'{"foo": "bar", "baz": 6}'
+
+            if method == "post":
+                check_call(
+                    method,
+                    post_data=QueryMatcher(stripe.util.parse_qsl(encoded)),
+                    request_options={"stream": True},
+                )
+            else:
+                abs_url = "%s%s?%s" % (
+                    stripe.api_base,
+                    self.valid_path,
+                    encoded,
+                )
+                check_call(
+                    method,
+                    abs_url=UrlMatcher(abs_url),
+                    request_options={"stream": True},
+                )
 
     def test_uses_headers(self, requestor, mock_response, check_call):
         mock_response("{}", 200)
@@ -624,6 +701,33 @@ class TestAPIRequestor(object):
         with pytest.raises(stripe.oauth_error.InvalidGrantError):
             requestor.request("get", self.valid_path, {})
 
+    def test_extract_error_from_stream_request_for_bytes(
+        self, requestor, mock_response
+    ):
+        mock_response(util.io.BytesIO(b'{"error": "invalid_grant"}'), 400)
+
+        with pytest.raises(stripe.oauth_error.InvalidGrantError):
+            requestor.request(
+                "get", self.valid_path, {}, request_options={"stream": True}
+            )
+
+    def test_extract_error_from_stream_request_for_response(
+        self, requestor, mock_response
+    ):
+        # Responses don't have getvalue, they only have a read method.
+        mock_response(
+            urllib3.response.HTTPResponse(
+                body=util.io.BytesIO(b'{"error": "invalid_grant"}'),
+                preload_content=False,
+            ),
+            400,
+        )
+
+        with pytest.raises(stripe.oauth_error.InvalidGrantError):
+            requestor.request(
+                "get", self.valid_path, {}, request_options={"stream": True}
+            )
+
     def test_raw_request_with_file_param(self, requestor, mock_response):
         test_file = tempfile.NamedTemporaryFile()
         test_file.write("\u263A".encode("utf-16"))
@@ -659,5 +763,6 @@ class TestDefaultClient(object):
             "get",
             "https://api.stripe.com/v1/charges?limit=3",
             mocker.ANY,
+            None,
             None,
         )

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -227,14 +227,14 @@ class TestHTTPClient(object):
         client.request = mocker.MagicMock(
             return_value=["", 200, {"Request-Id": "req_123"}]
         )
-        _, code, _ = client.request_with_retries("get", url, {}, None, None)
+        _, code, _ = client.request_with_retries("get", url, {}, None)
         assert code == 200
-        client.request.assert_called_with("get", url, {}, None, None)
+        client.request.assert_called_with("get", url, {}, None)
 
         client.request = mocker.MagicMock(
             return_value=["", 200, {"Request-Id": "req_234"}]
         )
-        _, code, _ = client.request_with_retries("get", url, {}, None, None)
+        _, code, _ = client.request_with_retries("get", url, {}, None)
         assert code == 200
         args, _ = client.request.call_args
         assert "X-Stripe-Client-Telemetry" in args[2]
@@ -252,12 +252,14 @@ class ClientTestBase(object):
     def valid_url(self, path="/foo"):
         return "https://api.stripe.com%s" % (path,)
 
-    def make_request(
-        self, method, url, headers, post_data, request_options=None
-    ):
+    def make_request(self, method, url, headers, post_data):
         client = self.REQUEST_CLIENT(verify_ssl_certs=True)
-        return client.request_with_retries(
-            method, url, headers, post_data, request_options
+        return client.request_with_retries(method, url, headers, post_data)
+
+    def make_request_stream(self, method, url, headers, post_data):
+        client = self.REQUEST_CLIENT(verify_ssl_certs=True)
+        return client.request_stream_with_retries(
+            method, url, headers, post_data
         )
 
     @pytest.fixture
@@ -281,7 +283,7 @@ class ClientTestBase(object):
     @pytest.fixture
     def check_call(self):
         def check_call(
-            mock, method, abs_url, headers, params, request_options=None
+            mock, method, abs_url, headers, params, is_streaming=False
         ):
             raise NotImplementedError(
                 "You must implement this in your test subclass"
@@ -309,11 +311,9 @@ class ClientTestBase(object):
 
             check_call(request_mock, method, abs_url, data, headers)
 
-    def test_stream_request(
+    def test_request_stream(
         self, mocker, request_mock, mock_response, check_call
     ):
-        request_options = {"stream": True}
-
         for method in VALID_API_METHODS:
             mock_response(request_mock, "some streamed content", 200)
 
@@ -326,19 +326,17 @@ class ClientTestBase(object):
 
             headers = {"my-header": "header val"}
 
-            body, code, _ = self.make_request(
-                method,
-                abs_url,
-                headers=headers,
-                post_data=data,
-                request_options=request_options,
+            print(dir(self))
+            print("make_request_stream" in dir(self))
+            stream, code, _ = self.make_request_stream(
+                method, abs_url, headers, data
             )
 
             assert code == 200
 
             # Here we need to convert and align all content on one type (string)
             # as some clients return a string stream others a byte stream.
-            body_content = body.read()
+            body_content = stream.read()
             if hasattr(body_content, "decode"):
                 body_content = body_content.decode("utf-8")
 
@@ -403,7 +401,7 @@ class TestRequestsClient(StripeClientTestCase, ClientTestBase):
             url,
             post_data,
             headers,
-            request_options=None,
+            is_streaming=False,
             timeout=80,
             times=None,
         ):
@@ -417,7 +415,7 @@ class TestRequestsClient(StripeClientTestCase, ClientTestBase):
                 "timeout": timeout,
             }
 
-            if request_options is not None and request_options.get("stream"):
+            if is_streaming:
                 kwargs["stream"] = True
 
             calls = [(args, kwargs) for _ in range(times)]
@@ -425,14 +423,18 @@ class TestRequestsClient(StripeClientTestCase, ClientTestBase):
 
         return check_call
 
-    def make_request(
-        self, method, url, headers, post_data, request_options=None, timeout=80
-    ):
+    def make_request(self, method, url, headers, post_data, timeout=80):
         client = self.REQUEST_CLIENT(
             verify_ssl_certs=True, timeout=timeout, proxy="http://slap/"
         )
-        return client.request_with_retries(
-            method, url, headers, post_data, request_options
+        return client.request_with_retries(method, url, headers, post_data)
+
+    def make_request_stream(self, method, url, headers, post_data, timeout=80):
+        client = self.REQUEST_CLIENT(
+            verify_ssl_certs=True, timeout=timeout, proxy="http://slap/"
+        )
+        return client.request_stream_with_retries(
+            method, url, headers, post_data
         )
 
     def test_timeout(self, request_mock, mock_response, check_call):
@@ -443,14 +445,11 @@ class TestRequestsClient(StripeClientTestCase, ClientTestBase):
 
         check_call(None, "POST", self.valid_url, data, headers, timeout=5)
 
-    def test_stream_request_forwards_stream_param(
+    def test_request_stream_forwards_stream_param(
         self, mocker, request_mock, mock_response, check_call
     ):
-        request_options = {"stream": True}
         mock_response(request_mock, "some streamed content", 200)
-        self.make_request(
-            "GET", self.valid_url, {}, None, request_options=request_options
-        )
+        self.make_request_stream("GET", self.valid_url, {}, None)
 
         check_call(
             None,
@@ -458,7 +457,7 @@ class TestRequestsClient(StripeClientTestCase, ClientTestBase):
             self.valid_url,
             None,
             {},
-            request_options=request_options,
+            is_streaming=True,
         )
 
 
@@ -515,15 +514,23 @@ class TestRequestClientRetryBehavior(TestRequestsClient):
     def check_call_numbers(self, check_call):
         valid_url = self.valid_url
 
-        def check_call_numbers(times):
-            check_call(None, "GET", valid_url, None, {}, times=times)
+        def check_call_numbers(times, is_streaming=False):
+            check_call(
+                None,
+                "GET",
+                valid_url,
+                None,
+                {},
+                times=times,
+                is_streaming=is_streaming,
+            )
 
         return check_call_numbers
 
     def max_retries(self):
         return 3
 
-    def make_request(self, *args, **kwargs):
+    def make_client(self):
         client = self.REQUEST_CLIENT(
             verify_ssl_certs=True, timeout=80, proxy="http://slap/"
         )
@@ -531,12 +538,16 @@ class TestRequestClientRetryBehavior(TestRequestsClient):
         client._sleep_time = lambda _: 0.0001
         # Override configured max retries
         client._max_network_retries = lambda: self.max_retries()
-        return client.request_with_retries(
-            "GET",
-            self.valid_url,
-            {},
-            None,
-            request_options=kwargs.get("request_options"),
+        return client
+
+    def make_request(self, *args, **kwargs):
+        client = self.make_client()
+        return client.request_with_retries("GET", self.valid_url, {}, None)
+
+    def make_request_stream(self, *args, **kwargs):
+        client = self.make_client()
+        return client.request_stream_with_retries(
+            "GET", self.valid_url, {}, None
         )
 
     def test_retry_error_until_response(
@@ -575,6 +586,47 @@ class TestRequestClientRetryBehavior(TestRequestsClient):
         _, code, _ = self.make_request()
         assert code == 409
         check_call_numbers(self.max_retries() + 1)
+
+    def test_retry_request_stream_error_until_response(
+        self, mock_retry, response, check_call_numbers
+    ):
+        mock_retry(retry_error_num=1, responses=[response(code=202)])
+        _, code, _ = self.make_request_stream()
+        assert code == 202
+        check_call_numbers(2, is_streaming=True)
+
+    def test_retry_request_stream_error_until_exceeded(
+        self, mock_retry, response, check_call_numbers
+    ):
+        mock_retry(retry_error_num=self.max_retries())
+        with pytest.raises(stripe.error.APIConnectionError):
+            self.make_request_stream()
+
+        check_call_numbers(self.max_retries(), is_streaming=True)
+
+    def test_no_retry_request_stream_error(
+        self, mock_retry, response, check_call_numbers
+    ):
+        mock_retry(no_retry_error_num=self.max_retries())
+        with pytest.raises(stripe.error.APIConnectionError):
+            self.make_request_stream()
+        check_call_numbers(1, is_streaming=True)
+
+    def test_retry_request_stream_codes(
+        self, mock_retry, response, check_call_numbers
+    ):
+        mock_retry(responses=[response(code=409), response(code=202)])
+        _, code, _ = self.make_request_stream()
+        assert code == 202
+        check_call_numbers(2, is_streaming=True)
+
+    def test_retry_request_stream_codes_until_exceeded(
+        self, mock_retry, response, check_call_numbers
+    ):
+        mock_retry(responses=[response(code=409)] * (self.max_retries() + 1))
+        _, code, _ = self.make_request_stream()
+        assert code == 409
+        check_call_numbers(self.max_retries() + 1, is_streaming=True)
 
     @pytest.fixture
     def connection_error(self, session):
@@ -653,7 +705,7 @@ class TestUrlFetchClient(StripeClientTestCase, ClientTestBase):
     @pytest.fixture
     def check_call(self):
         def check_call(
-            mock, method, url, post_data, headers, request_options=None
+            mock, method, url, post_data, headers, is_streaming=False
         ):
             mock.fetch.assert_called_with(
                 url=url,
@@ -670,13 +722,20 @@ class TestUrlFetchClient(StripeClientTestCase, ClientTestBase):
 class TestUrllib2Client(StripeClientTestCase, ClientTestBase):
     REQUEST_CLIENT = stripe.http_client.Urllib2Client
 
-    def make_request(
-        self, method, url, headers, post_data, request_options=None, proxy=None
-    ):
+    def make_client(self, proxy):
         self.client = self.REQUEST_CLIENT(verify_ssl_certs=True, proxy=proxy)
         self.proxy = proxy
+
+    def make_request(self, method, url, headers, post_data, proxy=None):
+        self.make_client(proxy)
         return self.client.request_with_retries(
-            method, url, headers, post_data, request_options
+            method, url, headers, post_data
+        )
+
+    def make_request_stream(self, method, url, headers, post_data, proxy=None):
+        self.make_client(proxy)
+        return self.client.request_stream_with_retries(
+            method, url, headers, post_data
         )
 
     @pytest.fixture
@@ -714,7 +773,7 @@ class TestUrllib2Client(StripeClientTestCase, ClientTestBase):
     @pytest.fixture
     def check_call(self):
         def check_call(
-            mock, method, url, post_data, headers, request_options=None
+            mock, method, url, post_data, headers, is_streaming=False
         ):
             if six.PY3 and isinstance(post_data, six.string_types):
                 post_data = post_data.encode("utf-8")
@@ -736,38 +795,54 @@ class TestUrllib2Client(StripeClientTestCase, ClientTestBase):
 
 
 class TestUrllib2ClientHttpsProxy(TestUrllib2Client):
-    def make_request(
-        self, method, url, headers, post_data, request_options=None, proxy=None
-    ):
+    def make_request(self, method, url, headers, post_data, proxy=None):
         return super(TestUrllib2ClientHttpsProxy, self).make_request(
             method,
             url,
             headers,
             post_data,
-            request_options,
+            {"http": "http://slap/", "https": "http://slap/"},
+        )
+
+    def make_request_stream(self, method, url, headers, post_data, proxy=None):
+        return super(TestUrllib2ClientHttpsProxy, self).make_request_stream(
+            method,
+            url,
+            headers,
+            post_data,
             {"http": "http://slap/", "https": "http://slap/"},
         )
 
 
 class TestUrllib2ClientHttpProxy(TestUrllib2Client):
-    def make_request(
-        self, method, url, headers, post_data, request_options=None, proxy=None
-    ):
+    def make_request(self, method, url, headers, post_data, proxy=None):
         return super(TestUrllib2ClientHttpProxy, self).make_request(
-            method, url, headers, post_data, request_options, "http://slap/"
+            method, url, headers, post_data, "http://slap/"
+        )
+
+    def make_request_stream(self, method, url, headers, post_data, proxy=None):
+        return super(TestUrllib2ClientHttpProxy, self).make_request_stream(
+            method, url, headers, post_data, "http://slap/"
         )
 
 
 class TestPycurlClient(StripeClientTestCase, ClientTestBase):
     REQUEST_CLIENT = stripe.http_client.PycurlClient
 
-    def make_request(
-        self, method, url, headers, post_data, request_options=None, proxy=None
-    ):
+    def make_client(self, proxy):
         self.client = self.REQUEST_CLIENT(verify_ssl_certs=True, proxy=proxy)
         self.proxy = proxy
+
+    def make_request(self, method, url, headers, post_data, proxy=None):
+        self.make_client(proxy)
         return self.client.request_with_retries(
-            method, url, headers, post_data, request_options
+            method, url, headers, post_data
+        )
+
+    def make_request_stream(self, method, url, headers, post_data, proxy=None):
+        self.make_client(proxy)
+        return self.client.request_stream_with_retries(
+            method, url, headers, post_data
         )
 
     @pytest.fixture
@@ -814,7 +889,7 @@ class TestPycurlClient(StripeClientTestCase, ClientTestBase):
     @pytest.fixture
     def check_call(self, request_mocks):
         def check_call(
-            mock, method, url, post_data, headers, request_options=None
+            mock, method, url, post_data, headers, is_streaming=False
         ):
             lib_mock = request_mocks[self.REQUEST_CLIENT.name]
 
@@ -854,29 +929,41 @@ class TestPycurlClient(StripeClientTestCase, ClientTestBase):
 
 
 class TestPycurlClientHttpProxy(TestPycurlClient):
-    def make_request(
-        self, method, url, headers, post_data, request_options=None, proxy=None
-    ):
+    def make_request(self, method, url, headers, post_data, proxy=None):
         return super(TestPycurlClientHttpProxy, self).make_request(
             method,
             url,
             headers,
             post_data,
-            request_options,
+            "http://user:withPwd@slap:8888/",
+        )
+
+    def make_request_stream(self, method, url, headers, post_data, proxy=None):
+        return super(TestPycurlClientHttpProxy, self).make_request_stream(
+            method,
+            url,
+            headers,
+            post_data,
             "http://user:withPwd@slap:8888/",
         )
 
 
 class TestPycurlClientHttpsProxy(TestPycurlClient):
-    def make_request(
-        self, method, url, headers, post_data, request_options=None, proxy=None
-    ):
+    def make_request(self, method, url, headers, post_data, proxy=None):
         return super(TestPycurlClientHttpsProxy, self).make_request(
             method,
             url,
             headers,
             post_data,
-            request_options,
+            {"http": "http://slap:8888/", "https": "http://slap2:444/"},
+        )
+
+    def make_request_stream(self, method, url, headers, post_data, proxy=None):
+        return super(TestPycurlClientHttpsProxy, self).make_request_stream(
+            method,
+            url,
+            headers,
+            post_data,
             {"http": "http://slap:8888/", "https": "http://slap2:444/"},
         )
 


### PR DESCRIPTION
…sing JSON.

<!-- If this branch is in-progress, start the title with [wip]. Cibot will prevent this branch from being merged until the title is edited to remove a leading [wip]. -->

### Notify
r? @richardm-stripe 

<!-- Assign a reviewer by commenting `r? <TEAM>` once your PR has built successfully. Once the reviewer has approved the change, comment `rl? <TEAM>` to find a Calibrated Reviewer if needed. go/code-review provides more guidance on the code review process. -->

### Summary
<!-- What does the code do? What have you changed? If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

Adds a new `request_stream` method to `StripeObject`, `ApiRequestor` and `HTTPClient`. When this is used instead of `request`, an object which extends `IOBase` will be returned with the response body (implementation differs per HTTP client). Clients will then be able to use this stream to pipe content elsewhere. For errors, we still parse the JSON and raise as appropriate. As part of this, we also had to update custom method decorators to support using `request_stream`.

Client library methods which return a binary format will use the `request_stream` method to get a `StripeStreamResponse`.

**While this change is not breaking by itself, as soon as we add a method that uses this we will need to release a new major version as custom HTTPClient implementations will need to implement `request_stream`.**

### Motivation
<!-- Why are you making this change? This can be a link to a Jira task. -->

The motivation for this is an upcoming `/pdf` method that will return a pdf instead of JSON.

### Test plan
<!-- How did you test this change? What were you unable to test? Reference automated tests or describe a manual test plan and confirm the outcome. Please keep the frontpage test, our auditors (who review a random sample of our PRs) and your reviewer in mind. -->

Added unit tests to ensure that we wire the IO objects appropriately for each HTTP client. 

We'll want to add a more concrete test which uses a stripe-mock endpoint that returns an actual PDF to make sure this works as expected across all supported Python versions.

In the interim, I manually tested this by changing an API call to return a stream and making sure that it works as expected for each HTTP client.