### PR TITLE
Add support for updating the version of the repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,4 +36,10 @@ lint: venv
 clean:
 	@rm -rf $(VENV_NAME) .coverage .coverage.* build/ dist/ htmlcov/
 
-.PHONY: venv test test-nomock test-travis coveralls fmt fmtcheck lint clean
+update-version:
+	@echo "$(VERSION)" > VERSION
+	@perl -pi -e 's|VERSION = "[.\d]+"|VERSION = "$(VERSION)"|' stripe/version.py
+
+codegen-format: fmt
+
+.PHONY: venv test test-nomock test-travis coveralls fmt fmtcheck lint clean update-version codegen-format

--- a/Makefile
+++ b/Makefile
@@ -42,4 +42,4 @@ update-version:
 
 codegen-format: fmt
 
-.PHONY: venv test test-nomock test-travis coveralls fmt fmtcheck lint clean update-version codegen-format
+.PHONY: clean codegen-format coveralls fmt fmtcheck lint test test-nomock test-travis update-version venv


### PR DESCRIPTION
Encodes the logic for version updating as a Makefile. Simplifies what the generation tools needs to know about the repo.
The plan is to have the same interface across all the repos.

Sample usage:

```
make update-version VERSION=1.2.5
```

Also adds a target that codegen will use to format all our repos:

```
make codegen-format
```