### PR TITLE
Fix issue where auto_paging_iter failed on nested list objects.

### DIFF
--- a/stripe/util.py
+++ b/stripe/util.py
@@ -174,8 +174,13 @@ def convert_to_stripe_object(
             last_response=stripe_response,
         )
 
-        if hasattr(obj, "object") and (
-            (obj.object == "list") or (obj.object == "search_result")
+        # We only need to update _retrieve_params when special params were
+        # actually passed. Otherwise, leave it as is as the list / search result
+        # constructors will instantiate their own params.
+        if (
+            params is not None
+            and hasattr(obj, "object")
+            and ((obj.object == "list") or (obj.object == "search_result"))
         ):
             obj._retrieve_params = params
 

--- a/tests/api_resources/test_invoice.py
+++ b/tests/api_resources/test_invoice.py
@@ -136,3 +136,11 @@ class TestInvoice(object):
             "post", "/v1/invoices/%s/void" % TEST_RESOURCE_ID
         )
         assert isinstance(resource, stripe.Invoice)
+
+    def test_can_iterate_lines(self, request_mock):
+        resource = stripe.Invoice.retrieve(TEST_RESOURCE_ID)
+        assert isinstance(resource.lines.data, list)
+        assert isinstance(resource.lines.data[0], stripe.InvoiceLineItem)
+        seen = [item["id"] for item in resource.lines.auto_paging_iter()]
+
+        assert seen.__len__() > 0


### PR DESCRIPTION
r? @pakrym-stripe 

## Summary

Update `convert_to_stripe_object` to only override `_retrieve_params` is any `params` were passed. Otherwise, the class constructor will instantiate its own. 

Fixes https://github.com/stripe/stripe-python/issues/854

Today when we create a `StripeObject` it says `_retrieve_params` to the value of the `params` kwarg. In this case, that means list objects always have `_retrieve_params = {}` (or any key/values passed to params).

This issue applied specifically to nested listing objects. We would invoke `convert_to_stripe_object` with `params=None` for the child list object. We then overrode the `_retrieve_params` to be `None` which caused `auto_paging_iter` to fail.
