### PR TITLE
Do not run coveralls when secret token is not available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Calculate and publish coverage
         run: make coveralls
-        if: matrix.python-version == '3.10'
+        if: env.COVERALLS_REPO_TOKEN && matrix.python-version == '3.10'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
Do not run Coveralls step if the secret token does not exist (for pushes triggered by outside collaborators).

## Motivation
https://github.com/stripe/stripe-php/pull/1379 - make this change consistent across all languages