### PR TITLE
Fix incorrect handling of additional request parameters

### DIFF
--- a/stripe/api_resources/abstract/api_resource.py
+++ b/stripe/api_resources/abstract/api_resource.py
@@ -116,19 +116,19 @@ class APIResource(StripeObject):
         params=None,
     ):
         if api_key is None and 'api_key' in params:
-            api_key = params['api_key'];
+            api_key = params['api_key']
             del params['api_key']
 
         if idempotency_key is None and 'idempotency_key' in params:
-            idempotency_key = params['idempotency_key'];
+            idempotency_key = params['idempotency_key']
             del params['idempotency_key']
 
         if stripe_version is None and 'stripe_version' in params:
-            stripe_version = params['stripe_version'];
+            stripe_version = params['stripe_version']
             del params['stripe_version']
 
         if stripe_account is None and 'stripe_account' in params:
-            stripe_account = params['stripe_account'];
+            stripe_account = params['stripe_account']
             del params['stripe_account']
 
         requestor = api_requestor.APIRequestor(
@@ -154,19 +154,19 @@ class APIResource(StripeObject):
         params=None,
     ):
         if api_key is None and 'api_key' in params:
-            api_key = params['api_key'];
+            api_key = params['api_key']
             del params['api_key']
 
         if idempotency_key is None and 'idempotency_key' in params:
-            idempotency_key = params['idempotency_key'];
+            idempotency_key = params['idempotency_key']
             del params['idempotency_key']
 
         if stripe_version is None and 'stripe_version' in params:
-            stripe_version = params['stripe_version'];
+            stripe_version = params['stripe_version']
             del params['stripe_version']
 
         if stripe_account is None and 'stripe_account' in params:
-            stripe_account = params['stripe_account'];
+            stripe_account = params['stripe_account']
             del params['stripe_account']
 
         requestor = api_requestor.APIRequestor(

--- a/stripe/api_resources/abstract/api_resource.py
+++ b/stripe/api_resources/abstract/api_resource.py
@@ -115,6 +115,22 @@ class APIResource(StripeObject):
         stripe_account=None,
         params=None,
     ):
+        if api_key is None and 'api_key' in params:
+            api_key = params['api_key'];
+            del params['api_key']
+
+        if idempotency_key is None and 'idempotency_key' in params:
+            idempotency_key = params['idempotency_key'];
+            del params['idempotency_key']
+
+        if stripe_version is None and 'stripe_version' in params:
+            stripe_version = params['stripe_version'];
+            del params['stripe_version']
+
+        if stripe_account is None and 'stripe_account' in params:
+            stripe_account = params['stripe_account'];
+            del params['stripe_account']
+
         requestor = api_requestor.APIRequestor(
             api_key, api_version=stripe_version, account=stripe_account
         )
@@ -137,6 +153,22 @@ class APIResource(StripeObject):
         stripe_account=None,
         params=None,
     ):
+        if api_key is None and 'api_key' in params:
+            api_key = params['api_key'];
+            del params['api_key']
+
+        if idempotency_key is None and 'idempotency_key' in params:
+            idempotency_key = params['idempotency_key'];
+            del params['idempotency_key']
+
+        if stripe_version is None and 'stripe_version' in params:
+            stripe_version = params['stripe_version'];
+            del params['stripe_version']
+
+        if stripe_account is None and 'stripe_account' in params:
+            stripe_account = params['stripe_account'];
+            del params['stripe_account']
+
         requestor = api_requestor.APIRequestor(
             api_key, api_version=stripe_version, account=stripe_account
         )

--- a/stripe/api_resources/abstract/api_resource.py
+++ b/stripe/api_resources/abstract/api_resource.py
@@ -115,11 +115,18 @@ class APIResource(StripeObject):
         stripe_account=None,
         params=None,
     ):
