### PR TITLE
Use the generated API version

### DIFF
--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -10,13 +10,14 @@ import os
 # Andrew Metcalf <andrew@stripe.com>
 
 # Configuration variables
+from stripe.api_version import _ApiVersion
 
 api_key = None
 client_id = None
 api_base = "https://api.stripe.com"
 connect_api_base = "https://connect.stripe.com"
 upload_api_base = "https://files.stripe.com"
-api_version = None
+api_version = _ApiVersion.CURRENT
 verify_ssl_certs = True
 proxy = None
 default_http_client = None

--- a/stripe/api_version.py
+++ b/stripe/api_version.py
@@ -1,0 +1,5 @@
+# File generated from our OpenAPI spec
+
+
+class _ApiVersion:
+    CURRENT = "2020-08-27"


### PR DESCRIPTION
To support generating beta header values, use the generated ApiVersion value instead of the hardcoded one.

This change applies to beta only.

r? @dcr-stripe