### PR TITLE
Assert types of pagination responses

### DIFF
--- a/stripe/api_resources/list_object.py
+++ b/stripe/api_resources/list_object.py
@@ -128,12 +128,14 @@ class ListObject(StripeObject):
         params_with_filters.update({"starting_after": last_id})
         params_with_filters.update(params)
 
-        return self.list(
+        result = self.list(
             api_key=api_key,
             stripe_version=stripe_version,
             stripe_account=stripe_account,
             **params_with_filters
         )
+        assert isinstance(result, ListObject)
+        return result
 
     def previous_page(
         self, api_key=None, stripe_version=None, stripe_account=None, **params

--- a/stripe/api_resources/search_result_object.py
+++ b/stripe/api_resources/search_result_object.py
@@ -76,9 +76,11 @@ class SearchResultObject(StripeObject):
         params_with_filters.update({"page": self.next_page})
         params_with_filters.update(params)
 
-        return self.search(
+        result = self.search(
             api_key=api_key,
             stripe_version=stripe_version,
             stripe_account=stripe_account,
             **params_with_filters
         )
+        assert isinstance(result, SearchResultObject)
+        return result

--- a/tests/api_resources/test_search_result_object.py
+++ b/tests/api_resources/test_search_result_object.py
@@ -59,14 +59,14 @@ class TestSearchResultObject(object):
         assert search_result_object
 
         empty = stripe.SearchResultObject.construct_from(
-            {"object": "list", "url": "/my/path", "data": []}, "mykey"
+            {"object": "search_result", "url": "/my/path", "data": []}, "mykey"
         )
         assert bool(empty) is False
 
     def test_next_search_result_page(self, request_mock):
         sro = stripe.SearchResultObject.construct_from(
             {
-                "object": "list",
+                "object": "search_result",
                 "data": [{"id": 1}],
                 "has_more": True,
                 "next_page": "next_page_token",
@@ -79,7 +79,7 @@ class TestSearchResultObject(object):
             "get",
             "/things",
             {
-                "object": "list",
+                "object": "search_result",
                 "data": [{"id": 2}],
                 "has_more": False,
                 "url": "/things",
@@ -97,7 +97,7 @@ class TestSearchResultObject(object):
     def test_next_search_result_page_with_filters(self, request_mock):
         sro = stripe.SearchResultObject.construct_from(
             {
-                "object": "list",
+                "object": "search_result",
                 "data": [{"id": 1}],
                 "has_more": True,
                 "next_page": "next_page_token",
@@ -111,7 +111,7 @@ class TestSearchResultObject(object):
             "get",
             "/things",
             {
-                "object": "list",
+                "object": "search_result",
                 "data": [{"id": 2}],
                 "has_more": False,
                 "next_page": None,
@@ -129,7 +129,7 @@ class TestSearchResultObject(object):
     def test_next_search_result_page_empty_search_result(self):
         sro = stripe.SearchResultObject.construct_from(
             {
-                "object": "list",
+                "object": "search_result",
                 "data": [{"id": 1}],
                 "has_more": False,
                 "next_page": None,
@@ -143,7 +143,7 @@ class TestSearchResultObject(object):
 
     def test_serialize_empty_search_result(self):
         empty = stripe.SearchResultObject.construct_from(
-            {"object": "list", "data": []}, "mykey"
+            {"object": "search_result", "data": []}, "mykey"
         )
         serialized = str(empty)
         deserialized = stripe.SearchResultObject.construct_from(
@@ -153,7 +153,7 @@ class TestSearchResultObject(object):
 
     def test_serialize_nested_empty_search_result(self):
         empty = stripe.SearchResultObject.construct_from(
-            {"object": "list", "data": []}, "mykey"
+            {"object": "search_result", "data": []}, "mykey"
         )
         obj = stripe.stripe_object.StripeObject.construct_from(
             {"nested": empty}, "mykey"


### PR DESCRIPTION
## Summary
This will remove the need to do a type suppression here when we add types. 

This isn't breaking under the assumption that API responses return the types they are declared to, but might break somebody's test against mock data (for example, [ours](https://github.com/stripe/stripe-python/pull/1015/commits/54682c45ed254dcca850ddb548f4fbc87f70f354)), hence I would like to do it in the major.