### PR TITLE
Pin ubuntu version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,10 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    # Specific ubuntu version to support python 3.6 testing
+    # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877 for details
+    # move to ubuntu-latest when we drop 3.6
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version:


### PR DESCRIPTION
Github Ubuntu-latest image updated recently and doesn't [support python 3.6 anymore](https://github.com/actions/setup-python/issues/544#issuecomment-1332535877). Pin to a specific ubuntu LTS(will be supported until 2025) version so we can keep testing 3.6