### PR TITLE
Add abstract methods for SearchableAPIResource

### DIFF
--- a/stripe/api_resources/abstract/searchable_api_resource.py
+++ b/stripe/api_resources/abstract/searchable_api_resource.py
@@ -21,3 +21,11 @@ class SearchableAPIResource(APIResource):
             stripe_account=stripe_account,
             params=params,
         )
+
+    @classmethod
+    def search(cls, *args, **kwargs):
+        raise NotImplementedError
+
+    @classmethod
+    def search_auto_paging_iter(cls, *args, **kwargs):
+        raise NotImplementedError


### PR DESCRIPTION
r? @anniel-stripe 

## Summary
Add `search` and `search_auto_paging_iter` "abstract methods" for `SearchableAPIResource`. This is functionally a no-op, but fixes the tests for the type annotation stubs here: https://github.com/python/typeshed/runs/8215124463