### PR TITLE
Introduce custom listing methods on objects.

### DIFF
--- a/stripe/api_resources/customer.py
+++ b/stripe/api_resources/customer.py
@@ -40,8 +40,10 @@ class Customer(
     def list_payment_methods(self, idempotency_key=None, **params):
         url = self.instance_url() + "/payment_methods"
         headers = util.populate_headers(idempotency_key)
-        self.refresh_from(self.request("get", url, params, headers))
-        return self
+        resp = self.request("get", url, params, headers)
+        stripe_object = util.convert_to_stripe_object(resp)
+        stripe_object._retrieve_params = params
+        return stripe_object
 
     def delete_discount(self, **params):
         requestor = api_requestor.APIRequestor(

--- a/stripe/api_resources/quote.py
+++ b/stripe/api_resources/quote.py
@@ -44,14 +44,18 @@ class Quote(CreateableAPIResource, ListableAPIResource, UpdateableAPIResource):
     def list_computed_upfront_line_items(self, idempotency_key=None, **params):
         url = self.instance_url() + "/computed_upfront_line_items"
         headers = util.populate_headers(idempotency_key)
-        self.refresh_from(self.request("get", url, params, headers))
-        return self
+        resp = self.request("get", url, params, headers)
+        stripe_object = util.convert_to_stripe_object(resp)
+        stripe_object._retrieve_params = params
+        return stripe_object
 
     def list_line_items(self, idempotency_key=None, **params):
         url = self.instance_url() + "/line_items"
         headers = util.populate_headers(idempotency_key)
-        self.refresh_from(self.request("get", url, params, headers))
-        return self
+        resp = self.request("get", url, params, headers)
+        stripe_object = util.convert_to_stripe_object(resp)
+        stripe_object._retrieve_params = params
+        return stripe_object
 
     @classmethod
     def _cls_pdf(

--- a/tests/api_resources/test_customer.py
+++ b/tests/api_resources/test_customer.py
@@ -179,3 +179,12 @@ class TestCustomerPaymentMethods(object):
         request_mock.assert_requested(
             "get", "/v1/customers/%s/payment_methods" % TEST_RESOURCE_ID
         )
+
+    def test_is_listable_on_object(self, request_mock):
+        resource = stripe.Customer.retrieve(
+            TEST_RESOURCE_ID
+        ).list_payment_methods(TEST_RESOURCE_ID, type="card")
+        request_mock.assert_requested(
+            "get", "/v1/customers/%s/payment_methods" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.ListObject)


### PR DESCRIPTION
r? @yejia-stripe 

### Summary

Updates the implementation for custom methods which return list objects to:

1. Create a new StripeObject rather than attempting to refresh - this is necessary as the returned object will be of a different type (now `list`) and fails to refresh.
2. Set `_retrieve_params` to make sure iteration continues with the same input set of parameters.

### Motivation

Partially fixes https://github.com/stripe/stripe-python/issues/755. We still need to do this for the static custom methods.

### Test plan

I added a test which previously failed and now passes.