### PR TITLE
New Orders API

### DIFF
--- a/stripe/api_resources/__init__.py
+++ b/stripe/api_resources/__init__.py
@@ -56,7 +56,6 @@ from stripe.api_resources.line_item import LineItem
 from stripe.api_resources.login_link import LoginLink
 from stripe.api_resources.mandate import Mandate
 from stripe.api_resources.order import Order
-from stripe.api_resources.order_return import OrderReturn
 from stripe.api_resources.payment_intent import PaymentIntent
 from stripe.api_resources.payment_link import PaymentLink
 from stripe.api_resources.payment_method import PaymentMethod

--- a/stripe/api_resources/order.py
+++ b/stripe/api_resources/order.py
@@ -8,19 +8,28 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import custom_method
 
 
-@custom_method("return_order", http_verb="post", http_path="returns")
-@custom_method("pay", http_verb="post")
+@custom_method("cancel", http_verb="post")
+@custom_method("list_line_items", http_verb="get", http_path="line_items")
+@custom_method("reopen", http_verb="post")
 class Order(CreateableAPIResource, ListableAPIResource, UpdateableAPIResource):
     OBJECT_NAME = "order"
 
-    def pay(self, idempotency_key=None, **params):
-        url = self.instance_url() + "/pay"
+    def cancel(self, idempotency_key=None, **params):
+        url = self.instance_url() + "/cancel"
         headers = util.populate_headers(idempotency_key)
         self.refresh_from(self.request("post", url, params, headers))
         return self
 
-    def return_order(self, idempotency_key=None, **params):
+    def list_line_items(self, idempotency_key=None, **params):
+        url = self.instance_url() + "/line_items"
         headers = util.populate_headers(idempotency_key)
-        return self.request(
-            "post", self.instance_url() + "/returns", params, headers
-        )
+        resp = self.request("get", url, params, headers)
+        stripe_object = util.convert_to_stripe_object(resp)
+        stripe_object._retrieve_params = params
+        return stripe_object
+
+    def reopen(self, idempotency_key=None, **params):
+        url = self.instance_url() + "/reopen"
+        headers = util.populate_headers(idempotency_key)
+        self.refresh_from(self.request("post", url, params, headers))
+        return self

--- a/stripe/api_resources/order.py
+++ b/stripe/api_resources/order.py
@@ -11,6 +11,7 @@ from stripe.api_resources.abstract import custom_method
 @custom_method("cancel", http_verb="post")
 @custom_method("list_line_items", http_verb="get", http_path="line_items")
 @custom_method("reopen", http_verb="post")
+@custom_method("submit", http_verb="post")
 class Order(CreateableAPIResource, ListableAPIResource, UpdateableAPIResource):
     OBJECT_NAME = "order"
 
@@ -30,6 +31,12 @@ class Order(CreateableAPIResource, ListableAPIResource, UpdateableAPIResource):
 
     def reopen(self, idempotency_key=None, **params):
         url = self.instance_url() + "/reopen"
+        headers = util.populate_headers(idempotency_key)
+        self.refresh_from(self.request("post", url, params, headers))
+        return self
+
+    def submit(self, idempotency_key=None, **params):
+        url = self.instance_url() + "/submit"
         headers = util.populate_headers(idempotency_key)
         self.refresh_from(self.request("post", url, params, headers))
         return self

