### PR TITLE
Update docs to use "go install" over "go get" when setting up stripe-mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ background terminal ([stripe-mock's README][stripe-mock] also contains
 instructions for installing via Homebrew and other methods):
 
 ```sh
-go get -u github.com/stripe/stripe-mock
+go install github.com/stripe/stripe-mock@latest
 stripe-mock
 ```
 


### PR DESCRIPTION
Hi there!  I was looking through the project and walking through the development setup instructions in the README and I came across a dependency warning when installing the `stripe-mock` binary.  It looks like `go install` is the preferred method moving forward, so just submitting this PR with the updated instructions.   https://golang.org/doc/go-get-install-deprecation

Would you prefer if the docs contained both ways of installing the binary based on the golang version or should I just use `go install` by itself?

Thank you!

```
$ ~ docker run --rm -it --entrypoint bash golang:1.17
root@061868e9b6e7:/go# go get -u github.com/stripe/stripe-mock
go: downloading github.com/stripe/stripe-mock v0.119.0
go: downloading github.com/lestrrat-go/jsval v0.0.0-20181205002323-20277e9befc0
go: downloading github.com/lestrrat-go/jsschema v0.0.0-20181205002244-5c81c58ffcc3
go: downloading github.com/lestrrat-go/pdebug v0.0.0-20180220043849-39f9a71bcabe
go: downloading github.com/lestrrat-go/jsref v0.0.0-20181205001954-1b590508f37d
go: downloading github.com/pkg/errors v0.8.1-0.20170505043639-c605e284fe17
go: downloading github.com/lestrrat-go/jsref v0.0.0-20211028120858-c0bcbb5abf20
go: downloading github.com/lestrrat-go/jspointer v0.0.0-20181205001929-82fadba7561c
go: downloading github.com/lestrrat-go/structinfo v0.0.0-20190212233437-acd51874663b
go: downloading github.com/lestrrat-go/pdebug v0.0.0-20210111095411-35b07dbf089b
go: downloading github.com/pkg/errors v0.9.1
go: downloading github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2
go: downloading github.com/lestrrat-go/structinfo v0.0.0-20210312050401-7f8bd69d6acb
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading github.com/lestrrat-go/option v1.0.0
go get: installing executables with 'go get' in module mode is deprecated.
	Use 'go install pkg@version' instead.
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

Using `go install` seems to succeed without the warning
```
$ ~ docker run --rm -it --entrypoint bash golang:1.17
root@2abc60fba175:/go# go install github.com/stripe/stripe-mock@latest
go: downloading github.com/stripe/stripe-mock v0.119.0
go: downloading github.com/lestrrat-go/jsval v0.0.0-20181205002323-20277e9befc0
go: downloading github.com/lestrrat-go/jsschema v0.0.0-20181205002244-5c81c58ffcc3
go: downloading github.com/lestrrat-go/pdebug v0.0.0-20180220043849-39f9a71bcabe
go: downloading github.com/lestrrat-go/jsref v0.0.0-20181205001954-1b590508f37d
go: downloading github.com/pkg/errors v0.8.1-0.20170505043639-c605e284fe17
go: downloading github.com/lestrrat-go/jspointer v0.0.0-20181205001929-82fadba7561c
go: downloading github.com/lestrrat-go/structinfo v0.0.0-20190212233437-acd51874663b
```