### PR TITLE
Handle developer message in preview error responses

### DIFF
--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -177,7 +177,9 @@ class APIRequestor(object):
         raise err
 
     def specific_api_error(self, rbody, rcode, resp, rheaders, error_data):
-        message = error_data.get("message") or error_data.get("developer_message")
+        message = error_data.get("message") or error_data.get(
+            "developer_message"
+        )
 
         util.log_info(
             "Stripe API error received",

--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -177,11 +177,15 @@ class APIRequestor(object):
         raise err
 
     def specific_api_error(self, rbody, rcode, resp, rheaders, error_data):
+        message_field_name = "message"
+        if error_data.get("developer_message") is not None:
+            message_field_name = "developer_message"
+
         util.log_info(
             "Stripe API error received",
             error_code=error_data.get("code"),
             error_type=error_data.get("type"),
-            error_message=error_data.get("message"),
+            error_message=error_data.get(message_field_name),
             error_param=error_data.get("param"),
         )
 
@@ -190,16 +194,24 @@ class APIRequestor(object):
             rcode == 400 and error_data.get("code") == "rate_limit"
         ):
             return error.RateLimitError(
-                error_data.get("message"), rbody, rcode, resp, rheaders
+                error_data.get(message_field_name),
+                rbody,
+                rcode,
+                resp,
+                rheaders,
             )
         elif rcode in [400, 404]:
             if error_data.get("type") == "idempotency_error":
                 return error.IdempotencyError(
-                    error_data.get("message"), rbody, rcode, resp, rheaders
+                    error_data.get(message_field_name),
+                    rbody,
+                    rcode,
+                    resp,
+                    rheaders,
                 )
             else:
                 return error.InvalidRequestError(
-                    error_data.get("message"),
+                    error_data.get(message_field_name),
                     error_data.get("param"),
                     error_data.get("code"),
                     rbody,
@@ -209,11 +221,15 @@ class APIRequestor(object):
                 )
         elif rcode == 401:
             return error.AuthenticationError(
-                error_data.get("message"), rbody, rcode, resp, rheaders
+                error_data.get(message_field_name),
+                rbody,
+                rcode,
+                resp,
+                rheaders,
             )
         elif rcode == 402:
             return error.CardError(
-                error_data.get("message"),
+                error_data.get(message_field_name),
                 error_data.get("param"),
                 error_data.get("code"),
                 rbody,
@@ -223,11 +239,19 @@ class APIRequestor(object):
             )
         elif rcode == 403:
             return error.PermissionError(
-                error_data.get("message"), rbody, rcode, resp, rheaders
+                error_data.get(message_field_name),
+                rbody,
+                rcode,
+                resp,
+                rheaders,
             )
         else:
             return error.APIError(
-                error_data.get("message"), rbody, rcode, resp, rheaders
+                error_data.get(message_field_name),
+                rbody,
+                rcode,
+                resp,
+                rheaders,
             )
 
     def specific_oauth_error(self, rbody, rcode, resp, rheaders, error_code):

--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -177,15 +177,13 @@ class APIRequestor(object):
         raise err
 
     def specific_api_error(self, rbody, rcode, resp, rheaders, error_data):
-        message_field_name = "message"
-        if error_data.get("developer_message") is not None:
-            message_field_name = "developer_message"
+        message = error_data.get("message") or error_data.get("developer_message")
 
         util.log_info(
             "Stripe API error received",
             error_code=error_data.get("code"),
             error_type=error_data.get("type"),
-            error_message=error_data.get(message_field_name),
+            error_message=message,
             error_param=error_data.get("param"),
         )
 
@@ -194,7 +192,7 @@ class APIRequestor(object):
             rcode == 400 and error_data.get("code") == "rate_limit"
         ):
             return error.RateLimitError(
-                error_data.get(message_field_name),
+                message,
                 rbody,
                 rcode,
                 resp,
@@ -203,7 +201,7 @@ class APIRequestor(object):
         elif rcode in [400, 404]:
             if error_data.get("type") == "idempotency_error":
                 return error.IdempotencyError(
-                    error_data.get(message_field_name),
+                    message,
                     rbody,
                     rcode,
                     resp,
@@ -211,7 +209,7 @@ class APIRequestor(object):
                 )
             else:
                 return error.InvalidRequestError(
-                    error_data.get(message_field_name),
+                    message,
                     error_data.get("param"),
                     error_data.get("code"),
                     rbody,
@@ -221,7 +219,7 @@ class APIRequestor(object):
                 )
         elif rcode == 401:
             return error.AuthenticationError(
-                error_data.get(message_field_name),
+                message,
                 rbody,
                 rcode,
                 resp,
@@ -229,7 +227,7 @@ class APIRequestor(object):
             )
         elif rcode == 402:
             return error.CardError(
-                error_data.get(message_field_name),
+                message,
                 error_data.get("param"),
                 error_data.get("code"),
                 rbody,
@@ -239,7 +237,7 @@ class APIRequestor(object):
             )
         elif rcode == 403:
             return error.PermissionError(
-                error_data.get(message_field_name),
+                message,
                 rbody,
                 rcode,
                 resp,
@@ -247,7 +245,7 @@ class APIRequestor(object):
             )
         else:
             return error.APIError(
-                error_data.get(message_field_name),
+                message,
                 rbody,
                 rcode,
                 resp,

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -734,8 +734,12 @@ class TestAPIRequestor(object):
             400,
         )
 
-        with pytest.raises(stripe.oauth_error.InvalidGrantError):
-            requestor.request_stream("get", self.valid_path, {})
+    def test_developer_message_in_error(self, requestor, mock_response):
+        mock_response('{"error": {"developer_message": "Unacceptable"}}', 400)
+
+        with pytest.raises(stripe.error.InvalidRequestError) as excinfo:
+            requestor.request("get", self.valid_path, {})
+        assert excinfo.value.user_message == "Unacceptable"
 
     def test_raw_request_with_file_param(self, requestor, mock_response):
         test_file = tempfile.NamedTemporaryFile()


### PR DESCRIPTION
The error message can be returned in a developer_message field, handle this case and throw a useful error.