### PR TITLE
Add raw_request

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,21 @@ To install a beta version use `pip install` with the exact version you'd like to
 pip install stripe==5.3.0b3
 ```
 
+### Custom requests
+
+If you would like to send a request to an undocumented API (for example you are in a private beta), or if you prefer to bypass the method definitions in the library and specify your request details directly, you can use the `raw_request` method on `stripe`.
+
+```python
+response = stripe.raw_request(
+    "post", "/v1/beta_endpoint", param=123, stripe_version="2022-11-15; feature_beta=v3"
+)
+
+# (Optional) response is a StripeResponse. You can use `stripe.deserialize` to get a StripeObject.
+deserialized_resp = stripe.deserialize(response)
+
+# Handle response...
+```
+
 > **Note**
 > There can be breaking changes between beta versions. Therefore we recommend pinning the package version to a specific beta version in your [requirements file](https://pip.pypa.io/en/stable/user_guide/#requirements-files) or `setup.py`. This way you can install the same version each time without breaking changes unless you are intentionally looking for the latest beta version.
 

--- a/README.md
+++ b/README.md
@@ -204,8 +204,6 @@ response = stripe.raw_request(
 
 # (Optional) response is a StripeResponse. You can use `stripe.deserialize` to get a StripeObject.
 deserialized_resp = stripe.deserialize(response)
-
-# Handle response...
 ```
 
 > **Note**

--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -44,6 +44,7 @@ from stripe.raw_request import _raw_request as raw_request  # noqa
 
 from stripe.raw_request import _deserialize as deserialize  # noqa
 
+from stripe.preview import preview
 
 # Sets some basic information about the running application that's sent along
 # with API requests. Useful for plugin authors to identify their plugin when

--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -42,6 +42,9 @@ from stripe.webhook import Webhook, WebhookSignature  # noqa
 
 from stripe.raw_request import _raw_request as raw_request  # noqa
 
+from stripe.raw_request import _deserialize as deserialize  # noqa
+
+
 # Sets some basic information about the running application that's sent along
 # with API requests. Useful for plugin authors to identify their plugin when
 # communicating with Stripe.

--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -44,7 +44,8 @@ from stripe.raw_request import _raw_request as raw_request  # noqa
 
 from stripe.raw_request import _deserialize as deserialize  # noqa
 
-from stripe.preview import preview
+from stripe.preview import preview  # noqa
+
 
 # Sets some basic information about the running application that's sent along
 # with API requests. Useful for plugin authors to identify their plugin when

--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -40,6 +40,7 @@ from stripe.oauth import OAuth  # noqa
 # Webhooks
 from stripe.webhook import Webhook, WebhookSignature  # noqa
 
+from stripe.raw_request import _raw_request as raw_request  # noqa
 
 # Sets some basic information about the running application that's sent along
 # with API requests. Useful for plugin authors to identify their plugin when

--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -74,6 +74,7 @@ class APIRequestor(object):
         api_base=None,
         api_version=None,
         account=None,
+        encoding=None
     ):
         self.api_base = api_base or stripe.api_base
         self.api_key = key
@@ -81,6 +82,7 @@ class APIRequestor(object):
         self.stripe_account = account
 
         self._default_proxy = None
+        self.encoding = encoding or 'form'
 
         from stripe import verify_ssl_certs as verify
         from stripe import proxy
@@ -287,6 +289,7 @@ class APIRequestor(object):
         params=None,
         supplied_headers=None,
         is_streaming=False,
+        encoding=None
     ):
         """
         Mechanism for issuing an API call

--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -123,14 +123,26 @@ class APIRequestor(object):
 
     def request(self, method, url, params=None, headers=None, encoding=None):
         rbody, rcode, rheaders, my_api_key = self.request_raw(
-            method.lower(), url, params, headers, is_streaming=False, encoding=encoding
+            method.lower(),
+            url,
+            params,
+            headers,
+            is_streaming=False,
+            encoding=encoding,
         )
         resp = self.interpret_response(rbody, rcode, rheaders)
         return resp, my_api_key
 
-    def request_stream(self, method, url, params=None, headers=None, encoding=None):
+    def request_stream(
+        self, method, url, params=None, headers=None, encoding=None
+    ):
         stream, rcode, rheaders, my_api_key = self.request_raw(
-            method.lower(), url, params, headers, is_streaming=True, encoding=encoding
+            method.lower(),
+            url,
+            params,
+            headers,
+            is_streaming=True,
+            encoding=encoding,
         )
         resp = self.interpret_streaming_response(stream, rcode, rheaders)
         return resp, my_api_key
@@ -279,7 +291,7 @@ class APIRequestor(object):
 
         if method == "post":
             headers.setdefault("Idempotency-Key", str(uuid.uuid4()))
-            if encoding == 'json':
+            if encoding == "json":
                 headers["Content-Type"] = "application/json"
             else:
                 headers["Content-Type"] = "application/x-www-form-urlencoded"
@@ -296,7 +308,7 @@ class APIRequestor(object):
         params=None,
         supplied_headers=None,
         is_streaming=False,
-        encoding=None
+        encoding=None,
     ):
         """
         Mechanism for issuing an API call
@@ -327,8 +339,10 @@ class APIRequestor(object):
         # makes these parameter strings easier to read.
         encoded_params = encoded_params.replace("%5B", "[").replace("%5D", "]")
 
-        if encoding == 'json':
-            encoded_body = json.dumps(params or {}, default=_json_encode_date_callback)
+        if encoding == "json":
+            encoded_body = json.dumps(
+                params or {}, default=_json_encode_date_callback
+            )
         else:
             encoded_body = encoded_params
 

--- a/stripe/api_version.py
+++ b/stripe/api_version.py
@@ -4,3 +4,4 @@
 
 class _ApiVersion:
     CURRENT = "2022-11-15"
+    PREVIEW = "20230509T165653"

--- a/stripe/preview.py
+++ b/stripe/preview.py
@@ -1,0 +1,20 @@
+from stripe import raw_request
+PREVIEW_STRIPE_VERSION = '20230509T165653'
+class Preview(object):
+    def _get_default_opts(self, params):
+        if 'stripe_version' not in params:
+            params['stripe_version'] = PREVIEW_STRIPE_VERSION
+        if 'encoding' not in params:
+            params['encoding'] = "json"
+        return params
+    
+    def post(self, url, **params):
+        return raw_request('post', url, **self._get_default_opts(params))
+    
+    def get(self, url, **params):
+        return raw_request('get', url, **self._get_default_opts(params))
+    
+    def delete(self, url, **params):
+        return raw_request('delete', url, **self._get_default_opts(params))
+
+preview = Preview()

--- a/stripe/preview.py
+++ b/stripe/preview.py
@@ -1,12 +1,8 @@
 from stripe import raw_request
 
-from stripe.api_version import _ApiVersion
-
 
 class Preview(object):
     def _get_default_opts(self, params):
-        if "stripe_version" not in params:
-            params["stripe_version"] = _ApiVersion.PREVIEW
         if "api_mode" not in params:
             params["api_mode"] = "preview"
         return params

--- a/stripe/preview.py
+++ b/stripe/preview.py
@@ -1,13 +1,12 @@
 from stripe import raw_request
 
-PREVIEW_STRIPE_VERSION = "20230509T165653"
-
+from stripe.api_version import _ApiVersion
 
 
 class Preview(object):
     def _get_default_opts(self, params):
         if "stripe_version" not in params:
