### PR TITLE
Update class custom methods to save list object parameters.

### DIFF
--- a/stripe/api_resources/abstract/custom_method.py
+++ b/stripe/api_resources/abstract/custom_method.py
@@ -20,7 +20,14 @@ def custom_method(name, http_verb, http_path=None, is_streaming=False):
                 quote_plus(util.utf8(sid)),
                 http_path,
             )
-            return cls._static_request(http_verb, url, **params)
+            obj = cls._static_request(http_verb, url, **params)
+
+            # For list objects, we have to attach the parameters so that they
+            # can be referenced in auto-pagination and ensure consistency.
+            if "object" in obj and obj.object == "list":
+                obj._retrieve_params = params
+
+            return obj
 
         def custom_method_request_stream(cls, sid, **params):
             url = "%s/%s/%s" % (


### PR DESCRIPTION
r? @yejia-stripe 

### Summary

Updates the implementation for class-level custom methods which return list objects to set `_retrieve_params` to make sure iteration continues with the same input set of parameters.

### Motivation

Fixes https://github.com/stripe/stripe-python/issues/755 in conjunction with https://github.com/stripe/stripe-python/pull/756.

### Test plan

I added a test which previously failed and now passes.