-        params, api_key = util.read_special_variable(params, "api_key", api_key)
-        params, idempotency_key = util.read_special_variable(params, "idempotency_key", idempotency_key)
-        params, stripe_version = util.read_special_variable(params, "stripe_version", stripe_version)
-        params, stripe_account = util.read_special_variable(params, "stripe_account", stripe_account)
-        params, headers = util.read_special_variable(params, "headers", None)
+        params = None if params is None else params.copy()
+        api_key = util.read_special_variable(params, "api_key", api_key)
+        idempotency_key = util.read_special_variable(
+            params, "idempotency_key", idempotency_key
+        )
+        stripe_version = util.read_special_variable(
+            params, "stripe_version", stripe_version
+        )
+        stripe_account = util.read_special_variable(
+            params, "stripe_account", stripe_account
+        )
+        headers = util.read_special_variable(params, "headers", None)
 
         requestor = api_requestor.APIRequestor(
             api_key, api_version=stripe_version, account=stripe_account
@@ -147,25 +154,26 @@ class APIResource(StripeObject):
         stripe_account=None,
         params=None,
     ):
-        if api_key is None and params and "api_key" in params:
-            api_key = params["api_key"]
-            del params["api_key"]
-
-        if idempotency_key is None and params and "idempotency_key" in params:
-            idempotency_key = params["idempotency_key"]
-            del params["idempotency_key"]
-
-        if stripe_version is None and params and "stripe_version" in params:
-            stripe_version = params["stripe_version"]
-            del params["stripe_version"]
-
-        if stripe_account is None and params and "stripe_account" in params:
-            stripe_account = params["stripe_account"]
-            del params["stripe_account"]
+        params = None if params is None else params.copy()
+        api_key = util.read_special_variable(params, "api_key", api_key)
+        idempotency_key = util.read_special_variable(
+            params, "idempotency_key", idempotency_key
+        )
+        stripe_version = util.read_special_variable(
+            params, "stripe_version", stripe_version
+        )
+        stripe_account = util.read_special_variable(
+            params, "stripe_account", stripe_account
+        )
+        headers = util.read_special_variable(params, "headers", None)
 
         requestor = api_requestor.APIRequestor(
             api_key, api_version=stripe_version, account=stripe_account
         )
-        headers = util.populate_headers(idempotency_key)
+
+        if idempotency_key is not None:
+            headers = {} if headers is None else headers.copy()
+            headers.update(util.populate_headers(idempotency_key))
+
         response, _ = requestor.request_stream(method_, url_, params, headers)
         return response

--- a/stripe/api_resources/abstract/api_resource.py
+++ b/stripe/api_resources/abstract/api_resource.py
@@ -115,21 +115,21 @@ class APIResource(StripeObject):
         stripe_account=None,
         params=None,
     ):
-        if api_key is None and 'api_key' in params:
-            api_key = params['api_key']
-            del params['api_key']
+        if api_key is None and params and "api_key" in params:
+            api_key = params["api_key"]
+            del params["api_key"]
 
-        if idempotency_key is None and 'idempotency_key' in params:
-            idempotency_key = params['idempotency_key']
-            del params['idempotency_key']
+        if idempotency_key is None and params and "idempotency_key" in params:
+            idempotency_key = params["idempotency_key"]
+            del params["idempotency_key"]
 
-        if stripe_version is None and 'stripe_version' in params:
-            stripe_version = params['stripe_version']
-            del params['stripe_version']
+        if stripe_version is None and params and "stripe_version" in params:
+            stripe_version = params["stripe_version"]
+            del params["stripe_version"]
 
-        if stripe_account is None and 'stripe_account' in params:
-            stripe_account = params['stripe_account']
-            del params['stripe_account']
+        if stripe_account is None and params and "stripe_account" in params:
+            stripe_account = params["stripe_account"]
+            del params["stripe_account"]
 
         requestor = api_requestor.APIRequestor(
             api_key, api_version=stripe_version, account=stripe_account
@@ -153,21 +153,21 @@ class APIResource(StripeObject):
         stripe_account=None,
         params=None,
     ):
-        if api_key is None and 'api_key' in params:
-            api_key = params['api_key']
-            del params['api_key']
+        if api_key is None and params and "api_key" in params:
+            api_key = params["api_key"]
+            del params["api_key"]
 
