### PR TITLE
Use the same python base version for fmt and lint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ skip_install = true
 
 [testenv:lint]
 description = run static analysis and style check using flake8
-basepython = python2.7
+basepython = python3.10
 deps = flake8
 commands = python -m flake8 --show-source stripe tests setup.py
 skip_install = true


### PR DESCRIPTION
So we can select one global version and it works for everything.