### PR TITLE
Pin click dependency to 8.0.4 to avoid breakage in black

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,5 +59,3 @@ venv.bak/
 !.vscode/launch.json
 !.vscode/extensions.json
 /.idea
-
-hello

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ venv.bak/
 !.vscode/launch.json
 !.vscode/extensions.json
 /.idea
+
+hello

--- a/tox.ini
+++ b/tox.ini
@@ -50,8 +50,10 @@ passenv = LDFLAGS CFLAGS
 
 [testenv:fmt]
 description = run code formatting using black
-basepython = python3.10
-deps = black==21.12b0
+basepython = python3.9
+deps =
+    black==21.12b0
+    click==8.0.4 # Version 8.1 breaks black
 commands = black . {posargs}
 skip_install = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ passenv = LDFLAGS CFLAGS
 
 [testenv:fmt]
 description = run code formatting using black
-basepython = python3.9
+basepython = python3.10
 deps =
     black==21.12b0
     click==8.0.4 # Version 8.1 breaks black


### PR DESCRIPTION
The new version of https://pypi.org/project/click/#history package broke the code formatter we use. Pin to a known good version.