-            params["stripe_version"] = PREVIEW_STRIPE_VERSION
+            params["stripe_version"] = _ApiVersion.PREVIEW
         if "api_mode" not in params:
             params["api_mode"] = "preview"
         return params

--- a/stripe/preview.py
+++ b/stripe/preview.py
@@ -1,20 +1,25 @@
 from stripe import raw_request
-PREVIEW_STRIPE_VERSION = '20230509T165653'
+
+PREVIEW_STRIPE_VERSION = "20230509T165653"
+
+
+
 class Preview(object):
     def _get_default_opts(self, params):
-        if 'stripe_version' not in params:
-            params['stripe_version'] = PREVIEW_STRIPE_VERSION
-        if 'encoding' not in params:
-            params['encoding'] = "json"
+        if "stripe_version" not in params:
+            params["stripe_version"] = PREVIEW_STRIPE_VERSION
+        if "api_mode" not in params:
+            params["api_mode"] = "preview"
         return params
-    
+
     def post(self, url, **params):
-        return raw_request('post', url, **self._get_default_opts(params))
-    
+        return raw_request("post", url, **self._get_default_opts(params))
+
     def get(self, url, **params):
-        return raw_request('get', url, **self._get_default_opts(params))
-    
+        return raw_request("get", url, **self._get_default_opts(params))
+
     def delete(self, url, **params):
-        return raw_request('delete', url, **self._get_default_opts(params))
+        return raw_request("delete", url, **self._get_default_opts(params))
+
 
 preview = Preview()

--- a/stripe/raw_request.py
+++ b/stripe/raw_request.py
@@ -1,0 +1,29 @@
+from stripe import api_requestor, util
+
+def _raw_request(method_, url_, **params):
+    params = None if params is None else params.copy()
+    api_key = util.read_special_variable(params, "api_key", None)
+    idempotency_key = util.read_special_variable(
+        params, "idempotency_key", None
+    )
+    stripe_version = util.read_special_variable(
+        params, "stripe_version", None
+    )
+    stripe_account = util.read_special_variable(
+        params, "stripe_account", None
+    )
+    encoding = util.read_special_variable(
+        params, "encoding", "form"
+    )
+    headers = util.read_special_variable(params, "headers", None)
+
+    requestor = api_requestor.APIRequestor(
+        api_key, api_version=stripe_version, account=stripe_account, encoding=encoding
+    )
+
+    if idempotency_key is not None:
+        headers = {} if headers is None else headers.copy()
+        headers.update(util.populate_headers(idempotency_key))
+
+    response, _ = requestor.request(method_, url_, params, headers)
+    return response

--- a/stripe/raw_request.py
+++ b/stripe/raw_request.py
@@ -1,29 +1,34 @@
 from stripe import api_requestor, util
 
+
 def _raw_request(method_, url_, **params):
     params = None if params is None else params.copy()
     api_key = util.read_special_variable(params, "api_key", None)
     idempotency_key = util.read_special_variable(
         params, "idempotency_key", None
     )
-    stripe_version = util.read_special_variable(
-        params, "stripe_version", None
-    )
-    stripe_account = util.read_special_variable(
-        params, "stripe_account", None
-    )
-    encoding = util.read_special_variable(
-        params, "encoding", "form"
-    )
+    stripe_version = util.read_special_variable(params, "stripe_version", None)
+    stripe_account = util.read_special_variable(params, "stripe_account", None)
+    encoding = util.read_special_variable(params, "encoding", "form")
     headers = util.read_special_variable(params, "headers", None)
 
     requestor = api_requestor.APIRequestor(
-        api_key, api_version=stripe_version, account=stripe_account, encoding=encoding
+        api_key,
+        api_version=stripe_version,
+        account=stripe_account,
     )
 
     if idempotency_key is not None:
         headers = {} if headers is None else headers.copy()
         headers.update(util.populate_headers(idempotency_key))
 
-    response, _ = requestor.request(method_, url_, params, headers)
+    response, _ = requestor.request(method_, url_, params, headers, encoding)
     return response
+
+
+def _deserialize(
+    resp, api_key=None, stripe_version=None, stripe_account=None, params=None
+):
+    return util.convert_to_stripe_object(
+        resp, api_key, stripe_version, stripe_account, params
+    )

--- a/stripe/raw_request.py
+++ b/stripe/raw_request.py
@@ -10,7 +10,7 @@ def _raw_request(method_, url_, **params):
     client = util.read_special_variable(params, "client", None)  # for testing
     stripe_version = util.read_special_variable(params, "stripe_version", None)
     stripe_account = util.read_special_variable(params, "stripe_account", None)
