### PR TITLE
ci: Fix github action warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       - name: lint
@@ -36,10 +36,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 
@@ -54,7 +54,7 @@ jobs:
           python -m twine check dist/*
 
       - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: dist
           path: dist/
@@ -81,28 +81,17 @@ jobs:
           ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: "setup.py"
 
       - name: Upgrade pip and virtualenv to latest
         run: pip install --upgrade pip virtualenv
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          python -c "from pip._internal.locations import USER_CACHE_DIR; print('::set-output name=dir::' + USER_CACHE_DIR)"
-
-      - name: pip cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
 
       - uses: stripe/openapi/actions/stripe-mock@master
 
@@ -125,14 +114,14 @@ jobs:
     needs: [build, test, lint]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: dist
           path: dist
       - name: Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test-nomock: venv
 
 ci-test: venv
 	${VENV_NAME}/bin/python -m pip install -U tox-gh-actions
-	@${VENV_NAME}/bin/tox -p auto $(TOX_ARGS)
+	@${VENV_NAME}/bin/tox $(TOX_ARGS)
 
 coveralls: venv
 	${VENV_NAME}/bin/python -m pip install -U coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -73,10 +73,7 @@ passenv = GITHUB_*
 deps =
     coverage >= 4.5.3, < 5 # TODO: upgrade to coverage 5 when we drop support for Python 3.4
     coveralls
-    pytest
-    pytest-mock
 commands =
-    coverage run --source=stripe -m pytest tests/
     coverage combine
     coveralls --service=github
 depends = py{310,39,38,37,36,35,34,27,py3,py2}


### PR DESCRIPTION
1) Update GH Actions. Fixes the following warnings:
    <img src="https://user-images.githubusercontent.com/44246099/233171339-52284ec5-03cf-4f30-a97b-f0a1c12e58a6.png" width="400" alt="GitHub Actions Warnings">

2) Use `actions/setup-python` builtin [cache](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#caching-packages) functionality (would need to re-run actions to test it)
3) Update `make ci-test` command to not use [`--parallel` mode](https://tox.wiki/en/latest/user_guide.html#parallel-mode). Every node executes tests for single python version / tox environment. This also improves GH Actions logs - you can expand the tests and coverage data:
      <img src="https://user-images.githubusercontent.com/44246099/233173851-310b7c68-d67a-4a65-a91e-9d42cc66e5c8.png" width="400" alt="Expandable Logs">

4) Update `coveralls` step - I think it should only "upload coverage to coveralls.io" (as per description). tox.ini `depends` config suggests the same - it should run after the tests run. I've tested it in `coveralls debug` mode - it pick-ups coverage files generated by the previous step (`Test with pytest`). Let me know if you have strong opinion about this step, I can revert the change.