-        if idempotency_key is None and 'idempotency_key' in params:
-            idempotency_key = params['idempotency_key']
-            del params['idempotency_key']
+        if idempotency_key is None and params and "idempotency_key" in params:
+            idempotency_key = params["idempotency_key"]
+            del params["idempotency_key"]
 
-        if stripe_version is None and 'stripe_version' in params:
-            stripe_version = params['stripe_version']
-            del params['stripe_version']
+        if stripe_version is None and params and "stripe_version" in params:
+            stripe_version = params["stripe_version"]
+            del params["stripe_version"]
 
-        if stripe_account is None and 'stripe_account' in params:
-            stripe_account = params['stripe_account']
-            del params['stripe_account']
+        if stripe_account is None and params and "stripe_account" in params:
+            stripe_account = params["stripe_account"]
+            del params["stripe_account"]
 
         requestor = api_requestor.APIRequestor(
             api_key, api_version=stripe_version, account=stripe_account

--- a/stripe/api_resources/abstract/api_resource.py
+++ b/stripe/api_resources/abstract/api_resource.py
@@ -115,26 +115,20 @@ class APIResource(StripeObject):
         stripe_account=None,
         params=None,
     ):
-        if api_key is None and params and "api_key" in params:
-            api_key = params["api_key"]
-            del params["api_key"]
-
-        if idempotency_key is None and params and "idempotency_key" in params:
-            idempotency_key = params["idempotency_key"]
-            del params["idempotency_key"]
-
-        if stripe_version is None and params and "stripe_version" in params:
-            stripe_version = params["stripe_version"]
-            del params["stripe_version"]
-
-        if stripe_account is None and params and "stripe_account" in params:
-            stripe_account = params["stripe_account"]
-            del params["stripe_account"]
+        params, api_key = util.read_special_variable(params, "api_key", api_key)
+        params, idempotency_key = util.read_special_variable(params, "idempotency_key", idempotency_key)
+        params, stripe_version = util.read_special_variable(params, "stripe_version", stripe_version)
+        params, stripe_account = util.read_special_variable(params, "stripe_account", stripe_account)
+        params, headers = util.read_special_variable(params, "headers", None)
 
         requestor = api_requestor.APIRequestor(
             api_key, api_version=stripe_version, account=stripe_account
         )
-        headers = util.populate_headers(idempotency_key)
+
+        if idempotency_key is not None:
+            headers = {} if headers is None else headers.copy()
+            headers.update(util.populate_headers(idempotency_key))
+
         response, api_key = requestor.request(method_, url_, params, headers)
         return util.convert_to_stripe_object(
             response, api_key, stripe_version, stripe_account, params

--- a/stripe/stripe_object.py
+++ b/stripe/stripe_object.py
@@ -250,7 +250,6 @@ class StripeObject(dict):
         headers=None,
         params=None,
     ):
-
         stripe_account = stripe_account or self.stripe_account
         stripe_version = stripe_version or self.stripe_version
         api_key = api_key or self.api_key

--- a/stripe/stripe_object.py
+++ b/stripe/stripe_object.py
@@ -250,10 +250,27 @@ class StripeObject(dict):
         headers=None,
         params=None,
     ):
+
         stripe_account = stripe_account or self.stripe_account
         stripe_version = stripe_version or self.stripe_version
         api_key = api_key or self.api_key
         params = params or self._retrieve_params
+
+        if api_key is None and 'api_key' in params:
+            api_key = params['api_key'];
+            del params['api_key']
+
+        if idempotency_key is None and 'idempotency_key' in params:
+            idempotency_key = params['idempotency_key'];
+            del params['idempotency_key']
+
+        if stripe_version is None and 'stripe_version' in params:
+            stripe_version = params['stripe_version'];
+            del params['stripe_version']
+
+        if stripe_account is None and 'stripe_account' in params:
+            stripe_account = params['stripe_account'];
+            del params['stripe_account']
 
         requestor = api_requestor.APIRequestor(
             key=api_key,

--- a/stripe/stripe_object.py
+++ b/stripe/stripe_object.py
@@ -250,11 +250,18 @@ class StripeObject(dict):
         headers=None,
         params=None,
     ):