-    encoding = util.read_special_variable(params, "encoding", None)
+    api_mode = util.read_special_variable(params, "api_mode", None)
     headers = util.read_special_variable(params, "headers", None)
 
     requestor = api_requestor.APIRequestor(
@@ -24,7 +24,7 @@ def _raw_request(method_, url_, **params):
         headers = {} if headers is None else headers.copy()
         headers.update(util.populate_headers(idempotency_key))
 
-    response, _ = requestor.request(method_, url_, params, headers, encoding)
+    response, _ = requestor.request(method_, url_, params, headers, api_mode)
     return response
 
 

--- a/stripe/raw_request.py
+++ b/stripe/raw_request.py
@@ -1,4 +1,5 @@
 from stripe import api_requestor, util
+from stripe.api_version import _ApiVersion
 
 
 def _raw_request(method_, url_, **params):
@@ -13,6 +14,9 @@ def _raw_request(method_, url_, **params):
     api_mode = util.read_special_variable(params, "api_mode", None)
     stripe_context = util.read_special_variable(params, "stripe_context", None)
     headers = util.read_special_variable(params, "headers", None)
+
+    if api_mode == "preview":
+        stripe_version = stripe_version or _ApiVersion.PREVIEW
 
     requestor = api_requestor.APIRequestor(
         key=api_key,

--- a/stripe/raw_request.py
+++ b/stripe/raw_request.py
@@ -11,6 +11,7 @@ def _raw_request(method_, url_, **params):
     stripe_version = util.read_special_variable(params, "stripe_version", None)
     stripe_account = util.read_special_variable(params, "stripe_account", None)
     api_mode = util.read_special_variable(params, "api_mode", None)
+    stripe_context = util.read_special_variable(params, "stripe_context", None)
     headers = util.read_special_variable(params, "headers", None)
 
     requestor = api_requestor.APIRequestor(
@@ -23,6 +24,14 @@ def _raw_request(method_, url_, **params):
     if idempotency_key is not None:
         headers = {} if headers is None else headers.copy()
         headers.update(util.populate_headers(idempotency_key))
+
+    # stripe-context goes *here* and not in api_requestor. Properties
+    # go on api_requestor when you want them to persist onto requests
+    # made when you call instance methods on APIResources that come from
+    # the first request. No need for that here, as we aren't deserializing APIResources
+    if stripe_context is not None:
+        headers = {} if headers is None else headers.copy()
+        headers.update({"Stripe-Context": stripe_context})
 
     response, _ = requestor.request(method_, url_, params, headers, api_mode)
     return response

--- a/stripe/raw_request.py
+++ b/stripe/raw_request.py
@@ -8,7 +8,6 @@ def _raw_request(method_, url_, **params):
     idempotency_key = util.read_special_variable(
         params, "idempotency_key", None
     )
-    client = util.read_special_variable(params, "client", None)  # for testing
     stripe_version = util.read_special_variable(params, "stripe_version", None)
     stripe_account = util.read_special_variable(params, "stripe_account", None)
     api_mode = util.read_special_variable(params, "api_mode", None)
@@ -20,7 +19,6 @@ def _raw_request(method_, url_, **params):
 
     requestor = api_requestor.APIRequestor(
         key=api_key,
-        client=client,
         api_version=stripe_version,
         account=stripe_account,
     )

--- a/stripe/raw_request.py
+++ b/stripe/raw_request.py
@@ -9,7 +9,7 @@ def _raw_request(method_, url_, **params):
     )
     stripe_version = util.read_special_variable(params, "stripe_version", None)
     stripe_account = util.read_special_variable(params, "stripe_account", None)
-    encoding = util.read_special_variable(params, "encoding", "form")
+    encoding = util.read_special_variable(params, "encoding", None)
     headers = util.read_special_variable(params, "headers", None)
 
     requestor = api_requestor.APIRequestor(

--- a/stripe/raw_request.py
+++ b/stripe/raw_request.py
@@ -7,13 +7,15 @@ def _raw_request(method_, url_, **params):
     idempotency_key = util.read_special_variable(
         params, "idempotency_key", None
     )
+    client = util.read_special_variable(params, "client", None)  # for testing
     stripe_version = util.read_special_variable(params, "stripe_version", None)
     stripe_account = util.read_special_variable(params, "stripe_account", None)
     encoding = util.read_special_variable(params, "encoding", None)
     headers = util.read_special_variable(params, "headers", None)
 
     requestor = api_requestor.APIRequestor(
-        api_key,
+        key=api_key,
+        client=client,
         api_version=stripe_version,
         account=stripe_account,
     )

--- a/tests/request_mock.py
+++ b/tests/request_mock.py
@@ -113,25 +113,25 @@ class RequestMock(object):
             raise AssertionError(msg)
 
     def assert_requested(
-        self, method, url, params=None, headers=None, encoding=None
+        self, method, url, params=None, headers=None, api_mode=None
     ):
         self.assert_requested_internal(
-            self.request_patcher, method, url, params, headers, encoding
+            self.request_patcher, method, url, params, headers, api_mode
         )
 
     def assert_requested_stream(
-        self, method, url, params=None, headers=None, encoding=None
+        self, method, url, params=None, headers=None, api_mode=None
     ):
         self.assert_requested_internal(
-            self.request_stream_patcher, method, url, params, headers, encoding
+            self.request_stream_patcher, method, url, params, headers, api_mode
         )
 
     def assert_requested_internal(
-        self, patcher, method, url, params, headers, encoding
+        self, patcher, method, url, params, headers, api_mode
     ):
         params = params or self._mocker.ANY
         headers = headers or self._mocker.ANY
-        encoding = encoding or self._mocker.ANY
+        api_mode = api_mode or self._mocker.ANY
         called = False
         exception = None
 
@@ -141,7 +141,7 @@ class RequestMock(object):
             (self._mocker.ANY, method, url),
             (self._mocker.ANY, method, url, params),
             (self._mocker.ANY, method, url, params, headers),
-            (self._mocker.ANY, method, url, params, headers, encoding),
+            (self._mocker.ANY, method, url, params, headers, api_mode),
         ]
 
         for args in possible_called_args:

--- a/tests/request_mock.py
+++ b/tests/request_mock.py
@@ -112,19 +112,26 @@ class RequestMock(object):
             )
             raise AssertionError(msg)
 
-    def assert_requested(self, method, url, params=None, headers=None):
+    def assert_requested(
+        self, method, url, params=None, headers=None, encoding=None
+    ):
         self.assert_requested_internal(
-            self.request_patcher, method, url, params, headers
+            self.request_patcher, method, url, params, headers, encoding
         )
 
-    def assert_requested_stream(self, method, url, params=None, headers=None):
+    def assert_requested_stream(
+        self, method, url, params=None, headers=None, encoding=None
+    ):
         self.assert_requested_internal(
-            self.request_stream_patcher, method, url, params, headers
+            self.request_stream_patcher, method, url, params, headers, encoding
         )
 
-    def assert_requested_internal(self, patcher, method, url, params, headers):
+    def assert_requested_internal(
+        self, patcher, method, url, params, headers, encoding
+    ):
         params = params or self._mocker.ANY
         headers = headers or self._mocker.ANY
+        encoding = encoding or self._mocker.ANY
         called = False
         exception = None
 
@@ -134,6 +141,7 @@ class RequestMock(object):
             (self._mocker.ANY, method, url),
             (self._mocker.ANY, method, url, params),
             (self._mocker.ANY, method, url, params, headers),
+            (self._mocker.ANY, method, url, params, headers, encoding),
         ]
 
         for args in possible_called_args:

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -10,6 +10,7 @@ import pytest
 
 import stripe
 from stripe import six, util
+from stripe.api_requestor import _json_encode_date_callback
 from stripe.stripe_response import StripeResponse, StripeStreamResponse
 
 from stripe.six.moves.urllib.parse import urlsplit
@@ -328,6 +329,16 @@ class TestAPIRequestor(object):
             expectation.extend([(k % (type_,), str(v)) for k, v in values])
 
         check_call("get", QueryMatcher(expectation))
+
+    def test_param_encoding_json(self, requestor, mock_response, check_call):
+        mock_response("{}", 200)
+
+        requestor.request("post", "/foo", self.ENCODE_INPUTS, encoding='json')
+
+        expectation = json.dumps(self.ENCODE_INPUTS, default=_json_encode_date_callback)
+        check_call("post", None, {
+            "Content-Type": "application/json",
+        }, expectation)
 
     def test_dictionary_list_encoding(self):
         params = {"foo": {"0": {"bar": "bat"}}}

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -290,11 +290,13 @@ class TestAPIRequestor(object):
 
         check_call("get", QueryMatcher(expectation))
 