--- a/stripe/object_classes.py
+++ b/stripe/object_classes.py
@@ -57,7 +57,6 @@ OBJECT_CLASSES = {
     api_resources.LoginLink.OBJECT_NAME: api_resources.LoginLink,
     api_resources.Mandate.OBJECT_NAME: api_resources.Mandate,
     api_resources.Order.OBJECT_NAME: api_resources.Order,
-    api_resources.OrderReturn.OBJECT_NAME: api_resources.OrderReturn,
     api_resources.PaymentIntent.OBJECT_NAME: api_resources.PaymentIntent,
     api_resources.PaymentLink.OBJECT_NAME: api_resources.PaymentLink,
     api_resources.PaymentMethod.OBJECT_NAME: api_resources.PaymentMethod,

--- a/tests/test_generated_examples.py
+++ b/tests/test_generated_examples.py
@@ -1402,53 +1402,6 @@ class TestGeneratedExamples(object):
         stripe.terminal.Reader.list(limit=3)
         request_mock.assert_requested("get", "/v1/terminal/readers")
 
-    def test_order_create(self, request_mock):
-        stripe.Order.create(
-            currency="usd",
-            email="jenny.rosen@example.com",
-            items=[{"type": "sku", "parent": "sku_xxxxxxxxxxxxx"}],
-            shipping={
-                "name": "Jenny Rosen",
-                "address": {
-                    "line1": "1234 Main Street",
-                    "city": "San Francisco",
-                    "state": "CA",
-                    "country": "US",
-                    "postal_code": "94111",
-                },
-            },
-        )
-        request_mock.assert_requested("post", "/v1/orders")
-
-    def test_order_retrieve(self, request_mock):
-        stripe.Order.retrieve("or_xxxxxxxxxxxxx")
-        request_mock.assert_requested("get", "/v1/orders/or_xxxxxxxxxxxxx")
-
-    def test_order_update(self, request_mock):
-        stripe.Order.modify("or_xxxxxxxxxxxxx", metadata={"order_id": "6735"})
-        request_mock.assert_requested("post", "/v1/orders/or_xxxxxxxxxxxxx")
-
-    def test_order_pay(self, request_mock):
-        stripe.Order.pay("or_xxxxxxxxxxxxx", source="tok_xxxx")
-        request_mock.assert_requested(
-            "post", "/v1/orders/or_xxxxxxxxxxxxx/pay"
-        )
-
-    def test_order_list(self, request_mock):
-        stripe.Order.list(limit=3)
-        request_mock.assert_requested("get", "/v1/orders")
-
-    def test_orderreturn_retrieve(self, request_mock):
-        stripe.OrderReturn.retrieve("orret_xxxxxxxxxxxxx")
-        request_mock.assert_requested(
-            "get",
-            "/v1/order_returns/orret_xxxxxxxxxxxxx",
-        )
-
-    def test_orderreturn_list(self, request_mock):
-        stripe.OrderReturn.list(limit=3)
-        request_mock.assert_requested("get", "/v1/order_returns")
-
     def test_sku_create(self, request_mock):
         stripe.SKU.create(
             attributes={"size": "Medium", "gender": "Unisex"},

--- a/tests/test_generated_examples.py
+++ b/tests/test_generated_examples.py
@@ -1670,3 +1670,35 @@ class TestGeneratedExamples(object):
             "post",
             "/v1/test_helpers/refunds/re_123/expire",
         )
+
+    def test_order_create(self, request_mock):
+        stripe.Order.create(
+            description="description",
+            currency="usd",
+            line_items=[{"description": "my line item"}],
+        )
+        request_mock.assert_requested("post", "/v1/orders")
+
+    def test_order_update(self, request_mock):
+        stripe.Order.modify("order_xyz")
+        request_mock.assert_requested("post", "/v1/orders/order_xyz")
+
+    def test_order_list_line_items(self, request_mock):
+        stripe.Order.list_line_items("order_xyz")
+        request_mock.assert_requested("get", "/v1/orders/order_xyz/line_items")
+
+    def test_order_cancel(self, request_mock):
+        stripe.Order.cancel("order_xyz")
+        request_mock.assert_requested("post", "/v1/orders/order_xyz/cancel")
+
+    def test_order_reopen(self, request_mock):
+        stripe.Order.reopen("order_xyz")
+        request_mock.assert_requested("post", "/v1/orders/order_xyz/reopen")
+
+    def test_order_submit(self, request_mock):
+        stripe.Order.submit("order_xyz", expected_total=100)
+        request_mock.assert_requested("post", "/v1/orders/order_xyz/submit")
+
+    def test_order_update2(self, request_mock):
+        stripe.Order.modify("order_xyz")
+        request_mock.assert_requested("post", "/v1/orders/order_xyz")


### PR DESCRIPTION
## Summary
* Introduces the revamped Orders API.
  * Remove legacy resources `OrderItem` and `OrderReturn`, and legacy methods on `Order` `pay` and `return_order`.
  * Add new methods `cancel`, `list_line_items`, and `reopen` methods on resource `Order`
  * Remove support for `pay` and `return_order` methods on resource `Order`