-        params, api_key = util.read_special_variable(params, "api_key", api_key)
-        params, idempotency_key = util.read_special_variable(params, "idempotency_key", idempotency_key)
-        params, stripe_version = util.read_special_variable(params, "stripe_version", stripe_version)
-        params, stripe_account = util.read_special_variable(params, "stripe_account", stripe_account)
-        params, headers = util.read_special_variable(params, "headers", headers)
+        params = None if params is None else params.copy()
+        api_key = util.read_special_variable(params, "api_key", api_key)
+        idempotency_key = util.read_special_variable(
+            params, "idempotency_key", idempotency_key
+        )
+        stripe_version = util.read_special_variable(
+            params, "stripe_version", stripe_version
+        )
+        stripe_account = util.read_special_variable(
+            params, "stripe_account", stripe_account
+        )
+        headers = util.read_special_variable(params, "headers", headers)
 
         stripe_account = stripe_account or self.stripe_account
         stripe_version = stripe_version or self.stripe_version

--- a/stripe/stripe_object.py
+++ b/stripe/stripe_object.py
@@ -257,19 +257,19 @@ class StripeObject(dict):
         params = params or self._retrieve_params
 
         if api_key is None and 'api_key' in params:
-            api_key = params['api_key'];
+            api_key = params['api_key']
             del params['api_key']
 
         if idempotency_key is None and 'idempotency_key' in params:
-            idempotency_key = params['idempotency_key'];
+            idempotency_key = params['idempotency_key']
             del params['idempotency_key']
 
         if stripe_version is None and 'stripe_version' in params:
-            stripe_version = params['stripe_version'];
+            stripe_version = params['stripe_version']
             del params['stripe_version']
 
         if stripe_account is None and 'stripe_account' in params:
