### PR TITLE
Stop sending raw exception message as part of Stripe user agent.

### DIFF
--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -257,7 +257,7 @@ class APIRequestor(object):
             try:
                 val = func()
             except Exception:
-                val = None
+                val = "(disabled)"
             ua[attr] = val
         if stripe.app_info:
             ua["application"] = stripe.app_info

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import datetime
 import json
-import platform
 import tempfile
 import uuid
 from collections import OrderedDict
@@ -115,8 +114,7 @@ class APIHeaderMatcher(object):
     def _x_stripe_ua_handles_failed_platform_function(self, other):
         if self.fail_platform_call:
             ua = json.loads(other["X-Stripe-Client-User-Agent"])
-            # Only the platform property should be set to none.
-            return ua["platform"] is None and ua["lang_version"] is not None
+            return ua["platform"] == "(disabled)"
         return True
 
     def _extra_match(self, other):


### PR DESCRIPTION
### Notify

r? @richardm-stripe 
cc @remi-stripe 

### Summary

Updates user agent generation to avoid sending the raw exception message when calling platform methods to determine user agent components. Instead just send `"(disabled)"` for the failed fields.

### Test plan

Added unit test.