### PR TITLE
Use tox-gh-actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -54,12 +54,15 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Upgrade pip and virtualenv to latest
         run: pip install --upgrade pip virtualenv
+
       - name: Get pip cache dir
         id: pip-cache
         run: |
           python -c "from pip._internal.locations import USER_CACHE_DIR; print('::set-output name=dir::' + USER_CACHE_DIR)"
+
       - name: pip cache
         uses: actions/cache@v2
         with:
@@ -75,4 +78,4 @@ jobs:
         run: docker run -d -p 12111-12112:12111-12112 stripe/stripe-mock && sleep 5
 
       - name: Test with pytest
-        run: make test
+        run: make test-gh-actions

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ test: venv
 test-nomock: venv
 	@${VENV_NAME}/bin/tox -p auto -- --nomock $(TOX_ARGS)
 
-test-travis: venv
-	${VENV_NAME}/bin/python -m pip install -U tox-travis
+test-gh-actions: venv
+	${VENV_NAME}/bin/python -m pip install -U tox-gh-actions
 	@${VENV_NAME}/bin/tox -p auto $(TOX_ARGS)
 
 coveralls: venv

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,19 @@ envlist =
     py{310,39,38,37,36,35,34,27,py3,py2}
 skip_missing_interpreters = true
 
+[gh-actions]
+python =
+    3.10: py310
+    3.9: py39
+    3.8: py38
+    3.7: py37
+    3.6: py36
+    3.5: py35
+    3.4: py34
+    2.7: py27
+    pypy-3: pypy3
+    pypy-2: pypy2
+
 [tool:pytest]
 testpaths = tests
 addopts =


### PR DESCRIPTION
Currently GitHub Actions is configured to run `make test`, which simply runs `tox`, which will test all Python versions for which an interpreter is available. GitHub Actions has its own version matrix, so we end up testing N*N versions.

(Example output: https://github.com/stripe/stripe-python/runs/4872868620?check_suite_focus=true#step:8:397)

This PR uses [tox-gh-actions](https://github.com/ymyzk/tox-gh-actions) to ensure that for each version in the GitHub Actions version matrix, we only run tests for that version.