### PR TITLE
PyPI / project URLs: Link to CHANGES.md

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     project_urls={
         "Bug Tracker": "https://github.com/stripe/stripe-python/issues",
+        "Changes": "https://github.com/stripe/stripe-python/blob/master/CHANGELOG.md",
         "Documentation": "https://stripe.com/docs/api/?lang=python",
         "Source Code": "https://github.com/stripe/stripe-python",
     },


### PR DESCRIPTION
When published, this will link to the changelog


I picked [CHANGELOG.md](https://github.com/stripe/stripe-python/blob/master/CHANGELOG.md) over [Releases](https://github.com/stripe/stripe-python/releases). Changelog files can are one page and scrolled through / searched / etc.

![image](https://user-images.githubusercontent.com/26336/160894221-0385af4a-ae10-4a59-b52c-c5723659adc5.png)


<details>

![image](https://user-images.githubusercontent.com/26336/160894154-52cd8326-6dd9-423b-8368-bfb10a9edec6.png)

</details>