-    def test_param_encoding_json(self, requestor, mock_response, check_call):
+    def test_param_api_mode_preview(
+        self, requestor, mock_response, check_call
+    ):
         mock_response("{}", 200)
 
         requestor.request(
-            "post", self.valid_path, self.ENCODE_INPUTS, encoding="json"
+            "post", self.valid_path, self.ENCODE_INPUTS, api_mode="preview"
         )
 
         expectation = json.dumps(

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -241,59 +241,9 @@ class TestAPIRequestor(object):
         stripe.enable_telemetry = orig_attrs["enable_telemetry"]
 
     @pytest.fixture
-    def http_client(self, mocker):
-        http_client = mocker.Mock(stripe.http_client.HTTPClient)
-        http_client._verify_ssl_certs = True
-        http_client.name = "mockclient"
-        return http_client
-
-    @pytest.fixture
     def requestor(self, http_client):
         requestor = stripe.api_requestor.APIRequestor(client=http_client)
         return requestor
-
-    @pytest.fixture
-    def mock_response(self, mocker, http_client):
-        def mock_response(return_body, return_code, headers=None):
-            http_client.request_with_retries = mocker.Mock(
-                return_value=(return_body, return_code, headers or {})
-            )
-
-        return mock_response
-
-    @pytest.fixture
-    def mock_streaming_response(self, mocker, http_client):
-        def mock_streaming_response(return_body, return_code, headers=None):
-            http_client.request_stream_with_retries = mocker.Mock(
-                return_value=(return_body, return_code, headers or {})
-            )
-
-        return mock_streaming_response
-
-    @pytest.fixture
-    def check_call(self, http_client):
-        def check_call(
-            method,
-            abs_url=None,
-            headers=None,
-            post_data=None,
-            is_streaming=False,
-        ):
-            if not abs_url:
-                abs_url = "%s%s" % (stripe.api_base, self.valid_path)
-            if not headers:
-                headers = APIHeaderMatcher(request_method=method)
-
-            if is_streaming:
-                http_client.request_stream_with_retries.assert_called_with(
-                    method, abs_url, headers, post_data
-                )
-            else:
-                http_client.request_with_retries.assert_called_with(
-                    method, abs_url, headers, post_data
-                )
-
-        return check_call
 
     @property
     def valid_path(self):

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -31,7 +31,7 @@ class TestPreview(object):
         resp = stripe.preview.get("/v2/accounts/acc_123")
 
         req = self.mock_request.mock_calls[0]
-        method, abs_url, headers, post_data = req.args
+        method, abs_url, headers = req.args
 
         assert method == "get"
         assert "Content-Type" not in headers
@@ -60,7 +60,7 @@ class TestPreview(object):
         resp = stripe.preview.delete("/v2/accounts/acc_123")
 
         req = self.mock_request.mock_calls[0]
-        method, abs_url, headers, post_data = req.args
+        method, abs_url, headers = req.args
 
         assert method == "delete"
         assert "Content-Type" not in headers

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -70,10 +70,11 @@ class TestPreview(object):
     def test_override_default_options(self, request_mock):
         expected_body = '{"id": "acc_123"}'
         stripe_version_override = "2022-11-15"
+        stripe_context = "acct_x"
         self.set_body(expected_body)
 
         resp = stripe.preview.post(
-            "/v2/accounts", stripe_version=stripe_version_override
+            "/v2/accounts", stripe_version=stripe_version_override, stripe_context=stripe_context
         )
 
         req = self.mock_request.mock_calls[0]
@@ -82,4 +83,5 @@ class TestPreview(object):
         assert method == "post"
         assert headers["Content-Type"] == "application/json"
         assert headers["Stripe-Version"] == stripe_version_override
+        assert headers["Stripe-Context"] == stripe_context
         assert resp.body == expected_body

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -74,7 +74,6 @@ class TestPreview(object):
             "%s/v1/accounts/acc_123" % stripe.api_base,
             APIHeaderMatcher(
                 request_method="delete",
-                content_type=None,
                 extra={"Stripe-Version": _ApiVersion.PREVIEW},
             ),
             None,

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1,0 +1,85 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+import stripe
+from stripe.api_version import _ApiVersion
+
+
+class TestPreview(object):
+    def set_body(self, body):
+        self.mock_request.return_value = (body, 200, {})
+
+    @pytest.fixture(autouse=True)
+    def setup_stripe(self, mocker):
+        orig_attrs = {
+            "api_key": stripe.api_key,
+            "default_http_client": stripe.default_http_client,
+        }
+        hc = mocker.Mock(stripe.default_http_client)
+        hc.name = "mockclient"
+        self.mock_request = mocker.Mock()
+        hc.request_with_retries = self.mock_request
+        stripe.default_http_client = hc
+        stripe.api_key = "sk_test_123"
+        yield
+        stripe.default_http_client = orig_attrs["default_http_client"]
+        stripe.api_key = orig_attrs["api_key"]
+
+    def test_get(self, request_mock):
+        expected_body = '{"id": "acc_123"}'
+        self.set_body(expected_body)
+        resp = stripe.preview.get("/v2/accounts/acc_123")
+
+        req = self.mock_request.mock_calls[0]
+        method, abs_url, headers, post_data = req.args
+
+        assert method == "get"
+        assert "Content-Type" not in headers
+        assert headers["Stripe-Version"] == _ApiVersion.PREVIEW
+        assert headers["Stripe-Version"] == _ApiVersion.PREVIEW
+        assert resp.body == expected_body
+
+    def test_post(self, request_mock):
+        expected_body = '{"id": "acc_123"}'
+        self.set_body(expected_body)
+
+        resp = stripe.preview.post("/v2/accounts", p1=1, p2="string")
+
+        req = self.mock_request.mock_calls[0]
+        method, abs_url, headers, post_data = req.args
+
+        assert method == "post"
+        assert headers["Content-Type"] == "application/json"
+        assert headers["Stripe-Version"] == _ApiVersion.PREVIEW
+        assert resp.body == expected_body
+
+    def test_delete(self, request_mock):
+        expected_body = '{"id": "acc_123"}'
+        self.set_body(expected_body)
+
+        resp = stripe.preview.delete("/v2/accounts/acc_123")
+
+        req = self.mock_request.mock_calls[0]
+        method, abs_url, headers, post_data = req.args
+
+        assert method == "delete"
+        assert "Content-Type" not in headers
+        assert headers["Stripe-Version"] == _ApiVersion.PREVIEW
+        assert resp.body == expected_body
+
+    def test_override_default_options(self, request_mock):
+        expected_body = '{"id": "acc_123"}'
+        stripe_version_override = "2022-11-15"
+        self.set_body(expected_body)
+
+        resp = stripe.preview.post(
+            "/v2/accounts", stripe_version=stripe_version_override
+        )
+
+        req = self.mock_request.mock_calls[0]
+        method, abs_url, headers, post_data = req.args
+
+        assert method == "post"
+        assert headers["Content-Type"] == "application/json"
+        assert headers["Stripe-Version"] == stripe_version_override
+        assert resp.body == expected_body

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -49,7 +49,7 @@ class TestPreview(object):
         expected_body = '{"id": "acc_123"}'
         self.set_body(expected_body)
 
-        resp = stripe.preview.post("/v2/accounts", p1=1, p2="string")
+        resp = stripe.preview.post("/v2/accounts", arg="string")
 
         self.mock_request.assert_called_with(
             "post",
@@ -59,7 +59,7 @@ class TestPreview(object):
                 content_type="application/json",
                 extra={"Stripe-Version": _ApiVersion.PREVIEW},
             ),
-            '{"p1": 1, "p2": "string"}',
+            '{"arg": "string"}',
         )
 
         assert resp.body == expected_body

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -30,14 +30,13 @@ class TestPreview(object):
         expected_body = '{"id": "acc_123"}'
         self.set_body(expected_body)
 
