### PR TITLE
API Updates

### DIFF
--- a/stripe/api_resources/checkout/session.py
+++ b/stripe/api_resources/checkout/session.py
@@ -1,11 +1,20 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.abstract import custom_method
 from stripe.api_resources.abstract import nested_resource_class_methods
 
 
+@custom_method("expire", http_verb="post")
 @nested_resource_class_methods("line_item", operations=["list"])
 class Session(CreateableAPIResource, ListableAPIResource):
     OBJECT_NAME = "checkout.session"
+
+    def expire(self, idempotency_key=None, **params):
+        url = self.instance_url() + "/expire"
+        headers = util.populate_headers(idempotency_key)
+        self.refresh_from(self.request("post", url, params, headers))
+        return self

--- a/tests/test_generated_examples.py
+++ b/tests/test_generated_examples.py
@@ -1562,3 +1562,10 @@ class TestGeneratedExamples(object):
             "get",
             "/v1/customers/cus_xyz/payment_methods",
         )
+
+    def test_checkout_session_expire(self, request_mock):
+        stripe.checkout.Session.expire("sess_xyz")
+        request_mock.assert_requested(
+            "post",
+            "/v1/checkout/sessions/sess_xyz/expire",
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ passenv = LDFLAGS CFLAGS
 [testenv:fmt]
 description = run code formatting using black
 basepython = python3.9
-deps = black==20.8b1
+deps = black==21.10b0
 commands = black . {posargs}
 skip_install = true
 


### PR DESCRIPTION
Codegen for openapi 21065d4.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `expire` method on resource `Checkout.Session`

