### PR TITLE
Deprecate @test_helper decorator

### DIFF
--- a/stripe/api_resources/abstract/test_helpers.py
+++ b/stripe/api_resources/abstract/test_helpers.py
@@ -20,6 +20,14 @@ class APIResourceTestHelpers:
         self.resource = resource
 
     @classmethod
+    def _static_request(cls, *args, **kwargs):
+        return cls._resource_cls._static_request(*args, **kwargs)
+
+    @classmethod
+    def _static_request_stream(cls, *args, **kwargs):
+        return cls._resource_cls._static_request_stream(*args, **kwargs)
+
+    @classmethod
     def class_url(cls):
         if cls == APIResourceTestHelpers:
             raise NotImplementedError(
@@ -48,16 +56,11 @@ class APIResourceTestHelpers:
         return "%s/%s" % (base, extn)
 
 
+# TODO (next major)
 def test_helpers(cls):
     """
-    test_helpers decorator adds a test_helpers property and
-    wires the parent resource class to the nested TestHelpers class.
-
-    Should only be used on types that inherit from APIResource.
-
-    @test_helpers
-    class Foo(APIResource):
-      class TestHelpers(APIResourceTestHelpers):
+    The test_helpers decorator is deprecated and will be removed in a future version
+    of the library.
     """
 
     def test_helpers_getter(self):

--- a/stripe/api_resources/customer.py
+++ b/stripe/api_resources/customer.py
@@ -11,9 +11,42 @@ from stripe.api_resources.abstract import SearchableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import nested_resource_class_methods
 from stripe.api_resources.abstract import test_helpers
+from typing import Type
 
 
-@test_helpers
+class _TestHelpers(APIResourceTestHelpers):
+    @classmethod
+    def _cls_fund_cash_balance(
+        cls,
+        customer,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/test_helpers/customers/{customer}/fund_cash_balance".format(
+                customer=util.sanitize_id(customer)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_fund_cash_balance")
+    def fund_cash_balance(self, idempotency_key=None, **params):
+        return self.resource._request(
+            "post",
+            "/v1/test_helpers/customers/{customer}/fund_cash_balance".format(
+                customer=util.sanitize_id(self.resource.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+
 @nested_resource_class_methods(
     "balance_transaction",
     operations=["create", "retrieve", "update", "list"],
@@ -222,34 +255,11 @@ class Customer(
             params=params,
         )
 
-    class TestHelpers(APIResourceTestHelpers):
-        @classmethod
-        def _cls_fund_cash_balance(
-            cls,
-            customer,
-            api_key=None,
-            stripe_version=None,
-            stripe_account=None,
-            **params
-        ):
-            return cls._static_request(
-                "post",
-                "/v1/test_helpers/customers/{customer}/fund_cash_balance".format(
-                    customer=util.sanitize_id(customer)
-                ),
-                api_key=api_key,
-                stripe_version=stripe_version,
-                stripe_account=stripe_account,
-                params=params,
-            )
+    TestHelpers = _TestHelpers
 
-        @util.class_method_variant("_cls_fund_cash_balance")
-        def fund_cash_balance(self, idempotency_key=None, **params):
-            return self.resource._request(
-                "post",
-                "/v1/test_helpers/customers/{customer}/fund_cash_balance".format(
-                    customer=util.sanitize_id(self.resource.get("id"))
-                ),
-                idempotency_key=idempotency_key,
-                params=params,
-            )
+    @property
+    def test_helpers(self):
+        return self.TestHelpers(self)
+
+
+_TestHelpers._resource_cls = Customer

--- a/stripe/api_resources/customer.py
+++ b/stripe/api_resources/customer.py
@@ -10,7 +10,6 @@ from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import SearchableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import nested_resource_class_methods
-from stripe.api_resources.abstract import test_helpers
 
 
 @nested_resource_class_methods(

--- a/stripe/api_resources/customer.py
+++ b/stripe/api_resources/customer.py
@@ -11,40 +11,6 @@ from stripe.api_resources.abstract import SearchableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import nested_resource_class_methods
 from stripe.api_resources.abstract import test_helpers
-from typing import Type
-
-
-class _TestHelpers(APIResourceTestHelpers):
-    @classmethod
-    def _cls_fund_cash_balance(
-        cls,
-        customer,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/test_helpers/customers/{customer}/fund_cash_balance".format(
-                customer=util.sanitize_id(customer)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_fund_cash_balance")
-    def fund_cash_balance(self, idempotency_key=None, **params):
-        return self.resource._request(
-            "post",
-            "/v1/test_helpers/customers/{customer}/fund_cash_balance".format(
-                customer=util.sanitize_id(self.resource.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
-        )
 
 
 @nested_resource_class_methods(
@@ -255,11 +221,41 @@ class Customer(
             params=params,
         )
 
-    TestHelpers = _TestHelpers
+    class TestHelpers(APIResourceTestHelpers):
+        @classmethod
+        def _cls_fund_cash_balance(
+            cls,
+            customer,
+            api_key=None,
+            stripe_version=None,
+            stripe_account=None,
+            **params
+        ):
+            return cls._static_request(
+                "post",
+                "/v1/test_helpers/customers/{customer}/fund_cash_balance".format(
+                    customer=util.sanitize_id(customer)
+                ),
+                api_key=api_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
+            )
+
+        @util.class_method_variant("_cls_fund_cash_balance")
+        def fund_cash_balance(self, idempotency_key=None, **params):
+            return self.resource._request(
+                "post",
+                "/v1/test_helpers/customers/{customer}/fund_cash_balance".format(
+                    customer=util.sanitize_id(self.resource.get("id"))
+                ),
+                idempotency_key=idempotency_key,
+                params=params,
+            )
 
     @property
     def test_helpers(self):
         return self.TestHelpers(self)
 
 
-_TestHelpers._resource_cls = Customer
+Customer.TestHelpers._resource_cls = Customer

--- a/stripe/api_resources/issuing/card.py
+++ b/stripe/api_resources/issuing/card.py
@@ -8,133 +8,6 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import test_helpers
-from typing import Type
-
-
-class _TestHelpers(APIResourceTestHelpers):
-    @classmethod
-    def _cls_deliver_card(
-        cls,
-        card,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/test_helpers/issuing/cards/{card}/shipping/deliver".format(
-                card=util.sanitize_id(card)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_deliver_card")
-    def deliver_card(self, idempotency_key=None, **params):
-        return self.resource._request(
-            "post",
-            "/v1/test_helpers/issuing/cards/{card}/shipping/deliver".format(
-                card=util.sanitize_id(self.resource.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
-        )
-
-    @classmethod
-    def _cls_fail_card(
-        cls,
-        card,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/test_helpers/issuing/cards/{card}/shipping/fail".format(
-                card=util.sanitize_id(card)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_fail_card")
-    def fail_card(self, idempotency_key=None, **params):
-        return self.resource._request(
-            "post",
-            "/v1/test_helpers/issuing/cards/{card}/shipping/fail".format(
-                card=util.sanitize_id(self.resource.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
-        )
-
-    @classmethod
-    def _cls_return_card(
-        cls,
-        card,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/test_helpers/issuing/cards/{card}/shipping/return".format(
-                card=util.sanitize_id(card)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_return_card")
-    def return_card(self, idempotency_key=None, **params):
-        return self.resource._request(
-            "post",
-            "/v1/test_helpers/issuing/cards/{card}/shipping/return".format(
-                card=util.sanitize_id(self.resource.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
-        )
-
-    @classmethod
-    def _cls_ship_card(
-        cls,
-        card,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/test_helpers/issuing/cards/{card}/shipping/ship".format(
-                card=util.sanitize_id(card)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_ship_card")
-    def ship_card(self, idempotency_key=None, **params):
-        return self.resource._request(
-            "post",
-            "/v1/test_helpers/issuing/cards/{card}/shipping/ship".format(
-                card=util.sanitize_id(self.resource.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
-        )
 
 
 class Card(CreateableAPIResource, ListableAPIResource, UpdateableAPIResource):
@@ -144,11 +17,134 @@ class Card(CreateableAPIResource, ListableAPIResource, UpdateableAPIResource):
 
     OBJECT_NAME = "issuing.card"
 
-    TestHelpers = _TestHelpers
+    class TestHelpers(APIResourceTestHelpers):
+        @classmethod
+        def _cls_deliver_card(
+            cls,
+            card,
+            api_key=None,
+            stripe_version=None,
+            stripe_account=None,
+            **params
+        ):
+            return cls._static_request(
+                "post",
+                "/v1/test_helpers/issuing/cards/{card}/shipping/deliver".format(
+                    card=util.sanitize_id(card)
+                ),
+                api_key=api_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
+            )
+
+        @util.class_method_variant("_cls_deliver_card")
+        def deliver_card(self, idempotency_key=None, **params):
+            return self.resource._request(
+                "post",
+                "/v1/test_helpers/issuing/cards/{card}/shipping/deliver".format(
+                    card=util.sanitize_id(self.resource.get("id"))
+                ),
+                idempotency_key=idempotency_key,
+                params=params,
+            )
+
+        @classmethod
+        def _cls_fail_card(
+            cls,
+            card,
+            api_key=None,
+            stripe_version=None,
+            stripe_account=None,
+            **params
+        ):
+            return cls._static_request(
+                "post",
+                "/v1/test_helpers/issuing/cards/{card}/shipping/fail".format(
+                    card=util.sanitize_id(card)
+                ),
+                api_key=api_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
+            )
+
+        @util.class_method_variant("_cls_fail_card")
+        def fail_card(self, idempotency_key=None, **params):
+            return self.resource._request(
+                "post",
+                "/v1/test_helpers/issuing/cards/{card}/shipping/fail".format(
+                    card=util.sanitize_id(self.resource.get("id"))
+                ),
+                idempotency_key=idempotency_key,
+                params=params,
+            )
+
+        @classmethod
+        def _cls_return_card(
+            cls,
+            card,
+            api_key=None,
+            stripe_version=None,
+            stripe_account=None,
+            **params
+        ):
+            return cls._static_request(
+                "post",
+                "/v1/test_helpers/issuing/cards/{card}/shipping/return".format(
+                    card=util.sanitize_id(card)
+                ),
+                api_key=api_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
+            )
+
+        @util.class_method_variant("_cls_return_card")
+        def return_card(self, idempotency_key=None, **params):
+            return self.resource._request(
+                "post",
+                "/v1/test_helpers/issuing/cards/{card}/shipping/return".format(
+                    card=util.sanitize_id(self.resource.get("id"))
+                ),
+                idempotency_key=idempotency_key,
+                params=params,
+            )
+
+        @classmethod
+        def _cls_ship_card(
+            cls,
+            card,
+            api_key=None,
+            stripe_version=None,
+            stripe_account=None,
+            **params
+        ):
+            return cls._static_request(
+                "post",
+                "/v1/test_helpers/issuing/cards/{card}/shipping/ship".format(
+                    card=util.sanitize_id(card)
+                ),
+                api_key=api_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
+            )
+
+        @util.class_method_variant("_cls_ship_card")
+        def ship_card(self, idempotency_key=None, **params):
+            return self.resource._request(
+                "post",
+                "/v1/test_helpers/issuing/cards/{card}/shipping/ship".format(
+                    card=util.sanitize_id(self.resource.get("id"))
+                ),
+                idempotency_key=idempotency_key,
+                params=params,
+            )
 
     @property
     def test_helpers(self):
         return self.TestHelpers(self)
 
 
-_TestHelpers._resource_cls = Card
+Card.TestHelpers._resource_cls = Card

--- a/stripe/api_resources/issuing/card.py
+++ b/stripe/api_resources/issuing/card.py
@@ -7,7 +7,6 @@ from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
-from stripe.api_resources.abstract import test_helpers
 
 
 class Card(CreateableAPIResource, ListableAPIResource, UpdateableAPIResource):

--- a/stripe/api_resources/issuing/card.py
+++ b/stripe/api_resources/issuing/card.py
@@ -8,9 +8,135 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import test_helpers
+from typing import Type
 
 
-@test_helpers
+class _TestHelpers(APIResourceTestHelpers):
+    @classmethod
+    def _cls_deliver_card(
+        cls,
+        card,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/test_helpers/issuing/cards/{card}/shipping/deliver".format(
+                card=util.sanitize_id(card)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_deliver_card")
+    def deliver_card(self, idempotency_key=None, **params):
+        return self.resource._request(
+            "post",
+            "/v1/test_helpers/issuing/cards/{card}/shipping/deliver".format(
+                card=util.sanitize_id(self.resource.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def _cls_fail_card(
+        cls,
+        card,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/test_helpers/issuing/cards/{card}/shipping/fail".format(
+                card=util.sanitize_id(card)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_fail_card")
+    def fail_card(self, idempotency_key=None, **params):
+        return self.resource._request(
+            "post",
+            "/v1/test_helpers/issuing/cards/{card}/shipping/fail".format(
+                card=util.sanitize_id(self.resource.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def _cls_return_card(
+        cls,
+        card,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/test_helpers/issuing/cards/{card}/shipping/return".format(
+                card=util.sanitize_id(card)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_return_card")
+    def return_card(self, idempotency_key=None, **params):
+        return self.resource._request(
+            "post",
+            "/v1/test_helpers/issuing/cards/{card}/shipping/return".format(
+                card=util.sanitize_id(self.resource.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def _cls_ship_card(
+        cls,
+        card,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/test_helpers/issuing/cards/{card}/shipping/ship".format(
+                card=util.sanitize_id(card)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_ship_card")
+    def ship_card(self, idempotency_key=None, **params):
+        return self.resource._request(
+            "post",
+            "/v1/test_helpers/issuing/cards/{card}/shipping/ship".format(
+                card=util.sanitize_id(self.resource.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+
 class Card(CreateableAPIResource, ListableAPIResource, UpdateableAPIResource):
     """
     You can [create physical or virtual cards](https://stripe.com/docs/issuing/cards) that are issued to cardholders.
@@ -18,127 +144,11 @@ class Card(CreateableAPIResource, ListableAPIResource, UpdateableAPIResource):
 
     OBJECT_NAME = "issuing.card"
 
-    class TestHelpers(APIResourceTestHelpers):
-        @classmethod
-        def _cls_deliver_card(
-            cls,
-            card,
-            api_key=None,
-            stripe_version=None,
-            stripe_account=None,
-            **params
-        ):
-            return cls._static_request(
-                "post",
-                "/v1/test_helpers/issuing/cards/{card}/shipping/deliver".format(
-                    card=util.sanitize_id(card)
-                ),
-                api_key=api_key,
-                stripe_version=stripe_version,
-                stripe_account=stripe_account,
-                params=params,
-            )
+    TestHelpers = _TestHelpers
 
-        @util.class_method_variant("_cls_deliver_card")
-        def deliver_card(self, idempotency_key=None, **params):
-            return self.resource._request(
-                "post",
-                "/v1/test_helpers/issuing/cards/{card}/shipping/deliver".format(
-                    card=util.sanitize_id(self.resource.get("id"))
-                ),
-                idempotency_key=idempotency_key,
-                params=params,
-            )
+    @property
+    def test_helpers(self):
+        return self.TestHelpers(self)
 
-        @classmethod
-        def _cls_fail_card(
-            cls,
-            card,
-            api_key=None,
-            stripe_version=None,
-            stripe_account=None,
-            **params
-        ):
-            return cls._static_request(
-                "post",
-                "/v1/test_helpers/issuing/cards/{card}/shipping/fail".format(
-                    card=util.sanitize_id(card)
-                ),
-                api_key=api_key,
-                stripe_version=stripe_version,
-                stripe_account=stripe_account,
-                params=params,
-            )
 
-        @util.class_method_variant("_cls_fail_card")
-        def fail_card(self, idempotency_key=None, **params):
-            return self.resource._request(
-                "post",
-                "/v1/test_helpers/issuing/cards/{card}/shipping/fail".format(
-                    card=util.sanitize_id(self.resource.get("id"))
-                ),
-                idempotency_key=idempotency_key,
-                params=params,
-            )
-
-        @classmethod
-        def _cls_return_card(
-            cls,
-            card,
-            api_key=None,
-            stripe_version=None,
-            stripe_account=None,
-            **params
-        ):
-            return cls._static_request(
-                "post",
-                "/v1/test_helpers/issuing/cards/{card}/shipping/return".format(
-                    card=util.sanitize_id(card)
-                ),
-                api_key=api_key,
-                stripe_version=stripe_version,
-                stripe_account=stripe_account,
-                params=params,
-            )
-
-        @util.class_method_variant("_cls_return_card")
-        def return_card(self, idempotency_key=None, **params):
-            return self.resource._request(
-                "post",
-                "/v1/test_helpers/issuing/cards/{card}/shipping/return".format(
-                    card=util.sanitize_id(self.resource.get("id"))
-                ),
-                idempotency_key=idempotency_key,
-                params=params,
-            )
-
-        @classmethod
-        def _cls_ship_card(
-            cls,
-            card,
-            api_key=None,
-            stripe_version=None,
-            stripe_account=None,
-            **params
-        ):
-            return cls._static_request(
-                "post",
-                "/v1/test_helpers/issuing/cards/{card}/shipping/ship".format(
-                    card=util.sanitize_id(card)
-                ),
-                api_key=api_key,
-                stripe_version=stripe_version,
-                stripe_account=stripe_account,
-                params=params,
-            )
-
-        @util.class_method_variant("_cls_ship_card")
-        def ship_card(self, idempotency_key=None, **params):
-            return self.resource._request(
-                "post",
-                "/v1/test_helpers/issuing/cards/{card}/shipping/ship".format(
-                    card=util.sanitize_id(self.resource.get("id"))
-                ),
-                idempotency_key=idempotency_key,
-                params=params,
-            )
+_TestHelpers._resource_cls = Card

--- a/stripe/api_resources/refund.py
+++ b/stripe/api_resources/refund.py
@@ -7,7 +7,6 @@ from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
-from stripe.api_resources.abstract import test_helpers
 
 
 class Refund(

--- a/stripe/api_resources/refund.py
+++ b/stripe/api_resources/refund.py
@@ -8,40 +8,6 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import test_helpers
-from typing import Type
-
-
-class _TestHelpers(APIResourceTestHelpers):
-    @classmethod
-    def _cls_expire(
-        cls,
-        refund,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/test_helpers/refunds/{refund}/expire".format(
-                refund=util.sanitize_id(refund)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_expire")
-    def expire(self, idempotency_key=None, **params):
-        return self.resource._request(
-            "post",
-            "/v1/test_helpers/refunds/{refund}/expire".format(
-                refund=util.sanitize_id(self.resource.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
-        )
 
 
 class Refund(
@@ -88,11 +54,41 @@ class Refund(
             params=params,
         )
 
-    TestHelpers = _TestHelpers
+    class TestHelpers(APIResourceTestHelpers):
+        @classmethod
+        def _cls_expire(
+            cls,
+            refund,
+            api_key=None,
+            stripe_version=None,
+            stripe_account=None,
+            **params
+        ):
+            return cls._static_request(
+                "post",
+                "/v1/test_helpers/refunds/{refund}/expire".format(
+                    refund=util.sanitize_id(refund)
+                ),
+                api_key=api_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
+            )
+
+        @util.class_method_variant("_cls_expire")
+        def expire(self, idempotency_key=None, **params):
+            return self.resource._request(
+                "post",
+                "/v1/test_helpers/refunds/{refund}/expire".format(
+                    refund=util.sanitize_id(self.resource.get("id"))
+                ),
+                idempotency_key=idempotency_key,
+                params=params,
+            )
 
     @property
     def test_helpers(self):
         return self.TestHelpers(self)
 
 
-_TestHelpers._resource_cls = Refund
+Refund.TestHelpers._resource_cls = Refund

--- a/stripe/api_resources/refund.py
+++ b/stripe/api_resources/refund.py
@@ -8,9 +8,42 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import test_helpers
+from typing import Type
 
 
-@test_helpers
+class _TestHelpers(APIResourceTestHelpers):
+    @classmethod
+    def _cls_expire(
+        cls,
+        refund,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/test_helpers/refunds/{refund}/expire".format(
+                refund=util.sanitize_id(refund)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_expire")
+    def expire(self, idempotency_key=None, **params):
+        return self.resource._request(
+            "post",
+            "/v1/test_helpers/refunds/{refund}/expire".format(
+                refund=util.sanitize_id(self.resource.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+
 class Refund(
     CreateableAPIResource, ListableAPIResource, UpdateableAPIResource
 ):
@@ -55,34 +88,11 @@ class Refund(
             params=params,
         )
 
-    class TestHelpers(APIResourceTestHelpers):
-        @classmethod
-        def _cls_expire(
-            cls,
-            refund,
-            api_key=None,
-            stripe_version=None,
-            stripe_account=None,
-            **params
-        ):
-            return cls._static_request(
-                "post",
-                "/v1/test_helpers/refunds/{refund}/expire".format(
-                    refund=util.sanitize_id(refund)
-                ),
-                api_key=api_key,
-                stripe_version=stripe_version,
-                stripe_account=stripe_account,
-                params=params,
-            )
+    TestHelpers = _TestHelpers
 
-        @util.class_method_variant("_cls_expire")
-        def expire(self, idempotency_key=None, **params):
-            return self.resource._request(
-                "post",
-                "/v1/test_helpers/refunds/{refund}/expire".format(
-                    refund=util.sanitize_id(self.resource.get("id"))
-                ),
-                idempotency_key=idempotency_key,
-                params=params,
-            )
+    @property
+    def test_helpers(self):
+        return self.TestHelpers(self)
+
+
+_TestHelpers._resource_cls = Refund

--- a/stripe/api_resources/terminal/reader.py
+++ b/stripe/api_resources/terminal/reader.py
@@ -9,9 +9,42 @@ from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import test_helpers
+from typing import Type
 
 
-@test_helpers
+class _TestHelpers(APIResourceTestHelpers):
+    @classmethod
+    def _cls_present_payment_method(
+        cls,
+        reader,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/test_helpers/terminal/readers/{reader}/present_payment_method".format(
+                reader=util.sanitize_id(reader)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_present_payment_method")
+    def present_payment_method(self, idempotency_key=None, **params):
+        return self.resource._request(
+            "post",
+            "/v1/test_helpers/terminal/readers/{reader}/present_payment_method".format(
+                reader=util.sanitize_id(self.resource.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+
 class Reader(
     CreateableAPIResource,
     DeletableAPIResource,
@@ -181,34 +214,11 @@ class Reader(
             params=params,
         )
 
-    class TestHelpers(APIResourceTestHelpers):
-        @classmethod
-        def _cls_present_payment_method(
-            cls,
-            reader,
-            api_key=None,
-            stripe_version=None,
-            stripe_account=None,
-            **params
-        ):
-            return cls._static_request(
-                "post",
-                "/v1/test_helpers/terminal/readers/{reader}/present_payment_method".format(
-                    reader=util.sanitize_id(reader)
-                ),
-                api_key=api_key,
-                stripe_version=stripe_version,
-                stripe_account=stripe_account,
-                params=params,
-            )
+    TestHelpers = _TestHelpers
 
-        @util.class_method_variant("_cls_present_payment_method")
-        def present_payment_method(self, idempotency_key=None, **params):
-            return self.resource._request(
-                "post",
-                "/v1/test_helpers/terminal/readers/{reader}/present_payment_method".format(
-                    reader=util.sanitize_id(self.resource.get("id"))
-                ),
-                idempotency_key=idempotency_key,
-                params=params,
-            )
+    @property
+    def test_helpers(self):
+        return self.TestHelpers(self)
+
+
+_TestHelpers._resource_cls = Reader

--- a/stripe/api_resources/terminal/reader.py
+++ b/stripe/api_resources/terminal/reader.py
@@ -9,40 +9,6 @@ from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import test_helpers
-from typing import Type
-
-
-class _TestHelpers(APIResourceTestHelpers):
-    @classmethod
-    def _cls_present_payment_method(
-        cls,
-        reader,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/test_helpers/terminal/readers/{reader}/present_payment_method".format(
-                reader=util.sanitize_id(reader)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_present_payment_method")
-    def present_payment_method(self, idempotency_key=None, **params):
-        return self.resource._request(
-            "post",
-            "/v1/test_helpers/terminal/readers/{reader}/present_payment_method".format(
-                reader=util.sanitize_id(self.resource.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
-        )
 
 
 class Reader(
@@ -214,11 +180,41 @@ class Reader(
             params=params,
         )
 
-    TestHelpers = _TestHelpers
+    class TestHelpers(APIResourceTestHelpers):
+        @classmethod
+        def _cls_present_payment_method(
+            cls,
+            reader,
+            api_key=None,
+            stripe_version=None,
+            stripe_account=None,
+            **params
+        ):
+            return cls._static_request(
+                "post",
+                "/v1/test_helpers/terminal/readers/{reader}/present_payment_method".format(
+                    reader=util.sanitize_id(reader)
+                ),
+                api_key=api_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
+            )
+
+        @util.class_method_variant("_cls_present_payment_method")
+        def present_payment_method(self, idempotency_key=None, **params):
+            return self.resource._request(
+                "post",
+                "/v1/test_helpers/terminal/readers/{reader}/present_payment_method".format(
+                    reader=util.sanitize_id(self.resource.get("id"))
+                ),
+                idempotency_key=idempotency_key,
+                params=params,
+            )
 
     @property
     def test_helpers(self):
         return self.TestHelpers(self)
 
 
-_TestHelpers._resource_cls = Reader
+Reader.TestHelpers._resource_cls = Reader

--- a/stripe/api_resources/terminal/reader.py
+++ b/stripe/api_resources/terminal/reader.py
@@ -8,7 +8,6 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
-from stripe.api_resources.abstract import test_helpers
 
 
 class Reader(

--- a/stripe/api_resources/treasury/inbound_transfer.py
+++ b/stripe/api_resources/treasury/inbound_transfer.py
@@ -7,9 +7,104 @@ from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import test_helpers
+from typing import Type
 
 
-@test_helpers
+class _TestHelpers(APIResourceTestHelpers):
+    @classmethod
+    def _cls_fail(
+        cls,
+        id,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/test_helpers/treasury/inbound_transfers/{id}/fail".format(
+                id=util.sanitize_id(id)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_fail")
+    def fail(self, idempotency_key=None, **params):
+        return self.resource._request(
+            "post",
+            "/v1/test_helpers/treasury/inbound_transfers/{id}/fail".format(
+                id=util.sanitize_id(self.resource.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def _cls_return_inbound_transfer(
+        cls,
+        id,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/test_helpers/treasury/inbound_transfers/{id}/return".format(
+                id=util.sanitize_id(id)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_return_inbound_transfer")
+    def return_inbound_transfer(self, idempotency_key=None, **params):
+        return self.resource._request(
+            "post",
+            "/v1/test_helpers/treasury/inbound_transfers/{id}/return".format(
+                id=util.sanitize_id(self.resource.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def _cls_succeed(
+        cls,
+        id,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/test_helpers/treasury/inbound_transfers/{id}/succeed".format(
+                id=util.sanitize_id(id)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_succeed")
+    def succeed(self, idempotency_key=None, **params):
+        return self.resource._request(
+            "post",
+            "/v1/test_helpers/treasury/inbound_transfers/{id}/succeed".format(
+                id=util.sanitize_id(self.resource.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+
 class InboundTransfer(CreateableAPIResource, ListableAPIResource):
     """
     Use [InboundTransfers](https://stripe.com/docs/treasury/moving-money/financial-accounts/into/inbound-transfers) to add funds to your [FinancialAccount](https://stripe.com/docs/api#financial_accounts) via a PaymentMethod that is owned by you. The funds will be transferred via an ACH debit.
@@ -48,96 +143,11 @@ class InboundTransfer(CreateableAPIResource, ListableAPIResource):
             params=params,
         )
 
-    class TestHelpers(APIResourceTestHelpers):
-        @classmethod
-        def _cls_fail(
-            cls,
-            id,
-            api_key=None,
-            stripe_version=None,
-            stripe_account=None,
-            **params
-        ):
-            return cls._static_request(
-                "post",
-                "/v1/test_helpers/treasury/inbound_transfers/{id}/fail".format(
-                    id=util.sanitize_id(id)
-                ),
-                api_key=api_key,
-                stripe_version=stripe_version,
-                stripe_account=stripe_account,
-                params=params,
-            )
+    TestHelpers = _TestHelpers
 
-        @util.class_method_variant("_cls_fail")
-        def fail(self, idempotency_key=None, **params):
-            return self.resource._request(
-                "post",
-                "/v1/test_helpers/treasury/inbound_transfers/{id}/fail".format(
-                    id=util.sanitize_id(self.resource.get("id"))
-                ),
-                idempotency_key=idempotency_key,
-                params=params,
-            )
+    @property
+    def test_helpers(self):
+        return self.TestHelpers(self)
 
-        @classmethod
-        def _cls_return_inbound_transfer(
-            cls,
-            id,
-            api_key=None,
-            stripe_version=None,
-            stripe_account=None,
-            **params
-        ):
-            return cls._static_request(
-                "post",
-                "/v1/test_helpers/treasury/inbound_transfers/{id}/return".format(
-                    id=util.sanitize_id(id)
-                ),
-                api_key=api_key,
-                stripe_version=stripe_version,
-                stripe_account=stripe_account,
-                params=params,
-            )
 
-        @util.class_method_variant("_cls_return_inbound_transfer")
-        def return_inbound_transfer(self, idempotency_key=None, **params):
-            return self.resource._request(
-                "post",
-                "/v1/test_helpers/treasury/inbound_transfers/{id}/return".format(
-                    id=util.sanitize_id(self.resource.get("id"))
-                ),
-                idempotency_key=idempotency_key,
-                params=params,
-            )
-
-        @classmethod
-        def _cls_succeed(
-            cls,
-            id,
-            api_key=None,
-            stripe_version=None,
-            stripe_account=None,
-            **params
-        ):
-            return cls._static_request(
-                "post",
-                "/v1/test_helpers/treasury/inbound_transfers/{id}/succeed".format(
-                    id=util.sanitize_id(id)
-                ),
-                api_key=api_key,
-                stripe_version=stripe_version,
-                stripe_account=stripe_account,
-                params=params,
-            )
-
-        @util.class_method_variant("_cls_succeed")
-        def succeed(self, idempotency_key=None, **params):
-            return self.resource._request(
-                "post",
-                "/v1/test_helpers/treasury/inbound_transfers/{id}/succeed".format(
-                    id=util.sanitize_id(self.resource.get("id"))
-                ),
-                idempotency_key=idempotency_key,
-                params=params,
-            )
+_TestHelpers._resource_cls = InboundTransfer

--- a/stripe/api_resources/treasury/inbound_transfer.py
+++ b/stripe/api_resources/treasury/inbound_transfer.py
@@ -6,7 +6,6 @@ from stripe import util
 from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
-from stripe.api_resources.abstract import test_helpers
 
 
 class InboundTransfer(CreateableAPIResource, ListableAPIResource):

--- a/stripe/api_resources/treasury/inbound_transfer.py
+++ b/stripe/api_resources/treasury/inbound_transfer.py
@@ -7,102 +7,6 @@ from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import test_helpers
-from typing import Type
-
-
-class _TestHelpers(APIResourceTestHelpers):
-    @classmethod
-    def _cls_fail(
-        cls,
-        id,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/test_helpers/treasury/inbound_transfers/{id}/fail".format(
-                id=util.sanitize_id(id)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_fail")
-    def fail(self, idempotency_key=None, **params):
-        return self.resource._request(
-            "post",
-            "/v1/test_helpers/treasury/inbound_transfers/{id}/fail".format(
-                id=util.sanitize_id(self.resource.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
-        )
-
-    @classmethod
-    def _cls_return_inbound_transfer(
-        cls,
-        id,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/test_helpers/treasury/inbound_transfers/{id}/return".format(
-                id=util.sanitize_id(id)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_return_inbound_transfer")
-    def return_inbound_transfer(self, idempotency_key=None, **params):
-        return self.resource._request(
-            "post",
-            "/v1/test_helpers/treasury/inbound_transfers/{id}/return".format(
-                id=util.sanitize_id(self.resource.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
-        )
-
-    @classmethod
-    def _cls_succeed(
-        cls,
-        id,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/test_helpers/treasury/inbound_transfers/{id}/succeed".format(
-                id=util.sanitize_id(id)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_succeed")
-    def succeed(self, idempotency_key=None, **params):
-        return self.resource._request(
-            "post",
-            "/v1/test_helpers/treasury/inbound_transfers/{id}/succeed".format(
-                id=util.sanitize_id(self.resource.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
-        )
 
 
 class InboundTransfer(CreateableAPIResource, ListableAPIResource):
@@ -143,11 +47,103 @@ class InboundTransfer(CreateableAPIResource, ListableAPIResource):
             params=params,
         )
 
-    TestHelpers = _TestHelpers
+    class TestHelpers(APIResourceTestHelpers):
+        @classmethod
+        def _cls_fail(
+            cls,
+            id,
+            api_key=None,
+            stripe_version=None,
+            stripe_account=None,
+            **params
+        ):
+            return cls._static_request(
+                "post",
+                "/v1/test_helpers/treasury/inbound_transfers/{id}/fail".format(
+                    id=util.sanitize_id(id)
+                ),
+                api_key=api_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
+            )
+
+        @util.class_method_variant("_cls_fail")
+        def fail(self, idempotency_key=None, **params):
+            return self.resource._request(
+                "post",
+                "/v1/test_helpers/treasury/inbound_transfers/{id}/fail".format(
+                    id=util.sanitize_id(self.resource.get("id"))
+                ),
+                idempotency_key=idempotency_key,
+                params=params,
+            )
+
+        @classmethod
+        def _cls_return_inbound_transfer(
+            cls,
+            id,
+            api_key=None,
+            stripe_version=None,
+            stripe_account=None,
+            **params
+        ):
+            return cls._static_request(
+                "post",
+                "/v1/test_helpers/treasury/inbound_transfers/{id}/return".format(
+                    id=util.sanitize_id(id)
+                ),
+                api_key=api_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
+            )
+
+        @util.class_method_variant("_cls_return_inbound_transfer")
+        def return_inbound_transfer(self, idempotency_key=None, **params):
+            return self.resource._request(
+                "post",
+                "/v1/test_helpers/treasury/inbound_transfers/{id}/return".format(
+                    id=util.sanitize_id(self.resource.get("id"))
+                ),
+                idempotency_key=idempotency_key,
+                params=params,
+            )
+
+        @classmethod
+        def _cls_succeed(
+            cls,
+            id,
+            api_key=None,
+            stripe_version=None,
+            stripe_account=None,
+            **params
+        ):
+            return cls._static_request(
+                "post",
+                "/v1/test_helpers/treasury/inbound_transfers/{id}/succeed".format(
+                    id=util.sanitize_id(id)
+                ),
+                api_key=api_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
+            )
+
+        @util.class_method_variant("_cls_succeed")
+        def succeed(self, idempotency_key=None, **params):
+            return self.resource._request(
+                "post",
+                "/v1/test_helpers/treasury/inbound_transfers/{id}/succeed".format(
+                    id=util.sanitize_id(self.resource.get("id"))
+                ),
+                idempotency_key=idempotency_key,
+                params=params,
+            )
 
     @property
     def test_helpers(self):
         return self.TestHelpers(self)
 
 
-_TestHelpers._resource_cls = InboundTransfer
+InboundTransfer.TestHelpers._resource_cls = InboundTransfer

--- a/stripe/api_resources/treasury/outbound_payment.py
+++ b/stripe/api_resources/treasury/outbound_payment.py
@@ -7,102 +7,6 @@ from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import test_helpers
-from typing import Type
-
-
-class _TestHelpers(APIResourceTestHelpers):
-    @classmethod
-    def _cls_fail(
-        cls,
-        id,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/test_helpers/treasury/outbound_payments/{id}/fail".format(
-                id=util.sanitize_id(id)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_fail")
-    def fail(self, idempotency_key=None, **params):
-        return self.resource._request(
-            "post",
-            "/v1/test_helpers/treasury/outbound_payments/{id}/fail".format(
-                id=util.sanitize_id(self.resource.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
-        )
-
-    @classmethod
-    def _cls_post(
-        cls,
-        id,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/test_helpers/treasury/outbound_payments/{id}/post".format(
-                id=util.sanitize_id(id)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_post")
-    def post(self, idempotency_key=None, **params):
-        return self.resource._request(
-            "post",
-            "/v1/test_helpers/treasury/outbound_payments/{id}/post".format(
-                id=util.sanitize_id(self.resource.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
-        )
-
-    @classmethod
-    def _cls_return_outbound_payment(
-        cls,
-        id,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/test_helpers/treasury/outbound_payments/{id}/return".format(
-                id=util.sanitize_id(id)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_return_outbound_payment")
-    def return_outbound_payment(self, idempotency_key=None, **params):
-        return self.resource._request(
-            "post",
-            "/v1/test_helpers/treasury/outbound_payments/{id}/return".format(
-                id=util.sanitize_id(self.resource.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
-        )
 
 
 class OutboundPayment(CreateableAPIResource, ListableAPIResource):
@@ -145,11 +49,103 @@ class OutboundPayment(CreateableAPIResource, ListableAPIResource):
             params=params,
         )
 
-    TestHelpers = _TestHelpers
+    class TestHelpers(APIResourceTestHelpers):
+        @classmethod
+        def _cls_fail(
+            cls,
+            id,
+            api_key=None,
+            stripe_version=None,
+            stripe_account=None,
+            **params
+        ):
+            return cls._static_request(
+                "post",
+                "/v1/test_helpers/treasury/outbound_payments/{id}/fail".format(
+                    id=util.sanitize_id(id)
+                ),
+                api_key=api_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
+            )
+
+        @util.class_method_variant("_cls_fail")
+        def fail(self, idempotency_key=None, **params):
+            return self.resource._request(
+                "post",
+                "/v1/test_helpers/treasury/outbound_payments/{id}/fail".format(
+                    id=util.sanitize_id(self.resource.get("id"))
+                ),
+                idempotency_key=idempotency_key,
+                params=params,
+            )
+
+        @classmethod
+        def _cls_post(
+            cls,
+            id,
+            api_key=None,
+            stripe_version=None,
+            stripe_account=None,
+            **params
+        ):
+            return cls._static_request(
+                "post",
+                "/v1/test_helpers/treasury/outbound_payments/{id}/post".format(
+                    id=util.sanitize_id(id)
+                ),
+                api_key=api_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
+            )
+
+        @util.class_method_variant("_cls_post")
+        def post(self, idempotency_key=None, **params):
+            return self.resource._request(
+                "post",
+                "/v1/test_helpers/treasury/outbound_payments/{id}/post".format(
+                    id=util.sanitize_id(self.resource.get("id"))
+                ),
+                idempotency_key=idempotency_key,
+                params=params,
+            )
+
+        @classmethod
+        def _cls_return_outbound_payment(
+            cls,
+            id,
+            api_key=None,
+            stripe_version=None,
+            stripe_account=None,
+            **params
+        ):
+            return cls._static_request(
+                "post",
+                "/v1/test_helpers/treasury/outbound_payments/{id}/return".format(
+                    id=util.sanitize_id(id)
+                ),
+                api_key=api_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
+            )
+
+        @util.class_method_variant("_cls_return_outbound_payment")
+        def return_outbound_payment(self, idempotency_key=None, **params):
+            return self.resource._request(
+                "post",
+                "/v1/test_helpers/treasury/outbound_payments/{id}/return".format(
+                    id=util.sanitize_id(self.resource.get("id"))
+                ),
+                idempotency_key=idempotency_key,
+                params=params,
+            )
 
     @property
     def test_helpers(self):
         return self.TestHelpers(self)
 
 
-_TestHelpers._resource_cls = OutboundPayment
+OutboundPayment.TestHelpers._resource_cls = OutboundPayment

--- a/stripe/api_resources/treasury/outbound_payment.py
+++ b/stripe/api_resources/treasury/outbound_payment.py
@@ -7,9 +7,104 @@ from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import test_helpers
+from typing import Type
 
 
-@test_helpers
+class _TestHelpers(APIResourceTestHelpers):
+    @classmethod
+    def _cls_fail(
+        cls,
+        id,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/test_helpers/treasury/outbound_payments/{id}/fail".format(
+                id=util.sanitize_id(id)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_fail")
+    def fail(self, idempotency_key=None, **params):
+        return self.resource._request(
+            "post",
+            "/v1/test_helpers/treasury/outbound_payments/{id}/fail".format(
+                id=util.sanitize_id(self.resource.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def _cls_post(
+        cls,
+        id,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/test_helpers/treasury/outbound_payments/{id}/post".format(
+                id=util.sanitize_id(id)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_post")
+    def post(self, idempotency_key=None, **params):
+        return self.resource._request(
+            "post",
+            "/v1/test_helpers/treasury/outbound_payments/{id}/post".format(
+                id=util.sanitize_id(self.resource.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def _cls_return_outbound_payment(
+        cls,
+        id,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/test_helpers/treasury/outbound_payments/{id}/return".format(
+                id=util.sanitize_id(id)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_return_outbound_payment")
+    def return_outbound_payment(self, idempotency_key=None, **params):
+        return self.resource._request(
+            "post",
+            "/v1/test_helpers/treasury/outbound_payments/{id}/return".format(
+                id=util.sanitize_id(self.resource.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+
 class OutboundPayment(CreateableAPIResource, ListableAPIResource):
     """
     Use OutboundPayments to send funds to another party's external bank account or [FinancialAccount](https://stripe.com/docs/api#financial_accounts). To send money to an account belonging to the same user, use an [OutboundTransfer](https://stripe.com/docs/api#outbound_transfers).
@@ -50,96 +145,11 @@ class OutboundPayment(CreateableAPIResource, ListableAPIResource):
             params=params,
         )
 
-    class TestHelpers(APIResourceTestHelpers):
-        @classmethod
-        def _cls_fail(
-            cls,
-            id,
-            api_key=None,
-            stripe_version=None,
-            stripe_account=None,
-            **params
-        ):
-            return cls._static_request(
-                "post",
-                "/v1/test_helpers/treasury/outbound_payments/{id}/fail".format(
-                    id=util.sanitize_id(id)
-                ),
-                api_key=api_key,
-                stripe_version=stripe_version,
-                stripe_account=stripe_account,
-                params=params,
-            )
+    TestHelpers = _TestHelpers
 
-        @util.class_method_variant("_cls_fail")
-        def fail(self, idempotency_key=None, **params):
-            return self.resource._request(
-                "post",
-                "/v1/test_helpers/treasury/outbound_payments/{id}/fail".format(
-                    id=util.sanitize_id(self.resource.get("id"))
-                ),
-                idempotency_key=idempotency_key,
-                params=params,
-            )
+    @property
+    def test_helpers(self):
+        return self.TestHelpers(self)
 
-        @classmethod
-        def _cls_post(
-            cls,
-            id,
-            api_key=None,
-            stripe_version=None,
-            stripe_account=None,
-            **params
-        ):
-            return cls._static_request(
-                "post",
-                "/v1/test_helpers/treasury/outbound_payments/{id}/post".format(
-                    id=util.sanitize_id(id)
-                ),
-                api_key=api_key,
-                stripe_version=stripe_version,
-                stripe_account=stripe_account,
-                params=params,
-            )
 
-        @util.class_method_variant("_cls_post")
-        def post(self, idempotency_key=None, **params):
-            return self.resource._request(
-                "post",
-                "/v1/test_helpers/treasury/outbound_payments/{id}/post".format(
-                    id=util.sanitize_id(self.resource.get("id"))
-                ),
-                idempotency_key=idempotency_key,
-                params=params,
-            )
-
-        @classmethod
-        def _cls_return_outbound_payment(
-            cls,
-            id,
-            api_key=None,
-            stripe_version=None,
-            stripe_account=None,
-            **params
-        ):
-            return cls._static_request(
-                "post",
-                "/v1/test_helpers/treasury/outbound_payments/{id}/return".format(
-                    id=util.sanitize_id(id)
-                ),
-                api_key=api_key,
-                stripe_version=stripe_version,
-                stripe_account=stripe_account,
-                params=params,
-            )
-
-        @util.class_method_variant("_cls_return_outbound_payment")
-        def return_outbound_payment(self, idempotency_key=None, **params):
-            return self.resource._request(
-                "post",
-                "/v1/test_helpers/treasury/outbound_payments/{id}/return".format(
-                    id=util.sanitize_id(self.resource.get("id"))
-                ),
-                idempotency_key=idempotency_key,
-                params=params,
-            )
+_TestHelpers._resource_cls = OutboundPayment

--- a/stripe/api_resources/treasury/outbound_payment.py
+++ b/stripe/api_resources/treasury/outbound_payment.py
@@ -6,7 +6,6 @@ from stripe import util
 from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
-from stripe.api_resources.abstract import test_helpers
 
 
 class OutboundPayment(CreateableAPIResource, ListableAPIResource):

--- a/stripe/api_resources/treasury/outbound_transfer.py
+++ b/stripe/api_resources/treasury/outbound_transfer.py
@@ -6,7 +6,6 @@ from stripe import util
 from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
-from stripe.api_resources.abstract import test_helpers
 
 
 class OutboundTransfer(CreateableAPIResource, ListableAPIResource):

--- a/stripe/api_resources/treasury/outbound_transfer.py
+++ b/stripe/api_resources/treasury/outbound_transfer.py
@@ -7,102 +7,6 @@ from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import test_helpers
-from typing import Type
-
-
-class _TestHelpers(APIResourceTestHelpers):
-    @classmethod
-    def _cls_fail(
-        cls,
-        outbound_transfer,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/fail".format(
-                outbound_transfer=util.sanitize_id(outbound_transfer)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_fail")
-    def fail(self, idempotency_key=None, **params):
-        return self.resource._request(
-            "post",
-            "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/fail".format(
-                outbound_transfer=util.sanitize_id(self.resource.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
-        )
-
-    @classmethod
-    def _cls_post(
-        cls,
-        outbound_transfer,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/post".format(
-                outbound_transfer=util.sanitize_id(outbound_transfer)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_post")
-    def post(self, idempotency_key=None, **params):
-        return self.resource._request(
-            "post",
-            "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/post".format(
-                outbound_transfer=util.sanitize_id(self.resource.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
-        )
-
-    @classmethod
-    def _cls_return_outbound_transfer(
-        cls,
-        outbound_transfer,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/return".format(
-                outbound_transfer=util.sanitize_id(outbound_transfer)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_return_outbound_transfer")
-    def return_outbound_transfer(self, idempotency_key=None, **params):
-        return self.resource._request(
-            "post",
-            "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/return".format(
-                outbound_transfer=util.sanitize_id(self.resource.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
-        )
 
 
 class OutboundTransfer(CreateableAPIResource, ListableAPIResource):
@@ -145,11 +49,103 @@ class OutboundTransfer(CreateableAPIResource, ListableAPIResource):
             params=params,
         )
 
-    TestHelpers = _TestHelpers
+    class TestHelpers(APIResourceTestHelpers):
+        @classmethod
+        def _cls_fail(
+            cls,
+            outbound_transfer,
+            api_key=None,
+            stripe_version=None,
+            stripe_account=None,
+            **params
+        ):
+            return cls._static_request(
+                "post",
+                "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/fail".format(
+                    outbound_transfer=util.sanitize_id(outbound_transfer)
+                ),
+                api_key=api_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
+            )
+
+        @util.class_method_variant("_cls_fail")
+        def fail(self, idempotency_key=None, **params):
+            return self.resource._request(
+                "post",
+                "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/fail".format(
+                    outbound_transfer=util.sanitize_id(self.resource.get("id"))
+                ),
+                idempotency_key=idempotency_key,
+                params=params,
+            )
+
+        @classmethod
+        def _cls_post(
+            cls,
+            outbound_transfer,
+            api_key=None,
+            stripe_version=None,
+            stripe_account=None,
+            **params
+        ):
+            return cls._static_request(
+                "post",
+                "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/post".format(
+                    outbound_transfer=util.sanitize_id(outbound_transfer)
+                ),
+                api_key=api_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
+            )
+
+        @util.class_method_variant("_cls_post")
+        def post(self, idempotency_key=None, **params):
+            return self.resource._request(
+                "post",
+                "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/post".format(
+                    outbound_transfer=util.sanitize_id(self.resource.get("id"))
+                ),
+                idempotency_key=idempotency_key,
+                params=params,
+            )
+
+        @classmethod
+        def _cls_return_outbound_transfer(
+            cls,
+            outbound_transfer,
+            api_key=None,
+            stripe_version=None,
+            stripe_account=None,
+            **params
+        ):
+            return cls._static_request(
+                "post",
+                "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/return".format(
+                    outbound_transfer=util.sanitize_id(outbound_transfer)
+                ),
+                api_key=api_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
+            )
+
+        @util.class_method_variant("_cls_return_outbound_transfer")
+        def return_outbound_transfer(self, idempotency_key=None, **params):
+            return self.resource._request(
+                "post",
+                "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/return".format(
+                    outbound_transfer=util.sanitize_id(self.resource.get("id"))
+                ),
+                idempotency_key=idempotency_key,
+                params=params,
+            )
 
     @property
     def test_helpers(self):
         return self.TestHelpers(self)
 
 
-_TestHelpers._resource_cls = OutboundTransfer
+OutboundTransfer.TestHelpers._resource_cls = OutboundTransfer

--- a/stripe/api_resources/treasury/outbound_transfer.py
+++ b/stripe/api_resources/treasury/outbound_transfer.py
@@ -7,9 +7,104 @@ from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import test_helpers
+from typing import Type
 
 
-@test_helpers
+class _TestHelpers(APIResourceTestHelpers):
+    @classmethod
+    def _cls_fail(
+        cls,
+        outbound_transfer,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/fail".format(
+                outbound_transfer=util.sanitize_id(outbound_transfer)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_fail")
+    def fail(self, idempotency_key=None, **params):
+        return self.resource._request(
+            "post",
+            "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/fail".format(
+                outbound_transfer=util.sanitize_id(self.resource.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def _cls_post(
+        cls,
+        outbound_transfer,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/post".format(
+                outbound_transfer=util.sanitize_id(outbound_transfer)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_post")
+    def post(self, idempotency_key=None, **params):
+        return self.resource._request(
+            "post",
+            "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/post".format(
+                outbound_transfer=util.sanitize_id(self.resource.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def _cls_return_outbound_transfer(
+        cls,
+        outbound_transfer,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/return".format(
+                outbound_transfer=util.sanitize_id(outbound_transfer)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_return_outbound_transfer")
+    def return_outbound_transfer(self, idempotency_key=None, **params):
+        return self.resource._request(
+            "post",
+            "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/return".format(
+                outbound_transfer=util.sanitize_id(self.resource.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+
 class OutboundTransfer(CreateableAPIResource, ListableAPIResource):
     """
     Use OutboundTransfers to transfer funds from a [FinancialAccount](https://stripe.com/docs/api#financial_accounts) to a PaymentMethod belonging to the same entity. To send funds to a different party, use [OutboundPayments](https://stripe.com/docs/api#outbound_payments) instead. You can send funds over ACH rails or through a domestic wire transfer to a user's own external bank account.
@@ -50,96 +145,11 @@ class OutboundTransfer(CreateableAPIResource, ListableAPIResource):
             params=params,
         )
 
-    class TestHelpers(APIResourceTestHelpers):
-        @classmethod
-        def _cls_fail(
-            cls,
-            outbound_transfer,
-            api_key=None,
-            stripe_version=None,
-            stripe_account=None,
-            **params
-        ):
-            return cls._static_request(
-                "post",
-                "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/fail".format(
-                    outbound_transfer=util.sanitize_id(outbound_transfer)
-                ),
-                api_key=api_key,
-                stripe_version=stripe_version,
-                stripe_account=stripe_account,
-                params=params,
-            )
+    TestHelpers = _TestHelpers
 
-        @util.class_method_variant("_cls_fail")
-        def fail(self, idempotency_key=None, **params):
-            return self.resource._request(
-                "post",
-                "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/fail".format(
-                    outbound_transfer=util.sanitize_id(self.resource.get("id"))
-                ),
-                idempotency_key=idempotency_key,
-                params=params,
-            )
+    @property
+    def test_helpers(self):
+        return self.TestHelpers(self)
 
-        @classmethod
-        def _cls_post(
-            cls,
-            outbound_transfer,
-            api_key=None,
-            stripe_version=None,
-            stripe_account=None,
-            **params
-        ):
-            return cls._static_request(
-                "post",
-                "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/post".format(
-                    outbound_transfer=util.sanitize_id(outbound_transfer)
-                ),
-                api_key=api_key,
-                stripe_version=stripe_version,
-                stripe_account=stripe_account,
-                params=params,
-            )
 
-        @util.class_method_variant("_cls_post")
-        def post(self, idempotency_key=None, **params):
-            return self.resource._request(
-                "post",
-                "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/post".format(
-                    outbound_transfer=util.sanitize_id(self.resource.get("id"))
-                ),
-                idempotency_key=idempotency_key,
-                params=params,
-            )
-
-        @classmethod
-        def _cls_return_outbound_transfer(
-            cls,
-            outbound_transfer,
-            api_key=None,
-            stripe_version=None,
-            stripe_account=None,
-            **params
-        ):
-            return cls._static_request(
-                "post",
-                "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/return".format(
-                    outbound_transfer=util.sanitize_id(outbound_transfer)
-                ),
-                api_key=api_key,
-                stripe_version=stripe_version,
-                stripe_account=stripe_account,
-                params=params,
-            )
-
-        @util.class_method_variant("_cls_return_outbound_transfer")
-        def return_outbound_transfer(self, idempotency_key=None, **params):
-            return self.resource._request(
-                "post",
-                "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/return".format(
-                    outbound_transfer=util.sanitize_id(self.resource.get("id"))
-                ),
-                idempotency_key=idempotency_key,
-                params=params,
-            )
+_TestHelpers._resource_cls = OutboundTransfer

--- a/stripe/api_resources/treasury/received_credit.py
+++ b/stripe/api_resources/treasury/received_credit.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import ListableAPIResource
-from stripe.api_resources.abstract import test_helpers
 
 
 class ReceivedCredit(ListableAPIResource):

--- a/stripe/api_resources/treasury/received_credit.py
+++ b/stripe/api_resources/treasury/received_credit.py
@@ -5,22 +5,6 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import test_helpers
-from typing import Type
-
-
-class _TestHelpers(APIResourceTestHelpers):
-    @classmethod
-    def create(
-        cls, api_key=None, stripe_version=None, stripe_account=None, **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/test_helpers/treasury/received_credits",
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
 
 
 class ReceivedCredit(ListableAPIResource):
@@ -30,11 +14,27 @@ class ReceivedCredit(ListableAPIResource):
 
     OBJECT_NAME = "treasury.received_credit"
 
-    TestHelpers = _TestHelpers
+    class TestHelpers(APIResourceTestHelpers):
+        @classmethod
+        def create(
+            cls,
+            api_key=None,
+            stripe_version=None,
+            stripe_account=None,
+            **params
+        ):
+            return cls._static_request(
+                "post",
+                "/v1/test_helpers/treasury/received_credits",
+                api_key=api_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
+            )
 
     @property
     def test_helpers(self):
         return self.TestHelpers(self)
 
 
-_TestHelpers._resource_cls = ReceivedCredit
+ReceivedCredit.TestHelpers._resource_cls = ReceivedCredit

--- a/stripe/api_resources/treasury/received_credit.py
+++ b/stripe/api_resources/treasury/received_credit.py
@@ -5,9 +5,24 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import test_helpers
+from typing import Type
 
 
-@test_helpers
+class _TestHelpers(APIResourceTestHelpers):
+    @classmethod
+    def create(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/test_helpers/treasury/received_credits",
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+
 class ReceivedCredit(ListableAPIResource):
     """
     ReceivedCredits represent funds sent to a [FinancialAccount](https://stripe.com/docs/api#financial_accounts) (for example, via ACH or wire). These money movements are not initiated from the FinancialAccount.
@@ -15,20 +30,11 @@ class ReceivedCredit(ListableAPIResource):
 
     OBJECT_NAME = "treasury.received_credit"
 
-    class TestHelpers(APIResourceTestHelpers):
-        @classmethod
-        def create(
-            cls,
-            api_key=None,
-            stripe_version=None,
-            stripe_account=None,
-            **params
-        ):
-            return cls._static_request(
-                "post",
-                "/v1/test_helpers/treasury/received_credits",
-                api_key=api_key,
-                stripe_version=stripe_version,
-                stripe_account=stripe_account,
-                params=params,
-            )
+    TestHelpers = _TestHelpers
+
+    @property
+    def test_helpers(self):
+        return self.TestHelpers(self)
+
+
+_TestHelpers._resource_cls = ReceivedCredit

--- a/stripe/api_resources/treasury/received_debit.py
+++ b/stripe/api_resources/treasury/received_debit.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import ListableAPIResource
-from stripe.api_resources.abstract import test_helpers
 
 
 class ReceivedDebit(ListableAPIResource):

--- a/stripe/api_resources/treasury/received_debit.py
+++ b/stripe/api_resources/treasury/received_debit.py
@@ -5,9 +5,24 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import test_helpers
+from typing import Type
 
 
-@test_helpers
+class _TestHelpers(APIResourceTestHelpers):
+    @classmethod
+    def create(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/test_helpers/treasury/received_debits",
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+
 class ReceivedDebit(ListableAPIResource):
     """
     ReceivedDebits represent funds pulled from a [FinancialAccount](https://stripe.com/docs/api#financial_accounts). These are not initiated from the FinancialAccount.
@@ -15,20 +30,11 @@ class ReceivedDebit(ListableAPIResource):
 
     OBJECT_NAME = "treasury.received_debit"
 
-    class TestHelpers(APIResourceTestHelpers):
-        @classmethod
-        def create(
-            cls,
-            api_key=None,
-            stripe_version=None,
-            stripe_account=None,
-            **params
-        ):
-            return cls._static_request(
-                "post",
-                "/v1/test_helpers/treasury/received_debits",
-                api_key=api_key,
-                stripe_version=stripe_version,
-                stripe_account=stripe_account,
-                params=params,
-            )
+    TestHelpers = _TestHelpers
+
+    @property
+    def test_helpers(self):
+        return self.TestHelpers(self)
+
+
+_TestHelpers._resource_cls = ReceivedDebit

--- a/stripe/api_resources/treasury/received_debit.py
+++ b/stripe/api_resources/treasury/received_debit.py
@@ -5,22 +5,6 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import test_helpers
-from typing import Type
-
-
-class _TestHelpers(APIResourceTestHelpers):
-    @classmethod
-    def create(
-        cls, api_key=None, stripe_version=None, stripe_account=None, **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/test_helpers/treasury/received_debits",
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
 
 
 class ReceivedDebit(ListableAPIResource):
@@ -30,11 +14,27 @@ class ReceivedDebit(ListableAPIResource):
 
     OBJECT_NAME = "treasury.received_debit"
 
-    TestHelpers = _TestHelpers
+    class TestHelpers(APIResourceTestHelpers):
+        @classmethod
+        def create(
+            cls,
+            api_key=None,
+            stripe_version=None,
+            stripe_account=None,
+            **params
+        ):
+            return cls._static_request(
+                "post",
+                "/v1/test_helpers/treasury/received_debits",
+                api_key=api_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
+            )
 
     @property
     def test_helpers(self):
         return self.TestHelpers(self)
 
 
-_TestHelpers._resource_cls = ReceivedDebit
+ReceivedDebit.TestHelpers._resource_cls = ReceivedDebit

--- a/tests/api_resources/abstract/test_test_helpers_api_resource.py
+++ b/tests/api_resources/abstract/test_test_helpers_api_resource.py
@@ -1,13 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
 import stripe
-import pytest
 from stripe import util
 from stripe.api_resources.abstract import APIResourceTestHelpers
 
 
 class TestTestHelperAPIResource(object):
-    @stripe.api_resources.abstract.test_helpers
     class MyTestHelpersResource(stripe.api_resources.abstract.APIResource):
         OBJECT_NAME = "myresource"
 
@@ -25,6 +23,12 @@ class TestTestHelperAPIResource(object):
                     self.resource.request("post", url, params, headers)
                 )
                 return self.resource
+
+        @property
+        def test_helpers(self):
+            return self.TestHelpers(self)
+
+    MyTestHelpersResource.TestHelpers._resource_cls = MyTestHelpersResource
 
     def test_call_custom_method_class(self, request_mock):
         request_mock.stub_request(
@@ -60,7 +64,3 @@ class TestTestHelperAPIResource(object):
             {"foo": "bar"},
         )
         assert obj.thing_done is True
-
-    def test_helper_decorator_raises_for_non_resource(self):
-        with pytest.raises(ValueError):
-            stripe.api_resources.abstract.test_helpers(str)


### PR DESCRIPTION
The `@test_helper` decorator is somewhat awkward and will make it difficult to add type annotations.

This PR deprecates the decorator and

1. adds a getter

```python
  @property
  def test_helpers(self):
      return self.TestHelpers(self)
```

2. sets `._resource_cls` directly
```
MyResource.TestHelper._resource_cls = MyResource
```
and
3. Puts `def _static_request` and `def _static_request_stream` in the APIResourceTestHelpers parent class instead of being added dynamically by the decorator.
