### PR TITLE
Deprecate save()

### DIFF
--- a/stripe/api_resources/abstract/updateable_api_resource.py
+++ b/stripe/api_resources/abstract/updateable_api_resource.py
@@ -4,7 +4,6 @@ from stripe import util
 from stripe.api_resources.abstract.api_resource import APIResource
 from stripe.six.moves.urllib.parse import quote_plus
 
-import warnings
 
 class UpdateableAPIResource(APIResource):
     @classmethod
@@ -13,13 +12,11 @@ class UpdateableAPIResource(APIResource):
         return cls._static_request("post", url, params=params)
 
     def save(self, idempotency_key=None):
-        warnings.warn(
-            """
-            The `save` method is deprecated and will be removed in
-            a future major version of the library.
-            Use the class method `modify` on the resource instead.
-            """,
-            DeprecationWarning)
+        """
+        The `save` method is deprecated and will be removed in a future major version of the library.
+
+        Use the class method `modify` on the resource instead.
+        """
         updated_params = self.serialize(None)
         if updated_params:
             self._request_and_refresh(

--- a/stripe/api_resources/abstract/updateable_api_resource.py
+++ b/stripe/api_resources/abstract/updateable_api_resource.py
@@ -12,7 +12,11 @@ class UpdateableAPIResource(APIResource):
         return cls._static_request("post", url, params=params)
 
     def save(self, idempotency_key=None):
-        """The save method is deprecated. Use the modify method with the resource ID instead."""
+        """
+        The `save` method is deprecated and will be removed in a future major version of the library.
+
+        Use the class method `modify` on the resource instead.
+        """
         updated_params = self.serialize(None)
         if updated_params:
             self._request_and_refresh(

--- a/stripe/api_resources/abstract/updateable_api_resource.py
+++ b/stripe/api_resources/abstract/updateable_api_resource.py
@@ -4,6 +4,7 @@ from stripe import util
 from stripe.api_resources.abstract.api_resource import APIResource
 from stripe.six.moves.urllib.parse import quote_plus
 
+import warnings
 
 class UpdateableAPIResource(APIResource):
     @classmethod
@@ -12,11 +13,13 @@ class UpdateableAPIResource(APIResource):
         return cls._static_request("post", url, params=params)
 
     def save(self, idempotency_key=None):
-        """
-        The `save` method is deprecated and will be removed in a future major version of the library.
-
-        Use the class method `modify` on the resource instead.
-        """
+        warnings.warn(
+            """
+            The `save` method is deprecated and will be removed in
+            a future major version of the library.
+            Use the class method `modify` on the resource instead.
+            """,
+            DeprecationWarning)
         updated_params = self.serialize(None)
         if updated_params:
             self._request_and_refresh(

--- a/stripe/api_resources/abstract/updateable_api_resource.py
+++ b/stripe/api_resources/abstract/updateable_api_resource.py
@@ -12,6 +12,7 @@ class UpdateableAPIResource(APIResource):
         return cls._static_request("post", url, params=params)
 
     def save(self, idempotency_key=None):
+        """The save method is deprecated. Use the modify method with the resource ID instead."""
         updated_params = self.serialize(None)
         if updated_params:
             self._request_and_refresh(

--- a/stripe/api_resources/bank_account.py
+++ b/stripe/api_resources/bank_account.py
@@ -54,7 +54,7 @@ class BankAccount(DeletableAPIResource, UpdateableAPIResource, VerifyMixin):
     def modify(cls, sid, **params):
         raise NotImplementedError(
             "Can't modify a bank account without a customer or account ID. "
-            "Call save on customer.sources.retrieve('bank_account_id') or "
+            "Call modify on customer.sources.retrieve('bank_account_id') or "
             "account.external_accounts.retrieve('bank_account_id') instead."
         )
 

--- a/stripe/api_resources/card.py
+++ b/stripe/api_resources/card.py
@@ -52,7 +52,7 @@ class Card(DeletableAPIResource, UpdateableAPIResource):
     def modify(cls, sid, **params):
         raise NotImplementedError(
             "Can't modify a card without a customer or account "
-            "ID. Call save on customer.sources.retrieve('card_id'), or "
+            "ID. Call modify on customer.sources.retrieve('card_id'), or "
             "account.external_accounts.retrieve('card_id') instead."
         )
 

--- a/stripe/api_resources/person.py
+++ b/stripe/api_resources/person.py
@@ -31,7 +31,7 @@ class Person(UpdateableAPIResource):
     def modify(cls, sid, **params):
         raise NotImplementedError(
             "Can't modify a person without an account"
-            "ID. Call save on account.persons.retrieve('person_id')"
+            "ID. Call modify on account.persons.retrieve('person_id')"
         )
 
     @classmethod

--- a/stripe/api_resources/reversal.py
+++ b/stripe/api_resources/reversal.py
@@ -38,7 +38,7 @@ class Reversal(UpdateableAPIResource):
     def modify(cls, sid, **params):
         raise NotImplementedError(
             "Can't modify a reversal without a transfer"
-            "ID. Call save on transfer.reversals.retrieve('reversal_id')"
+            "ID. Call modify on transfer.reversals.retrieve('reversal_id')"
         )
 
     @classmethod


### PR DESCRIPTION
## Summary
Mark `save()` method as deprecated. Also update `NotImplementedError` messages in some resources to point to `modify()` instead of `save()`.

## Changelog
* Deprecate `save` method on resources in favor of `modify`.