### PR TITLE
Manually sign python packages

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   workflow_dispatch: {}
   push:
-    branches: [master]
+    branches: [master, pakrym/release-pipeline]
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*
   pull_request:
@@ -104,7 +104,7 @@ jobs:
 
   publish:
     name: Publish
-    if: (((github.event_name == 'workflow_dispatch')) && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && endsWith(github.actor, '-stripe'))
+    if: (((github.event_name == 'workflow_dispatch')) && (github.ref == 'refs/heads/pakrym/release-pipeline' || startsWith(github.ref, 'refs/tags/v')) && endsWith(github.actor, '-stripe'))
     needs: [build, test, lint]
     runs-on: ubuntu-latest
     steps:
@@ -121,22 +121,24 @@ jobs:
 
       - name: Configure GPG Key
         run: |
-          set -x
-          echo $GPG_SIGNING_PUBKEY | base64 --decode | gpg --import --batch --yes
+          set -ex
           echo $GPG_SIGNING_PRIVKEY | base64 --decode | gpg --import --batch --yes --pinentry-mode loopback --passphrase "$GPG_SIGNING_PASSPHRASE"
         env:
-          GPG_SIGNING_PUBKEY: ${{ secrets.GPG_SIGNING_PUBKEY }}
           GPG_SIGNING_PRIVKEY: ${{ secrets.GPG_SIGNING_PRIVKEY }}
           GPG_SIGNING_PASSPHRASE: ${{ secrets.GPG_SIGNING_PASSPHRASE }}
       - name: Install tools
         run: make venv
       - name: Publish packages to PyPy
         run: |
-          set -x
-          export GPG_TTY=$(tty)
+          set -ex
           source venv/bin/activate
-          python -m twine upload --identity $GPG_SIGNING_KEYID --sign dist/*
+          export VERSION=(cat VERSION)
+          gpg --detach-sign --local-user $GPG_SIGNING_KEYID  --pinentry-mode loopback --passphrase $GPG_SIGNING_PASSPHRASE -a dist/stripe-$VERSION.tar.gz
+          gpg --detach-sign --local-user $GPG_SIGNING_KEYID  --pinentry-mode loopback --passphrase $GPG_SIGNING_PASSPHRASE -a dist/stripe-$VERSION-py2.py3-none-any.whl
+
+          python -m twine upload dist/stripe-$VERSION.tar.gz  dist/stripe-$VERSION-py2.py3-none-any.whl dist/stripe-$VERSION.tar.gz.asc dist/stripe-$VERSION-py2.py3-none-any.whl.asc
         env:
           GPG_SIGNING_KEYID: ${{ secrets.GPG_SIGNING_KEYID }}
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          GPG_SIGNING_PASSPHRASE: ${{ secrets.GPG_SIGNING_PASSPHRASE }}


### PR DESCRIPTION
Use manual signing for the python package. 

Also allow running the workflow on a custom branch so it's easier to iterate. I'll remove it when things work.