-            stripe_account = params['stripe_account'];
+            stripe_account = params['stripe_account']
             del params['stripe_account']
 
         requestor = api_requestor.APIRequestor(

--- a/stripe/stripe_object.py
+++ b/stripe/stripe_object.py
@@ -256,21 +256,21 @@ class StripeObject(dict):
         api_key = api_key or self.api_key
         params = params or self._retrieve_params
 
-        if api_key is None and 'api_key' in params:
-            api_key = params['api_key']
-            del params['api_key']
+        if api_key is None and params and "api_key" in params:
+            api_key = params["api_key"]
+            del params["api_key"]
 
-        if idempotency_key is None and 'idempotency_key' in params:
-            idempotency_key = params['idempotency_key']
-            del params['idempotency_key']
+        if idempotency_key is None and params and "idempotency_key" in params:
+            idempotency_key = params["idempotency_key"]
+            del params["idempotency_key"]
 
-        if stripe_version is None and 'stripe_version' in params:
-            stripe_version = params['stripe_version']
-            del params['stripe_version']
+        if stripe_version is None and params and "stripe_version" in params:
+            stripe_version = params["stripe_version"]
+            del params["stripe_version"]
 
-        if stripe_account is None and 'stripe_account' in params:
-            stripe_account = params['stripe_account']
-            del params['stripe_account']
+        if stripe_account is None and params and "stripe_account" in params:
+            stripe_account = params["stripe_account"]
+            del params["stripe_account"]
 
         requestor = api_requestor.APIRequestor(
             key=api_key,

--- a/stripe/stripe_object.py
+++ b/stripe/stripe_object.py
@@ -250,30 +250,16 @@ class StripeObject(dict):
         headers=None,
         params=None,
     ):
+        params, api_key = util.read_special_variable(params, "api_key", api_key)
+        params, idempotency_key = util.read_special_variable(params, "idempotency_key", idempotency_key)
+        params, stripe_version = util.read_special_variable(params, "stripe_version", stripe_version)
+        params, stripe_account = util.read_special_variable(params, "stripe_account", stripe_account)
+        params, headers = util.read_special_variable(params, "headers", headers)
+
         stripe_account = stripe_account or self.stripe_account
         stripe_version = stripe_version or self.stripe_version
         api_key = api_key or self.api_key
         params = params or self._retrieve_params
-
-        if api_key is None and params and "api_key" in params:
-            api_key = params["api_key"]
-            del params["api_key"]
-
-        if idempotency_key is None and params and "idempotency_key" in params:
-            idempotency_key = params["idempotency_key"]
-            del params["idempotency_key"]
-
-        if stripe_version is None and params and "stripe_version" in params:
-            stripe_version = params["stripe_version"]
-            del params["stripe_version"]
-
-        if stripe_account is None and params and "stripe_account" in params:
-            stripe_account = params["stripe_account"]
-            del params["stripe_account"]
-
-        if headers is None and params and "headers" in params:
-            headers = params["headers"]
-            del params["headers"]
 
         requestor = api_requestor.APIRequestor(
             key=api_key,

--- a/stripe/stripe_object.py
+++ b/stripe/stripe_object.py
@@ -272,6 +272,10 @@ class StripeObject(dict):
             stripe_account = params["stripe_account"]
             del params["stripe_account"]
 
+        if headers is None and params and "headers" in params:
+            headers = params["headers"]
+            del params["headers"]
+
         requestor = api_requestor.APIRequestor(
             key=api_key,
             api_base=self.api_base(),

--- a/stripe/util.py
+++ b/stripe/util.py
@@ -216,13 +216,12 @@ def read_special_variable(params, key_name, default_value):
 
     if params is not None and key_name in params:
         params_value = params[key_name]
-        params = params.copy()
         del params[key_name]
 
     if value is None:
         value = params_value
 
-    return params, value
+    return value
 
 
 def merge_dicts(x, y):

--- a/stripe/util.py
+++ b/stripe/util.py
@@ -210,6 +210,21 @@ def populate_headers(idempotency_key):
     return None
 
 
+def read_special_variable(params, key_name, default_value):
+    value = default_value
+    params_value = None
+
+    if params is not None and key_name in params:
+        params_value = params[key_name]
+        params = params.copy()
+        del params[key_name]
+
+    if value is None:
+        value = params_value
+
+    return params, value
+
+
 def merge_dicts(x, y):
     z = x.copy()
     z.update(y)

--- a/tests/api_resources/abstract/test_api_resource.py
+++ b/tests/api_resources/abstract/test_api_resource.py
@@ -50,17 +50,12 @@ class TestAPIResource(object):
             "get",
             "/v1/myresources/foo",
             idempotency_key="explicit",
-            params={
-                "idempotency_key": "params",
-                "bobble": "scrobble"
-            }
+            params={"idempotency_key": "params", "bobble": "scrobble"},
         )
 
         request_mock.assert_requested(
-            "get",
-            url,
-            {"bobble": "scrobble"},
-            {"Idempotency-Key": "explicit"})
+            "get", url, {"bobble": "scrobble"}, {"Idempotency-Key": "explicit"}
+        )
 
     def test_convert_to_stripe_object(self):
         sample = {

--- a/tests/api_resources/abstract/test_api_resource.py
+++ b/tests/api_resources/abstract/test_api_resource.py
@@ -38,6 +38,30 @@ class TestAPIResource(object):
         with pytest.raises(KeyError):
             res["bobble"]
 
+    def test_request_with_special_fields_prefers_explicit(self, request_mock):
+        url = "/v1/myresources/foo"
+        request_mock.stub_request(
+            "get",
+            url,
+            {"id": "foo2", "bobble": "scrobble"},
+        )
+
+        self.MyResource._static_request(
+            "get",
+            "/v1/myresources/foo",
+            idempotency_key="explicit",
+            params={
+                "idempotency_key": "params",
+                "bobble": "scrobble"
+            }
+        )
+
+        request_mock.assert_requested(
+            "get",
+            url,
+            {"bobble": "scrobble"},
+            {"Idempotency-Key": "explicit"})
+
     def test_convert_to_stripe_object(self):
         sample = {
             "foo": "bar",

--- a/tests/api_resources/abstract/test_custom_method.py
+++ b/tests/api_resources/abstract/test_custom_method.py
@@ -233,13 +233,14 @@ class TestCustomMethod(object):
             rheaders={"request-id": "req_id"},
         )
 
-        self.MyResource.do_stuff("mid",
-                                 foo="bar",
-                                 stripe_version="2017-08-15",
-                                 api_key="APIKEY",
-                                 idempotency_key="IdempotencyKey",
-                                 stripe_account="Acc"
-                                 )
+        self.MyResource.do_stuff(
+            "mid",
+            foo="bar",
+            stripe_version="2017-08-15",
+            api_key="APIKEY",
+            idempotency_key="IdempotencyKey",
+            stripe_account="Acc",
+        )
 
         request_mock.assert_requested(
             "post",
@@ -249,7 +250,9 @@ class TestCustomMethod(object):
         )
         request_mock.assert_api_version("2017-08-15")
 
-    def test_call_custom_method_class_newcodegen_special_fields(self, request_mock):
+    def test_call_custom_method_class_newcodegen_special_fields(
+        self, request_mock
+    ):
         request_mock.stub_request(
             "post",
             "/v1/myresources/mid/do_the_thing",
@@ -257,13 +260,14 @@ class TestCustomMethod(object):
             rheaders={"request-id": "req_id"},
         )
 
-        self.MyResource.do_stuff_new_codegen("mid",
-                                             foo="bar",
-                                             stripe_version="2017-08-15",
-                                             api_key="APIKEY",
-                                             idempotency_key="IdempotencyKey",
-                                             stripe_account="Acc"
-                                             )
+        self.MyResource.do_stuff_new_codegen(
+            "mid",
+            foo="bar",
+            stripe_version="2017-08-15",
+            api_key="APIKEY",
+            idempotency_key="IdempotencyKey",
+            stripe_account="Acc",
+        )
 
         request_mock.assert_requested(
             "post",
@@ -273,7 +277,9 @@ class TestCustomMethod(object):
         )
         request_mock.assert_api_version("2017-08-15")
 
-    def test_call_custom_method_instance_newcodegen_special_fields(self, request_mock):
+    def test_call_custom_method_instance_newcodegen_special_fields(
+        self, request_mock
+    ):
         request_mock.stub_request(
             "post",
             "/v1/myresources/mid/do_the_thing",
@@ -282,21 +288,19 @@ class TestCustomMethod(object):
         )
 
         obj = self.MyResource.construct_from({"id": "mid"}, "mykey")
-        obj.do_stuff_new_codegen(foo="bar",
-                                 stripe_version="2017-08-15",
-                                 api_key="APIKEY",
-                                 idempotency_key="IdempotencyKey",
-                                 stripe_account="Acc",
-                                 headers={"extra_header": "val"},
-                                 )
+        obj.do_stuff_new_codegen(
+            foo="bar",
+            stripe_version="2017-08-15",
+            api_key="APIKEY",
+            idempotency_key="IdempotencyKey",
+            stripe_account="Acc",
+            headers={"extra_header": "val"},
+        )
 
         request_mock.assert_requested(
             "post",
             "/v1/myresources/mid/do_the_thing",
             {"foo": "bar"},
-            {
-                "Idempotency-Key": "IdempotencyKey",
-                "extra_header": "val"
-            },
+            {"Idempotency-Key": "IdempotencyKey", "extra_header": "val"},
         )
         request_mock.assert_api_version("2017-08-15")

--- a/tests/api_resources/abstract/test_custom_method.py
+++ b/tests/api_resources/abstract/test_custom_method.py
@@ -31,6 +31,37 @@ class TestCustomMethod(object):
             headers = util.populate_headers(idempotency_key)
             return self.request_stream("post", url, params, headers)
 
+        @classmethod
+        def _cls_do_stuff_new_codegen(
+            cls,
+            id,
+            api_key=None,
+            stripe_version=None,
+            stripe_account=None,
+            **params
+        ):
+            return cls._static_request(
+                "post",
+                "/v1/myresources/{id}/do_the_thing".format(
+                    id=util.sanitize_id(id)
+                ),
+                api_key=api_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
+            )
+
+        @util.class_method_variant("_cls_do_stuff_new_codegen")
+        def do_stuff_new_codegen(self, idempotency_key=None, **params):
+            return self._request(
+                "post",
+                "/v1/myresources/{id}/do_the_thing".format(
+                    id=util.sanitize_id(self.get("id"))
+                ),
+                idempotency_key=idempotency_key,
+                params=params,
+            )
+
     def test_call_custom_method_class(self, request_mock):
         request_mock.stub_request(
             "post",
@@ -193,3 +224,79 @@ class TestCustomMethod(object):
             body_content = body_content.decode("utf-8")
 
         assert body_content == "response body"
+
+    def test_call_custom_method_class_special_fields(self, request_mock):
+        request_mock.stub_request(
+            "post",
+            "/v1/myresources/mid/do_the_thing",
+            {"id": "mid", "thing_done": True},
+            rheaders={"request-id": "req_id"},
+        )
+
+        self.MyResource.do_stuff("mid",
+                                 foo="bar",
+                                 stripe_version="2017-08-15",
+                                 api_key="APIKEY",
+                                 idempotency_key="IdempotencyKey",
+                                 stripe_account="Acc"
+                                 )
+
+        request_mock.assert_requested(
+            "post",
+            "/v1/myresources/mid/do_the_thing",
+            {"foo": "bar"},
+            {"Idempotency-Key": "IdempotencyKey"},
+        )
+        request_mock.assert_api_version("2017-08-15")
+
+    def test_call_custom_method_class_newcodegen_special_fields(self, request_mock):
+        request_mock.stub_request(
+            "post",
+            "/v1/myresources/mid/do_the_thing",
+            {"id": "mid", "thing_done": True},
+            rheaders={"request-id": "req_id"},
+        )
+
+        self.MyResource.do_stuff_new_codegen("mid",
+                                             foo="bar",
+                                             stripe_version="2017-08-15",
+                                             api_key="APIKEY",
+                                             idempotency_key="IdempotencyKey",
+                                             stripe_account="Acc"
+                                             )
+
+        request_mock.assert_requested(
+            "post",
+            "/v1/myresources/mid/do_the_thing",
+            {"foo": "bar"},
+            {"Idempotency-Key": "IdempotencyKey"},
+        )
+        request_mock.assert_api_version("2017-08-15")
+
+    def test_call_custom_method_instance_newcodegen_special_fields(self, request_mock):
+        request_mock.stub_request(
+            "post",
+            "/v1/myresources/mid/do_the_thing",
+            {"id": "mid", "thing_done": True},
+            rheaders={"request-id": "req_id"},
+        )
+
+        obj = self.MyResource.construct_from({"id": "mid"}, "mykey")
+        obj.do_stuff_new_codegen(foo="bar",
+                                 stripe_version="2017-08-15",
+                                 api_key="APIKEY",
+                                 idempotency_key="IdempotencyKey",
+                                 stripe_account="Acc",
+                                 headers={"extra_header": "val"},
+                                 )
+
+        request_mock.assert_requested(
+            "post",
+            "/v1/myresources/mid/do_the_thing",
+            {"foo": "bar"},
+            {
+                "Idempotency-Key": "IdempotencyKey",
+                "extra_header": "val"
+            },
+        )
+        request_mock.assert_api_version("2017-08-15")

--- a/tests/api_resources/abstract/test_deletable_api_resource.py
+++ b/tests/api_resources/abstract/test_deletable_api_resource.py
@@ -69,13 +69,14 @@ class TestDeletableAPIResource(object):
             {"Idempotency-Key": "IdempotencyKey"},
         )
 
-        self.MyDeletable.delete("foo",
-                                stripe_version="2017-08-15",
-                                api_key="APIKEY",
-                                idempotency_key="IdempotencyKey",
-                                stripe_account="Acc",
-                                bobble="new_scrobble"
-                                )
+        self.MyDeletable.delete(
+            "foo",
+            stripe_version="2017-08-15",
+            api_key="APIKEY",
+            idempotency_key="IdempotencyKey",
+            stripe_account="Acc",
+            bobble="new_scrobble",
+        )
 
         request_mock.assert_requested(
             "delete",

--- a/tests/api_resources/abstract/test_deletable_api_resource.py
+++ b/tests/api_resources/abstract/test_deletable_api_resource.py
@@ -60,3 +60,27 @@ class TestDeletableAPIResource(object):
 
         assert obj.last_response is not None
         assert obj.last_response.request_id == "req_id"
+
+    def test_delete_with_all_special_fields(self, request_mock):
+        request_mock.stub_request(
+            "delete",
+            "/v1/mydeletables/foo",
+            {"id": "foo", "bobble": "new_scrobble"},
+            {"Idempotency-Key": "IdempotencyKey"},
+        )
+
+        self.MyDeletable.delete("foo",
+                                stripe_version="2017-08-15",
+                                api_key="APIKEY",
+                                idempotency_key="IdempotencyKey",
+                                stripe_account="Acc",
+                                bobble="new_scrobble"
+                                )
+
+        request_mock.assert_requested(
+            "delete",
+            "/v1/mydeletables/foo",
+            {"bobble": "new_scrobble"},
+            {"Idempotency-Key": "IdempotencyKey"},
+        )
+        request_mock.assert_api_version("2017-08-15")

--- a/tests/api_resources/abstract/test_updateable_api_resource.py
+++ b/tests/api_resources/abstract/test_updateable_api_resource.py
@@ -355,22 +355,20 @@ class TestUpdateableAPIResource(object):
             {"Idempotency-Key": "IdempotencyKey"},
         )
 
-        self.MyUpdateable.modify("foo",
-                                 stripe_version="2017-08-15",
-                                 api_key="APIKEY",
-                                 idempotency_key="IdempotencyKey",
-                                 stripe_account="Acc",
-                                 bobble="new_scrobble",
-                                 headers={"extra_header": "val"},
-                                 )
+        self.MyUpdateable.modify(
+            "foo",
+            stripe_version="2017-08-15",
+            api_key="APIKEY",
+            idempotency_key="IdempotencyKey",
+            stripe_account="Acc",
+            bobble="new_scrobble",
+            headers={"extra_header": "val"},
+        )
 
         request_mock.assert_requested(
             "post",
             "/v1/myupdateables/foo",
             {"bobble": "new_scrobble"},
-            {
-                "Idempotency-Key": "IdempotencyKey",
-                "extra_header": "val"
-            },
+            {"Idempotency-Key": "IdempotencyKey", "extra_header": "val"},
         )
         request_mock.assert_api_version("2017-08-15")

--- a/tests/api_resources/abstract/test_updateable_api_resource.py
+++ b/tests/api_resources/abstract/test_updateable_api_resource.py
@@ -346,3 +346,31 @@ class TestUpdateableAPIResource(object):
         res.save()
 
         request_mock.assert_api_version("2017-08-15")
+
+    def test_modify_with_all_special_fields(self, request_mock, obj):
+        request_mock.stub_request(
+            "post",
+            "/v1/myupdateables/foo",
+            {"id": "foo", "bobble": "new_scrobble"},
+            {"Idempotency-Key": "IdempotencyKey"},
+        )
+
+        self.MyUpdateable.modify("foo",
+                                 stripe_version="2017-08-15",
+                                 api_key="APIKEY",
+                                 idempotency_key="IdempotencyKey",
+                                 stripe_account="Acc",
+                                 bobble="new_scrobble",
+                                 headers={"extra_header": "val"},
+                                 )
+
+        request_mock.assert_requested(
+            "post",
+            "/v1/myupdateables/foo",
+            {"bobble": "new_scrobble"},
+            {
+                "Idempotency-Key": "IdempotencyKey",
+                "extra_header": "val"
+            },
+        )
+        request_mock.assert_api_version("2017-08-15")


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-python/issues/849

Fixes issue where using special parameter like `api_key`, `idempotency_key`, `stripe_version`, `stripe_account`, `headers` can cause a `Received unknown parameter error`.


Before fix:
``` 
resource = stripe.Customer.modify(
    "cus_123", metadata={"key": "value"}, email="a@b.c", idempotency_key="abc"
)
```
resulted in 
```
stripe.error.InvalidRequestError: Request req_123: Received unknown parameter: idempotency_key
```
The code executes fine with the fix.