-        resp = stripe.preview.get("/v2/accounts/acc_123")
+        resp = stripe.preview.get("/v1/accounts/acc_123")
 
         self.mock_request.assert_called_with(
             "get",
-            "%s/v2/accounts/acc_123" % stripe.api_base,
+            "%s/v1/accounts/acc_123" % stripe.api_base,
             APIHeaderMatcher(
                 request_method="get",
-                content_type=None,
                 extra={"Stripe-Version": _ApiVersion.PREVIEW},
             ),
             None,
@@ -49,11 +48,11 @@ class TestPreview(object):
         expected_body = '{"id": "acc_123"}'
         self.set_body(expected_body)
 
-        resp = stripe.preview.post("/v2/accounts", arg="string")
+        resp = stripe.preview.post("/v1/accounts", arg="string")
 
         self.mock_request.assert_called_with(
             "post",
-            "%s/v2/accounts" % stripe.api_base,
+            "%s/v1/accounts" % stripe.api_base,
             APIHeaderMatcher(
                 request_method="post",
                 content_type="application/json",
@@ -68,11 +67,11 @@ class TestPreview(object):
         expected_body = '{"id": "acc_123"}'
         self.set_body(expected_body)
 
-        resp = stripe.preview.delete("/v2/accounts/acc_123")
+        resp = stripe.preview.delete("/v1/accounts/acc_123")
 
         self.mock_request.assert_called_with(
             "delete",
-            "%s/v2/accounts/acc_123" % stripe.api_base,
+            "%s/v1/accounts/acc_123" % stripe.api_base,
             APIHeaderMatcher(
                 request_method="delete",
                 content_type=None,
@@ -90,14 +89,14 @@ class TestPreview(object):
         self.set_body(expected_body)
 
         resp = stripe.preview.post(
-            "/v2/accounts",
+            "/v1/accounts",
             stripe_version=stripe_version_override,
             stripe_context=stripe_context,
         )
 
         self.mock_request.assert_called_with(
             "post",
-            "%s/v2/accounts" % stripe.api_base,
+            "%s/v1/accounts" % stripe.api_base,
             APIHeaderMatcher(
                 request_method="post",
                 content_type="application/json",

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -74,7 +74,9 @@ class TestPreview(object):
         self.set_body(expected_body)
 
         resp = stripe.preview.post(
-            "/v2/accounts", stripe_version=stripe_version_override, stripe_context=stripe_context
+            "/v2/accounts",
+            stripe_version=stripe_version_override,
+            stripe_context=stripe_context,
         )
 
         req = self.mock_request.mock_calls[0]

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -31,8 +31,9 @@ class TestPreview(object):
         resp = stripe.preview.get("/v2/accounts/acc_123")
 
         req = self.mock_request.mock_calls[0]
-        method = req.args[0]
-        headers = req.args[2]
+        args = tuple(req.args)
+        method = args[0]
+        headers = args[2]
 
         assert method == "get"
         assert "Content-Type" not in headers
@@ -47,8 +48,9 @@ class TestPreview(object):
         resp = stripe.preview.post("/v2/accounts", p1=1, p2="string")
 
         req = self.mock_request.mock_calls[0]
-        method = req.args[0]
-        headers = req.args[2]
+        args = tuple(req.args)
+        method = args[0]
+        headers = args[2]
 
         assert method == "post"
         assert headers["Content-Type"] == "application/json"
@@ -62,8 +64,9 @@ class TestPreview(object):
         resp = stripe.preview.delete("/v2/accounts/acc_123")
 
         req = self.mock_request.mock_calls[0]
-        method = req.args[0]
-        headers = req.args[2]
+        args = tuple(req.args)
+        method = args[0]
+        headers = args[2]
 
         assert method == "delete"
         assert "Content-Type" not in headers
@@ -83,8 +86,9 @@ class TestPreview(object):
         )
 
         req = self.mock_request.mock_calls[0]
-        method = req.args[0]
-        headers = req.args[2]
+        args = tuple(req.args)
+        method = args[0]
+        headers = args[2]
 
         assert method == "post"
         assert headers["Content-Type"] == "application/json"

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -31,7 +31,8 @@ class TestPreview(object):
         resp = stripe.preview.get("/v2/accounts/acc_123")
 
         req = self.mock_request.mock_calls[0]
-        method, abs_url, headers = req.args
+        method = req.args[0]
+        headers = req.args[2]
 
         assert method == "get"
         assert "Content-Type" not in headers
@@ -46,7 +47,8 @@ class TestPreview(object):
         resp = stripe.preview.post("/v2/accounts", p1=1, p2="string")
 
         req = self.mock_request.mock_calls[0]
-        method, abs_url, headers, post_data = req.args
+        method = req.args[0]
+        headers = req.args[2]
 
         assert method == "post"
         assert headers["Content-Type"] == "application/json"
@@ -60,7 +62,8 @@ class TestPreview(object):
         resp = stripe.preview.delete("/v2/accounts/acc_123")
 
         req = self.mock_request.mock_calls[0]
-        method, abs_url, headers = req.args
+        method = req.args[0]
+        headers = req.args[2]
 
         assert method == "delete"
         assert "Content-Type" not in headers
@@ -80,7 +83,8 @@ class TestPreview(object):
         )
 
         req = self.mock_request.mock_calls[0]
-        method, abs_url, headers, post_data = req.args
+        method = req.args[0]
+        headers = req.args[2]
 
         assert method == "post"
         assert headers["Content-Type"] == "application/json"

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import pytest
 import stripe
 from stripe.api_version import _ApiVersion
+from tests.test_api_requestor import APIHeaderMatcher
 
 
 class TestPreview(object):
@@ -25,55 +26,64 @@ class TestPreview(object):
         stripe.default_http_client = orig_attrs["default_http_client"]
         stripe.api_key = orig_attrs["api_key"]
 
-    def test_get(self, request_mock):
+    def test_get(self):
         expected_body = '{"id": "acc_123"}'
         self.set_body(expected_body)
+
         resp = stripe.preview.get("/v2/accounts/acc_123")
 
-        req = self.mock_request.mock_calls[0]
-        args = tuple(req.args)
-        method = args[0]
-        headers = args[2]
+        self.mock_request.assert_called_with(
+            "get",
+            "%s/v2/accounts/acc_123" % stripe.api_base,
+            APIHeaderMatcher(
+                request_method="get",
+                content_type=None,
+                extra={"Stripe-Version": _ApiVersion.PREVIEW},
+            ),
+            None,
+        )
 
-        assert method == "get"
-        assert "Content-Type" not in headers
-        assert headers["Stripe-Version"] == _ApiVersion.PREVIEW
-        assert headers["Stripe-Version"] == _ApiVersion.PREVIEW
         assert resp.body == expected_body
 
-    def test_post(self, request_mock):
+    def test_post(self):
         expected_body = '{"id": "acc_123"}'
         self.set_body(expected_body)
 
         resp = stripe.preview.post("/v2/accounts", p1=1, p2="string")
 
-        req = self.mock_request.mock_calls[0]
-        args = tuple(req.args)
-        method = args[0]
-        headers = args[2]
+        self.mock_request.assert_called_with(
+            "post",
+            "%s/v2/accounts" % stripe.api_base,
+            APIHeaderMatcher(
+                request_method="post",
+                content_type="application/json",
+                extra={"Stripe-Version": _ApiVersion.PREVIEW},
+            ),
+            '{"p1": 1, "p2": "string"}',
+        )
 
-        assert method == "post"
-        assert headers["Content-Type"] == "application/json"
-        assert headers["Stripe-Version"] == _ApiVersion.PREVIEW
         assert resp.body == expected_body
 
-    def test_delete(self, request_mock):
+    def test_delete(self):
         expected_body = '{"id": "acc_123"}'
         self.set_body(expected_body)
 
         resp = stripe.preview.delete("/v2/accounts/acc_123")
 
-        req = self.mock_request.mock_calls[0]
-        args = tuple(req.args)
-        method = args[0]
-        headers = args[2]
+        self.mock_request.assert_called_with(
+            "delete",
+            "%s/v2/accounts/acc_123" % stripe.api_base,
+            APIHeaderMatcher(
+                request_method="delete",
+                content_type=None,
+                extra={"Stripe-Version": _ApiVersion.PREVIEW},
+            ),
+            None,
+        )
 
-        assert method == "delete"
-        assert "Content-Type" not in headers
-        assert headers["Stripe-Version"] == _ApiVersion.PREVIEW
         assert resp.body == expected_body
 
-    def test_override_default_options(self, request_mock):
+    def test_override_default_options(self):
         expected_body = '{"id": "acc_123"}'
         stripe_version_override = "2022-11-15"
         stripe_context = "acct_x"
@@ -85,13 +95,18 @@ class TestPreview(object):
             stripe_context=stripe_context,
         )
 
-        req = self.mock_request.mock_calls[0]
-        args = tuple(req.args)
-        method = args[0]
-        headers = args[2]
+        self.mock_request.assert_called_with(
+            "post",
+            "%s/v2/accounts" % stripe.api_base,
+            APIHeaderMatcher(
+                request_method="post",
+                content_type="application/json",
+                extra={
+                    "Stripe-Context": stripe_context,
+                    "Stripe-Version": stripe_version_override,
+                },
+            ),
+            "{}",
+        )
 
-        assert method == "post"
-        assert headers["Content-Type"] == "application/json"
-        assert headers["Stripe-Version"] == stripe_version_override
-        assert headers["Stripe-Context"] == stripe_context
         assert resp.body == expected_body

--- a/tests/test_raw_request.py
+++ b/tests/test_raw_request.py
@@ -1,0 +1,42 @@
+from __future__ import absolute_import, division, print_function
+
+import stripe
+
+
+class TestRawRequest(object):
+    def test_form_request(self, request_mock):
+        request_mock.stub_request(
+            "get",
+            "/v1/accounts/acct_123",
+            "{\"id\": \"acct_123\", \"object\": \"account\"}",
+        )
+
+        resp = stripe.raw_request(
+            "get", "/v1/accounts/acct_123"
+        )
+        request_mock.assert_requested(
+            "get",
+            "/v1/accounts/acct_123", None,
+        )
+
+        assert resp.body == "{\"id\": \"acct_123\", \"object\": \"account\"}"
+
+    # same test as above but also pass stripe-account header
+    def test_form_request_with_extra_headers(self, request_mock):
+        request_mock.stub_request(
+            "get",
+            "/v1/accounts/acct_123",
+            "{\"id\": \"acct_123\", \"object\": \"account\"}",
+        )
+
+        resp = stripe.raw_request(
+            "get", "/v1/accounts/acct_123", headers={"Stripe-Account": "acct_123"}
+        )
+        request_mock.assert_requested(
+            "get",
+            "/v1/accounts/acct_123",
+            {},
+            {"Stripe-Account": "acct_123"},
+        )
+
+        assert resp.body == "{\"id\": \"acct_123\", \"object\": \"account\"}"

--- a/tests/test_raw_request.py
+++ b/tests/test_raw_request.py
@@ -53,7 +53,7 @@ class TestRawRequest(object):
     def test_form_request_post(self, http_client, mock_response, check_call):
         mock_response('{"id": "acct_123", "object": "account"}', 200)
 
-        params = dict(**{"client": http_client}, **self.ENCODE_INPUTS)
+        params = dict({"client": http_client}, **self.ENCODE_INPUTS)
         expectation = "type=standard&int=123&datetime=1356994801"
 
         resp = stripe.raw_request("post", self.POST_REL_URL, **params)

--- a/tests/test_raw_request.py
+++ b/tests/test_raw_request.py
@@ -8,35 +8,38 @@ class TestRawRequest(object):
         request_mock.stub_request(
             "get",
             "/v1/accounts/acct_123",
-            "{\"id\": \"acct_123\", \"object\": \"account\"}",
+            '{"id": "acct_123", "object": "account"}',
         )
 
-        resp = stripe.raw_request(
-            "get", "/v1/accounts/acct_123"
-        )
+        resp = stripe.raw_request("get", "/v1/accounts/acct_123")
         request_mock.assert_requested(
-            "get",
-            "/v1/accounts/acct_123", None,
+            "get", "/v1/accounts/acct_123", {}, None, "form"
         )
 
-        assert resp.body == "{\"id\": \"acct_123\", \"object\": \"account\"}"
+        assert resp.body == '{"id": "acct_123", "object": "account"}'
 
-    # same test as above but also pass stripe-account header
+        deserialized = stripe.deserialize(resp)
+        assert isinstance(deserialized, stripe.Account)
+
     def test_form_request_with_extra_headers(self, request_mock):
         request_mock.stub_request(
             "get",
             "/v1/accounts/acct_123",
-            "{\"id\": \"acct_123\", \"object\": \"account\"}",
+            '{"id": "acct_123", "object": "account"}',
         )
 
         resp = stripe.raw_request(
-            "get", "/v1/accounts/acct_123", headers={"Stripe-Account": "acct_123"}
+            "get",
+            "/v1/accounts/acct_123",
+            headers={"Stripe-Account": "acct_123"},
         )
+
         request_mock.assert_requested(
             "get",
             "/v1/accounts/acct_123",
             {},
             {"Stripe-Account": "acct_123"},
+            "form",
         )
 
-        assert resp.body == "{\"id\": \"acct_123\", \"object\": \"account\"}"
+        assert resp.body == '{"id": "acct_123", "object": "account"}'

--- a/tests/test_raw_request.py
+++ b/tests/test_raw_request.py
@@ -77,7 +77,7 @@ class TestRawRequest(object):
         mock_response('{"id": "acct_123", "object": "account"}', 200)
 
         params = dict(
-            **{"client": http_client, "api_mode": "preview"},
+            {"client": http_client, "api_mode": "preview"},
             **self.ENCODE_INPUTS
         )
         expectation = (

--- a/tests/test_raw_request.py
+++ b/tests/test_raw_request.py
@@ -42,9 +42,7 @@ class TestRawRequest(object):
     def test_form_request_get(self, mock_response, check_call):
         mock_response('{"id": "acct_123", "object": "account"}', 200)
 
-        params = {}
-
-        resp = stripe.raw_request("get", self.GET_REL_URL, **params)
+        resp = stripe.raw_request("get", self.GET_REL_URL)
 
         check_call("get", abs_url=self.GET_ABS_URL)
 

--- a/tests/test_raw_request.py
+++ b/tests/test_raw_request.py
@@ -7,6 +7,7 @@ from collections import OrderedDict
 import pytest
 
 import stripe
+from stripe.api_requestor import _json_encode_date_callback
 from stripe.api_version import _ApiVersion
 
 from tests.test_api_requestor import APIHeaderMatcher
@@ -79,11 +80,9 @@ class TestRawRequest(object):
     def test_preview_request_post(self, mock_response, check_call):
         mock_response('{"id": "acct_123", "object": "account"}', 200)
 
-        params = OrderedDict(
-            list(self.ENCODE_INPUTS.items()) + [("api_mode", "preview")]
-        )
-        expectation = (
-            '{"type": "standard", "int": 123, "datetime": 1356994801}'
+        params = dict({"api_mode": "preview"}, **self.ENCODE_INPUTS)
+        expectation = json.dumps(
+            self.ENCODE_INPUTS, default=_json_encode_date_callback
         )
 
         resp = stripe.raw_request("post", self.POST_REL_URL, **params)

--- a/tests/test_raw_request.py
+++ b/tests/test_raw_request.py
@@ -25,7 +25,7 @@ class TestRawRequest(object):
     GET_ABS_URL = stripe.api_base + GET_REL_URL
 
     @pytest.fixture(autouse=True)
-    def setup_stripe(self):
+    def setup_stripe(self, http_client):
         orig_attrs = {
             "api_key": stripe.api_key,
             "api_version": stripe.api_version,
@@ -33,7 +33,7 @@ class TestRawRequest(object):
         }
         stripe.api_key = "sk_test_123"
         stripe.api_version = "2017-12-14"
-        stripe.default_http_client = None
+        stripe.default_http_client = http_client
         yield
         stripe.api_key = orig_attrs["api_key"]
         stripe.api_version = orig_attrs["api_version"]
@@ -42,7 +42,7 @@ class TestRawRequest(object):
     def test_form_request_get(self, http_client, mock_response, check_call):
         mock_response('{"id": "acct_123", "object": "account"}', 200)
 
-        params = {"client": http_client}
+        params = {}
 
         resp = stripe.raw_request("get", self.GET_REL_URL, **params)
 

--- a/tests/test_raw_request.py
+++ b/tests/test_raw_request.py
@@ -13,7 +13,7 @@ class TestRawRequest(object):
 
         resp = stripe.raw_request("get", "/v1/accounts/acct_123")
         request_mock.assert_requested(
-            "get", "/v1/accounts/acct_123", {}, None, "form"
+            "get", "/v1/accounts/acct_123", {}, None, None
         )
 
         assert resp.body == '{"id": "acct_123", "object": "account"}'
@@ -39,7 +39,7 @@ class TestRawRequest(object):
             "/v1/accounts/acct_123",
             {},
             {"Stripe-Account": "acct_123"},
-            "form",
+            None,
         )
 
         assert resp.body == '{"id": "acct_123", "object": "account"}'

--- a/tests/test_raw_request.py
+++ b/tests/test_raw_request.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import json
+import datetime
 
 import pytest
 
@@ -10,9 +11,8 @@ from stripe.six.moves.urllib.parse import urlencode
 
 from tests.test_api_requestor import APIHeaderMatcher
 
-
 class TestRawRequest(object):
-    ENCODE_INPUTS = {"type": "standard"}
+    ENCODE_INPUTS = {"type": "standard", "int": 123, "datetime": datetime.datetime(2013, 1, 1, second=1)}
     POST_REL_URL = "/v1/accounts"
     GET_REL_URL = "/v1/accounts/acct_123"
     POST_ABS_URL = stripe.api_base + POST_REL_URL
@@ -49,7 +49,7 @@ class TestRawRequest(object):
         mock_response('{"id": "acct_123", "object": "account"}', 200)
 
         params = dict(**{"client": http_client}, **self.ENCODE_INPUTS)
-        expectation = urlencode(self.ENCODE_INPUTS)
+        expectation = "type=standard&int=123&datetime=1357027201"
 
         resp = stripe.raw_request("post", self.POST_REL_URL, **params)
 
@@ -75,7 +75,7 @@ class TestRawRequest(object):
             **{"client": http_client, "api_mode": "preview"},
             **self.ENCODE_INPUTS
         )
-        expectation = json.dumps(self.ENCODE_INPUTS)
+        expectation = '{"type": "standard", "int": 123, "datetime": 1357027201}'
 
         resp = stripe.raw_request("post", self.POST_REL_URL, **params)
 

--- a/tests/test_raw_request.py
+++ b/tests/test_raw_request.py
@@ -68,11 +68,14 @@ class TestRawRequest(object):
         deserialized = stripe.deserialize(resp)
         assert isinstance(deserialized, stripe.Account)
 
-    def test_json_request_post(self, http_client, mock_response, check_call):
+    def test_preview_request_post(
+        self, http_client, mock_response, check_call
+    ):
         mock_response('{"id": "acct_123", "object": "account"}', 200)
 
         params = dict(
-            {"client": http_client, "encoding": "json"}, **self.ENCODE_INPUTS
+            {"client": http_client, "api_mode": "preview"},
+            **self.ENCODE_INPUTS
         )
         expectation = json.dumps(self.ENCODE_INPUTS)
 

--- a/tests/test_raw_request.py
+++ b/tests/test_raw_request.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import json
 import datetime
+from collections import OrderedDict
 
 import pytest
 
@@ -53,7 +54,7 @@ class TestRawRequest(object):
     def test_form_request_post(self, http_client, mock_response, check_call):
         mock_response('{"id": "acct_123", "object": "account"}', 200)
 
-        params = dict({"client": http_client}, **self.ENCODE_INPUTS)
+        params = OrderedDict({"client": http_client}, **self.ENCODE_INPUTS)
         expectation = "type=standard&int=123&datetime=1356994801"
 
         resp = stripe.raw_request("post", self.POST_REL_URL, **params)
@@ -76,7 +77,7 @@ class TestRawRequest(object):
     ):
         mock_response('{"id": "acct_123", "object": "account"}', 200)
 
-        params = dict(
+        params = OrderedDict(
             {"client": http_client, "api_mode": "preview"},
             **self.ENCODE_INPUTS
         )

--- a/tests/test_raw_request.py
+++ b/tests/test_raw_request.py
@@ -39,7 +39,7 @@ class TestRawRequest(object):
         stripe.api_version = orig_attrs["api_version"]
         stripe.default_http_client = orig_attrs["default_http_client"]
 
-    def test_form_request_get(self, http_client, mock_response, check_call):
+    def test_form_request_get(self, mock_response, check_call):
         mock_response('{"id": "acct_123", "object": "account"}', 200)
 
         params = {}
@@ -51,10 +51,10 @@ class TestRawRequest(object):
         deserialized = stripe.deserialize(resp)
         assert isinstance(deserialized, stripe.Account)
 
-    def test_form_request_post(self, http_client, mock_response, check_call):
+    def test_form_request_post(self, mock_response, check_call):
         mock_response('{"id": "acct_123", "object": "account"}', 200)
 
-        params = OrderedDict({"client": http_client}, **self.ENCODE_INPUTS)
+        params = OrderedDict(**self.ENCODE_INPUTS)
         expectation = "type=standard&int=123&datetime=1356994801"
 
         resp = stripe.raw_request("post", self.POST_REL_URL, **params)
@@ -72,15 +72,10 @@ class TestRawRequest(object):
         deserialized = stripe.deserialize(resp)
         assert isinstance(deserialized, stripe.Account)
 
-    def test_preview_request_post(
-        self, http_client, mock_response, check_call
-    ):
+    def test_preview_request_post(self, mock_response, check_call):
         mock_response('{"id": "acct_123", "object": "account"}', 200)
 
-        params = OrderedDict(
-            {"client": http_client, "api_mode": "preview"},
-            **self.ENCODE_INPUTS
-        )
+        params = OrderedDict({"api_mode": "preview"}, **self.ENCODE_INPUTS)
         expectation = (
             '{"type": "standard", "int": 123, "datetime": 1356994801}'
         )
@@ -100,13 +95,11 @@ class TestRawRequest(object):
         deserialized = stripe.deserialize(resp)
         assert isinstance(deserialized, stripe.Account)
 
-    def test_form_request_with_extra_headers(
-        self, http_client, mock_response, check_call
-    ):
+    def test_form_request_with_extra_headers(self, mock_response, check_call):
         mock_response('{"id": "acct_123", "object": "account"}', 200)
 
         extraHeaders = {"foo": "bar", "Stripe-Account": "acct_123"}
-        params = {"client": http_client, "headers": extraHeaders}
+        params = {"headers": extraHeaders}
 
         stripe.raw_request("get", self.GET_REL_URL, **params)
 
@@ -117,10 +110,10 @@ class TestRawRequest(object):
         )
 
     def test_preview_request_default_api_version(
-        self, http_client, mock_response, check_call
+        self, mock_response, check_call
     ):
         mock_response('{"id": "acct_123", "object": "account"}', 200)
-        params = {"client": http_client, "api_mode": "preview"}
+        params = {"api_mode": "preview"}
 
         stripe.raw_request("get", self.GET_REL_URL, **params)
 
@@ -134,12 +127,11 @@ class TestRawRequest(object):
         )
 
     def test_preview_request_overridden_api_version(
-        self, http_client, mock_response, check_call
+        self, mock_response, check_call
     ):
         mock_response('{"id": "acct_123", "object": "account"}', 200)
         stripe_version_override = "2023-05-15.preview"
         params = {
-            "client": http_client,
             "api_mode": "preview",
             "stripe_version": stripe_version_override,
         }

--- a/tests/test_raw_request.py
+++ b/tests/test_raw_request.py
@@ -14,11 +14,16 @@ from tests.test_api_requestor import GMT1
 
 
 class TestRawRequest(object):
-    ENCODE_INPUTS = {
-        "type": "standard",
-        "int": 123,
-        "datetime": datetime.datetime(2013, 1, 1, second=1, tzinfo=GMT1()),
-    }
+    ENCODE_INPUTS = OrderedDict(
+        [
+            ("type", "standard"),
+            ("int", 123),
+            (
+                "datetime",
+                datetime.datetime(2013, 1, 1, second=1, tzinfo=GMT1()),
+            ),
+        ],
+    )
     POST_REL_URL = "/v1/accounts"
     GET_REL_URL = "/v1/accounts/acct_123"
     POST_ABS_URL = stripe.api_base + POST_REL_URL
@@ -52,10 +57,11 @@ class TestRawRequest(object):
     def test_form_request_post(self, mock_response, check_call):
         mock_response('{"id": "acct_123", "object": "account"}', 200)
 
-        params = OrderedDict(**self.ENCODE_INPUTS)
         expectation = "type=standard&int=123&datetime=1356994801"
 
-        resp = stripe.raw_request("post", self.POST_REL_URL, **params)
+        resp = stripe.raw_request(
+            "post", self.POST_REL_URL, **self.ENCODE_INPUTS
+        )
 
         check_call(
             "post",
@@ -73,7 +79,9 @@ class TestRawRequest(object):
     def test_preview_request_post(self, mock_response, check_call):
         mock_response('{"id": "acct_123", "object": "account"}', 200)
 
-        params = OrderedDict({"api_mode": "preview"}, **self.ENCODE_INPUTS)
+        params = OrderedDict(
+            list(self.ENCODE_INPUTS.items()) + [("api_mode", "preview")]
+        )
         expectation = (
             '{"type": "standard", "int": 123, "datetime": 1356994801}'
         )

--- a/tests/test_raw_request.py
+++ b/tests/test_raw_request.py
@@ -1,45 +1,108 @@
 from __future__ import absolute_import, division, print_function
 
+import json
+
+import pytest
+
 import stripe
+from stripe.six.moves.urllib.parse import urlencode
+
+from tests.test_api_requestor import APIHeaderMatcher
 
 
 class TestRawRequest(object):
-    def test_form_request(self, request_mock):
-        request_mock.stub_request(
-            "get",
-            "/v1/accounts/acct_123",
-            '{"id": "acct_123", "object": "account"}',
-        )
+    ENCODE_INPUTS = {"type": "standard"}
+    POST_REL_URL = "/v1/accounts"
+    GET_REL_URL = "/v1/accounts/acct_123"
+    POST_ABS_URL = stripe.api_base + POST_REL_URL
+    GET_ABS_URL = stripe.api_base + GET_REL_URL
 
-        resp = stripe.raw_request("get", "/v1/accounts/acct_123")
-        request_mock.assert_requested(
-            "get", "/v1/accounts/acct_123", {}, None, None
-        )
+    @pytest.fixture(autouse=True)
+    def setup_stripe(self):
+        orig_attrs = {
+            "api_key": stripe.api_key,
+            "api_version": stripe.api_version,
+            "default_http_client": stripe.default_http_client,
+            "enable_telemetry": stripe.enable_telemetry,
+        }
+        stripe.api_key = "sk_test_123"
+        stripe.api_version = "2017-12-14"
+        stripe.default_http_client = None
+        stripe.enable_telemetry = False
+        yield
+        stripe.api_key = orig_attrs["api_key"]
+        stripe.api_version = orig_attrs["api_version"]
+        stripe.default_http_client = orig_attrs["default_http_client"]
+        stripe.enable_telemetry = orig_attrs["enable_telemetry"]
 
-        assert resp.body == '{"id": "acct_123", "object": "account"}'
+    def test_form_request_get(self, http_client, mock_response, check_call):
+        mock_response('{"id": "acct_123", "object": "account"}', 200)
+
+        params = {"client": http_client}
+
+        resp = stripe.raw_request("get", self.GET_REL_URL, **params)
+
+        check_call("get", abs_url=self.GET_ABS_URL)
 
         deserialized = stripe.deserialize(resp)
         assert isinstance(deserialized, stripe.Account)
 
-    def test_form_request_with_extra_headers(self, request_mock):
-        request_mock.stub_request(
-            "get",
-            "/v1/accounts/acct_123",
-            '{"id": "acct_123", "object": "account"}',
+    def test_form_request_post(self, http_client, mock_response, check_call):
+        mock_response('{"id": "acct_123", "object": "account"}', 200)
+
+        params = dict({"client": http_client}, **self.ENCODE_INPUTS)
+        expectation = urlencode(self.ENCODE_INPUTS)
+
+        resp = stripe.raw_request("post", self.POST_REL_URL, **params)
+
+        check_call(
+            "post",
+            abs_url=self.POST_ABS_URL,
+            headers=APIHeaderMatcher(
+                content_type="application/x-www-form-urlencoded",
+                request_method="post",
+            ),
+            post_data=expectation,
         )
 
-        resp = stripe.raw_request(
-            "get",
-            "/v1/accounts/acct_123",
-            headers={"Stripe-Account": "acct_123"},
+        deserialized = stripe.deserialize(resp)
+        assert isinstance(deserialized, stripe.Account)
+
+    def test_json_request_post(self, http_client, mock_response, check_call):
+        mock_response('{"id": "acct_123", "object": "account"}', 200)
+
+        params = dict(
+            {"client": http_client, "encoding": "json"}, **self.ENCODE_INPUTS
+        )
+        expectation = json.dumps(self.ENCODE_INPUTS)
+
+        resp = stripe.raw_request("post", self.POST_REL_URL, **params)
+
+        check_call(
+            "post",
+            abs_url=self.POST_ABS_URL,
+            headers=APIHeaderMatcher(
+                content_type="application/json",
+                request_method="post",
+            ),
+            post_data=expectation,
         )
 
-        request_mock.assert_requested(
-            "get",
-            "/v1/accounts/acct_123",
-            {},
-            {"Stripe-Account": "acct_123"},
-            None,
-        )
+        deserialized = stripe.deserialize(resp)
+        assert isinstance(deserialized, stripe.Account)
 
-        assert resp.body == '{"id": "acct_123", "object": "account"}'
+    def test_form_request_with_extra_headers(
+        self, http_client, mock_response, check_call
+    ):
+        mock_response('{"id": "acct_123", "object": "account"}', 200)
+
+        extraHeaders = {"foo": "bar", "Stripe-Account": "acct_123"}
+        params = {"client": http_client, "headers": extraHeaders}
+
+        stripe.raw_request("get", self.GET_REL_URL, **params)
+
+        check_call(
+            "get",
+            abs_url=self.GET_ABS_URL,
+            headers=APIHeaderMatcher(extra=extraHeaders, request_method="get"),
+        )


### PR DESCRIPTION
Adds a `raw_request` method that allows sending untyped requests to Stripe API.