### PR TITLE
Stop testing Python 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           python setup.py clean --all sdist bdist_wheel --universal
           python -m twine check dist/*
 
-      - name: 'Upload Artifact'
+      - name: "Upload Artifact"
         uses: actions/upload-artifact@v3
         with:
           name: dist
@@ -69,7 +69,6 @@ jobs:
       matrix:
         python-version:
           [
-            "2.7",
             "3.6",
             "3.7",
             "3.8",


### PR DESCRIPTION
Python 2.7 is no longer supported by setup-python: https://github.com/actions/setup-python/issues/672

Since we are planning on dropping Python 2.7 very soon, let's go ahead and remove it from the test matrix.