### PR TITLE
API Updates

### DIFF
--- a/stripe/api_resources/terminal/reader.py
+++ b/stripe/api_resources/terminal/reader.py
@@ -1,12 +1,21 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
+from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.abstract import custom_method
+from stripe.api_resources.abstract import test_helpers
 
 
+@test_helpers
+@custom_method("cancel_action", http_verb="post")
+@custom_method("process_payment_intent", http_verb="post")
+@custom_method("process_setup_intent", http_verb="post")
+@custom_method("set_reader_display", http_verb="post")
 class Reader(
     CreateableAPIResource,
     DeletableAPIResource,
@@ -14,3 +23,37 @@ class Reader(
     UpdateableAPIResource,
 ):
     OBJECT_NAME = "terminal.reader"
+
+    def cancel_action(self, idempotency_key=None, **params):
+        url = self.instance_url() + "/cancel_action"
+        headers = util.populate_headers(idempotency_key)
+        self.refresh_from(self.request("post", url, params, headers))
+        return self
+
+    def process_payment_intent(self, idempotency_key=None, **params):
+        url = self.instance_url() + "/process_payment_intent"
+        headers = util.populate_headers(idempotency_key)
+        self.refresh_from(self.request("post", url, params, headers))
+        return self
+
+    def process_setup_intent(self, idempotency_key=None, **params):
+        url = self.instance_url() + "/process_setup_intent"
+        headers = util.populate_headers(idempotency_key)
+        self.refresh_from(self.request("post", url, params, headers))
+        return self
+
+    def set_reader_display(self, idempotency_key=None, **params):
+        url = self.instance_url() + "/set_reader_display"
+        headers = util.populate_headers(idempotency_key)
+        self.refresh_from(self.request("post", url, params, headers))
+        return self
+
+    @custom_method("present_payment_method", http_verb="post")
+    class TestHelpers(APIResourceTestHelpers):
+        def present_payment_method(self, idempotency_key=None, **params):
+            url = self.instance_url() + "/present_payment_method"
+            headers = util.populate_headers(idempotency_key)
+            self.resource.refresh_from(
+                self.resource.request("post", url, params, headers)
+            )
+            return self.resource

--- a/tests/api_resources/terminal/test_reader.py
+++ b/tests/api_resources/terminal/test_reader.py
@@ -60,3 +60,10 @@ class TestReader(object):
             "delete", "/v1/terminal/readers/%s" % TEST_RESOURCE_ID
         )
         assert resource.deleted is True
+
+    def test_can_present_payment_method(self, request_mock):
+        resource = stripe.terminal.Reader.TestHelpers.present_payment_method(TEST_RESOURCE_ID)
+        request_mock.assert_requested(
+            "post", "/v1/test_helpers/terminal/readers/%s/present_payment_method" % TEST_RESOURCE_ID
+        )
+        assert isinstance(resource, stripe.terminal.Reader)

--- a/tests/api_resources/terminal/test_reader.py
+++ b/tests/api_resources/terminal/test_reader.py
@@ -62,8 +62,12 @@ class TestReader(object):
         assert resource.deleted is True
 
     def test_can_present_payment_method(self, request_mock):
-        resource = stripe.terminal.Reader.TestHelpers.present_payment_method(TEST_RESOURCE_ID)
+        resource = stripe.terminal.Reader.TestHelpers.present_payment_method(
+            TEST_RESOURCE_ID
+        )
         request_mock.assert_requested(
-            "post", "/v1/test_helpers/terminal/readers/%s/present_payment_method" % TEST_RESOURCE_ID
+            "post",
+            "/v1/test_helpers/terminal/readers/%s/present_payment_method"
+            % TEST_RESOURCE_ID,
         )
         assert isinstance(resource, stripe.terminal.Reader)


### PR DESCRIPTION
Codegen for openapi 1700e20.
r? @yejia-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `cancel_action`, `process_payment_intent`, `process_setup_intent`, and `set_reader_display` methods on resource `Terminal.Reader`

