### PR TITLE
Explicitly define CRUDL methods in each resource

### DIFF
--- a/stripe/api_resources/account.py
+++ b/stripe/api_resources/account.py
@@ -12,7 +12,7 @@ from stripe.api_resources.abstract import (
 )
 from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 from typing_extensions import Literal
 from urllib.parse import quote_plus
 
@@ -79,6 +79,65 @@ class Account(
     settings: Optional[StripeObject]
     tos_acceptance: StripeObject
     type: str
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Account":
+        return cast(
+            "Account",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def _cls_delete(cls, sid, **params) -> "Account":
+        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        return cast(
+            "Account",
+            cls._static_request("delete", url, params=params),
+        )
+
+    @util.class_method_variant("_cls_delete")
+    def delete(self, **params) -> "Account":
+        return self._request_and_refresh(
+            "delete",
+            self.instance_url(),
+            params=params,
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Account"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
 
     @classmethod
     def _cls_persons(

--- a/stripe/api_resources/account_link.py
+++ b/stripe/api_resources/account_link.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import CreateableAPIResource
+from typing import cast
 from typing_extensions import Literal
 
 
@@ -19,3 +20,25 @@ class AccountLink(CreateableAPIResource["AccountLink"]):
     expires_at: str
     object: Literal["account_link"]
     url: str
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "AccountLink":
+        return cast(
+            "AccountLink",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )

--- a/stripe/api_resources/account_session.py
+++ b/stripe/api_resources/account_session.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.stripe_object import StripeObject
+from typing import cast
 from typing_extensions import Literal
 
 
@@ -25,3 +26,25 @@ class AccountSession(CreateableAPIResource["AccountSession"]):
     expires_at: str
     livemode: bool
     object: Literal["account_session"]
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "AccountSession":
+        return cast(
+            "AccountSession",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )

--- a/stripe/api_resources/apple_pay_domain.py
+++ b/stripe/api_resources/apple_pay_domain.py
@@ -2,12 +2,16 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     DeletableAPIResource,
     ListableAPIResource,
 )
+from stripe.api_resources.list_object import ListObject
+from typing import cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 
 class ApplePayDomain(
@@ -21,6 +25,71 @@ class ApplePayDomain(
     id: str
     livemode: bool
     object: Literal["apple_pay_domain"]
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "ApplePayDomain":
+        return cast(
+            "ApplePayDomain",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def _cls_delete(cls, sid, **params) -> "ApplePayDomain":
+        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        return cast(
+            "ApplePayDomain",
+            cls._static_request("delete", url, params=params),
+        )
+
+    @util.class_method_variant("_cls_delete")
+    def delete(self, **params) -> "ApplePayDomain":
+        return self._request_and_refresh(
+            "delete",
+            self.instance_url(),
+            params=params,
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["ApplePayDomain"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "ApplePayDomain":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance
 
     @classmethod
     def class_url(cls):

--- a/stripe/api_resources/application_fee.py
+++ b/stripe/api_resources/application_fee.py
@@ -46,6 +46,27 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
     refunds: ListObject["ApplicationFeeRefund"]
 
     @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["ApplicationFee"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
     def _cls_refund(
         cls,
         id,
@@ -75,3 +96,9 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
             idempotency_key=idempotency_key,
             params=params,
         )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "ApplicationFee":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/apps/secret.py
+++ b/stripe/api_resources/apps/secret.py
@@ -6,8 +6,9 @@ from stripe.api_resources.abstract import (
     CreateableAPIResource,
     ListableAPIResource,
 )
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Optional
+from typing import Optional, cast
 from typing_extensions import Literal
 
 
@@ -36,6 +37,28 @@ class Secret(CreateableAPIResource["Secret"], ListableAPIResource["Secret"]):
     scope: StripeObject
 
     @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Secret":
+        return cast(
+            "Secret",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
     def delete_where(
         cls, api_key=None, stripe_version=None, stripe_account=None, **params
     ):
@@ -60,3 +83,24 @@ class Secret(CreateableAPIResource["Secret"], ListableAPIResource["Secret"]):
             stripe_account=stripe_account,
             params=params,
         )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Secret"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result

--- a/stripe/api_resources/balance.py
+++ b/stripe/api_resources/balance.py
@@ -33,5 +33,11 @@ class Balance(SingletonAPIResource["Balance"]):
     pending: List[StripeObject]
 
     @classmethod
+    def retrieve(cls, **params) -> "Balance":
+        instance = cls(None, **params)
+        instance.refresh()
+        return instance
+
+    @classmethod
     def class_url(cls):
         return "/v1/balance"

--- a/stripe/api_resources/balance_transaction.py
+++ b/stripe/api_resources/balance_transaction.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Any, List, Optional
 from typing_extensions import Literal
@@ -33,3 +34,30 @@ class BalanceTransaction(ListableAPIResource["BalanceTransaction"]):
     source: Optional[ExpandableField[Any]]
     status: str
     type: str
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["BalanceTransaction"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "BalanceTransaction":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/bank_account.py
+++ b/stripe/api_resources/bank_account.py
@@ -2,7 +2,7 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
-from stripe import error
+from stripe import error, util
 from stripe.api_resources.abstract import (
     DeletableAPIResource,
     UpdateableAPIResource,
@@ -12,7 +12,7 @@ from stripe.api_resources.account import Account
 from stripe.api_resources.customer import Customer
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
 from urllib.parse import quote_plus
 
@@ -52,6 +52,22 @@ class BankAccount(
     requirements: Optional[StripeObject]
     routing_number: Optional[str]
     status: str
+
+    @classmethod
+    def _cls_delete(cls, sid, **params) -> Any:
+        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        return cast(
+            Any,
+            cls._static_request("delete", url, params=params),
+        )
+
+    @util.class_method_variant("_cls_delete")
+    def delete(self, **params) -> Any:
+        return self._request_and_refresh(
+            "delete",
+            self.instance_url(),
+            params=params,
+        )
 
     def instance_url(self):
         token = self.id

--- a/stripe/api_resources/billing_portal/configuration.py
+++ b/stripe/api_resources/billing_portal/configuration.py
@@ -2,14 +2,16 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     ListableAPIResource,
     UpdateableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 from typing_extensions import Literal
 
 
@@ -36,3 +38,83 @@ class Configuration(
     metadata: Optional[Dict[str, str]]
     object: Literal["billing_portal.configuration"]
     updated: str
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Configuration":
+        return cast(
+            "Configuration",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Configuration"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        configuration,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/billing_portal/configurations/{configuration}".format(
+                configuration=util.sanitize_id(configuration)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/billing_portal/configurations/{configuration}".format(
+                configuration=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Configuration":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/billing_portal/configuration.py
+++ b/stripe/api_resources/billing_portal/configuration.py
@@ -2,7 +2,6 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
-from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     ListableAPIResource,
@@ -13,6 +12,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Any, Dict, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 
 class Configuration(
@@ -83,34 +83,11 @@ class Configuration(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        configuration,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/billing_portal/configurations/{configuration}".format(
-                configuration=util.sanitize_id(configuration)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/billing_portal/configurations/{configuration}".format(
-                configuration=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "Configuration":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "Configuration",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/billing_portal/session.py
+++ b/stripe/api_resources/billing_portal/session.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Optional
+from typing import Optional, cast
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -44,3 +44,25 @@ class Session(CreateableAPIResource["Session"]):
     on_behalf_of: Optional[str]
     return_url: Optional[str]
     url: str
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Session":
+        return cast(
+            "Session",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )

--- a/stripe/api_resources/card.py
+++ b/stripe/api_resources/card.py
@@ -2,7 +2,7 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
-from stripe import error
+from stripe import error, util
 from stripe.api_resources.abstract import (
     DeletableAPIResource,
     UpdateableAPIResource,
@@ -10,7 +10,7 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.account import Account
 from stripe.api_resources.customer import Customer
 from stripe.api_resources.expandable_field import ExpandableField
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
 from urllib.parse import quote_plus
 
@@ -56,6 +56,22 @@ class Card(DeletableAPIResource["Card"], UpdateableAPIResource["Card"]):
     object: Literal["card"]
     status: Optional[str]
     tokenization_method: Optional[str]
+
+    @classmethod
+    def _cls_delete(cls, sid, **params) -> Any:
+        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        return cast(
+            Any,
+            cls._static_request("delete", url, params=params),
+        )
+
+    @util.class_method_variant("_cls_delete")
+    def delete(self, **params) -> Any:
+        return self._request_and_refresh(
+            "delete",
+            self.instance_url(),
+            params=params,
+        )
 
     def instance_url(self):
         token = self.id

--- a/stripe/api_resources/charge.py
+++ b/stripe/api_resources/charge.py
@@ -14,6 +14,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Any, Dict, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -169,32 +170,11 @@ class Charge(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        charge,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/charges/{charge}".format(charge=util.sanitize_id(charge)),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/charges/{charge}".format(
-                charge=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "Charge":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "Charge",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/charge.py
+++ b/stripe/api_resources/charge.py
@@ -12,7 +12,7 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -126,11 +126,89 @@ class Charge(
         )
 
     @classmethod
-    def search(cls, *args, **kwargs):
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Charge":
+        return cast(
+            "Charge",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Charge"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        charge,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/charges/{charge}".format(charge=util.sanitize_id(charge)),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/charges/{charge}".format(
+                charge=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Charge":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance
+
+    @classmethod
+    def search(cls, *args, **kwargs) -> Any:
         return cls._search(search_url="/v1/charges/search", *args, **kwargs)
 
     @classmethod
-    def search_auto_paging_iter(cls, *args, **kwargs):
+    def search_auto_paging_iter(cls, *args, **kwargs) -> Any:
         return cls.search(*args, **kwargs).auto_paging_iter()
 
     def mark_as_fraudulent(self, idempotency_key=None):

--- a/stripe/api_resources/checkout/session.py
+++ b/stripe/api_resources/checkout/session.py
@@ -10,7 +10,7 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -96,6 +96,28 @@ class Session(
     url: Optional[str]
 
     @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Session":
+        return cast(
+            "Session",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
     def _cls_expire(
         cls,
         session,
@@ -127,6 +149,27 @@ class Session(
         )
 
     @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Session"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
     def _cls_list_line_items(
         cls,
         session,
@@ -156,3 +199,9 @@ class Session(
             idempotency_key=idempotency_key,
             params=params,
         )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Session":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/country_spec.py
+++ b/stripe/api_resources/country_spec.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Dict, List
 from typing_extensions import Literal
@@ -27,3 +28,30 @@ class CountrySpec(ListableAPIResource["CountrySpec"]):
     supported_payment_methods: List[str]
     supported_transfer_countries: List[str]
     verification_fields: StripeObject
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["CountrySpec"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "CountrySpec":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/coupon.py
+++ b/stripe/api_resources/coupon.py
@@ -2,15 +2,18 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     DeletableAPIResource,
     ListableAPIResource,
     UpdateableAPIResource,
 )
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Dict, Optional
+from typing import Dict, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 
 class Coupon(
@@ -43,3 +46,97 @@ class Coupon(
     redeem_by: Optional[str]
     times_redeemed: int
     valid: bool
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Coupon":
+        return cast(
+            "Coupon",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def _cls_delete(cls, sid, **params) -> "Coupon":
+        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        return cast(
+            "Coupon",
+            cls._static_request("delete", url, params=params),
+        )
+
+    @util.class_method_variant("_cls_delete")
+    def delete(self, **params) -> "Coupon":
+        return self._request_and_refresh(
+            "delete",
+            self.instance_url(),
+            params=params,
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Coupon"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        coupon,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/coupons/{coupon}".format(coupon=util.sanitize_id(coupon)),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/coupons/{coupon}".format(
+                coupon=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Coupon":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/coupon.py
+++ b/stripe/api_resources/coupon.py
@@ -107,32 +107,11 @@ class Coupon(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        coupon,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/coupons/{coupon}".format(coupon=util.sanitize_id(coupon)),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/coupons/{coupon}".format(
-                coupon=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "Coupon":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "Coupon",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/credit_note.py
+++ b/stripe/api_resources/credit_note.py
@@ -12,7 +12,7 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -76,6 +76,78 @@ class CreditNote(
     voided_at: Optional[str]
 
     @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "CreditNote":
+        return cast(
+            "CreditNote",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["CreditNote"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        id,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/credit_notes/{id}".format(id=util.sanitize_id(id)),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/credit_notes/{id}".format(
+                id=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
     def preview(
         cls, api_key=None, stripe_version=None, stripe_account=None, **params
     ):
@@ -100,6 +172,12 @@ class CreditNote(
             stripe_account=stripe_account,
             params=params,
         )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "CreditNote":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance
 
     @classmethod
     def _cls_void_credit_note(

--- a/stripe/api_resources/credit_note.py
+++ b/stripe/api_resources/credit_note.py
@@ -14,6 +14,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -119,32 +120,11 @@ class CreditNote(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        id,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/credit_notes/{id}".format(id=util.sanitize_id(id)),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/credit_notes/{id}".format(
-                id=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "CreditNote":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "CreditNote",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/credit_note_line_item.py
+++ b/stripe/api_resources/credit_note_line_item.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import List, Optional
 from typing_extensions import Literal
@@ -35,3 +36,24 @@ class CreditNoteLineItem(ListableAPIResource["CreditNoteLineItem"]):
     unit_amount: Optional[int]
     unit_amount_decimal: Optional[float]
     unit_amount_excluding_tax: Optional[float]
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["CreditNoteLineItem"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result

--- a/stripe/api_resources/customer.py
+++ b/stripe/api_resources/customer.py
@@ -241,34 +241,11 @@ class Customer(
         )
 
     @classmethod
-    def _cls_modify(
-        cls,
-        customer,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/customers/{customer}".format(
-                customer=util.sanitize_id(customer)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/customers/{customer}".format(
-                customer=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "Customer":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "Customer",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/customer_cash_balance_transaction.py
+++ b/stripe/api_resources/customer_cash_balance_transaction.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing_extensions import Literal
 
@@ -38,3 +39,32 @@ class CustomerCashBalanceTransaction(
     refunded_from_payment: StripeObject
     type: str
     unapplied_from_payment: StripeObject
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["CustomerCashBalanceTransaction"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(
+        cls, id, api_key=None, **params
+    ) -> "CustomerCashBalanceTransaction":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/dispute.py
+++ b/stripe/api_resources/dispute.py
@@ -8,6 +8,7 @@ from stripe.api_resources.abstract import (
     UpdateableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional
 from typing_extensions import Literal
@@ -82,3 +83,59 @@ class Dispute(
             idempotency_key=idempotency_key,
             params=params,
         )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Dispute"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        dispute,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/disputes/{dispute}".format(dispute=util.sanitize_id(dispute)),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/disputes/{dispute}".format(
+                dispute=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Dispute":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/dispute.py
+++ b/stripe/api_resources/dispute.py
@@ -10,8 +10,9 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -106,32 +107,11 @@ class Dispute(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        dispute,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/disputes/{dispute}".format(dispute=util.sanitize_id(dispute)),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/disputes/{dispute}".format(
-                dispute=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "Dispute":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "Dispute",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/ephemeral_key.py
+++ b/stripe/api_resources/ephemeral_key.py
@@ -4,7 +4,9 @@ from __future__ import absolute_import, division, print_function
 
 from stripe import api_requestor, util
 from stripe.api_resources.abstract import DeletableAPIResource
+from typing import cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 
 class EphemeralKey(DeletableAPIResource["EphemeralKey"]):
@@ -15,6 +17,22 @@ class EphemeralKey(DeletableAPIResource["EphemeralKey"]):
     livemode: bool
     object: Literal["ephemeral_key"]
     secret: str
+
+    @classmethod
+    def _cls_delete(cls, sid, **params) -> "EphemeralKey":
+        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        return cast(
+            "EphemeralKey",
+            cls._static_request("delete", url, params=params),
+        )
+
+    @util.class_method_variant("_cls_delete")
+    def delete(self, **params) -> "EphemeralKey":
+        return self._request_and_refresh(
+            "delete",
+            self.instance_url(),
+            params=params,
+        )
 
     @classmethod
     def create(

--- a/stripe/api_resources/event.py
+++ b/stripe/api_resources/event.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Optional
 from typing_extensions import Literal
@@ -52,3 +53,30 @@ class Event(ListableAPIResource["Event"]):
     pending_webhooks: int
     request: Optional[StripeObject]
     type: str
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Event"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Event":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/exchange_rate.py
+++ b/stripe/api_resources/exchange_rate.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.list_object import ListObject
 from typing import Dict
 from typing_extensions import Literal
 
@@ -26,3 +27,30 @@ class ExchangeRate(ListableAPIResource["ExchangeRate"]):
     id: str
     object: Literal["exchange_rate"]
     rates: Dict[str, float]
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["ExchangeRate"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "ExchangeRate":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/file.py
+++ b/stripe/api_resources/file.py
@@ -39,6 +39,33 @@ class File(ListableAPIResource["File"]):
     type: Optional[str]
     url: Optional[str]
 
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["File"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "File":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance
+
     # This resource can have two different object names. In latter API
     # versions, only `file` is used, but since stripe-python may be used with
     # any API version, we need to support deserializing the older

--- a/stripe/api_resources/file_link.py
+++ b/stripe/api_resources/file_link.py
@@ -2,13 +2,15 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     ListableAPIResource,
     UpdateableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
-from typing import Dict, Optional
+from stripe.api_resources.list_object import ListObject
+from typing import Dict, Optional, cast
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -38,3 +40,81 @@ class FileLink(
     metadata: Dict[str, str]
     object: Literal["file_link"]
     url: Optional[str]
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "FileLink":
+        return cast(
+            "FileLink",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["FileLink"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        link,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/file_links/{link}".format(link=util.sanitize_id(link)),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/file_links/{link}".format(
+                link=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "FileLink":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/file_link.py
+++ b/stripe/api_resources/file_link.py
@@ -2,7 +2,6 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
-from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     ListableAPIResource,
@@ -12,6 +11,7 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from typing import Dict, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -85,32 +85,11 @@ class FileLink(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        link,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/file_links/{link}".format(link=util.sanitize_id(link)),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/file_links/{link}".format(
-                link=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "FileLink":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "FileLink",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/financial_connections/account.py
+++ b/stripe/api_resources/financial_connections/account.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe import util
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import List, Optional
 from typing_extensions import Literal
@@ -73,6 +74,27 @@ class Account(ListableAPIResource["Account"]):
         )
 
     @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Account"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
     def _cls_list_owners(
         cls,
         account,
@@ -133,3 +155,9 @@ class Account(ListableAPIResource["Account"]):
             idempotency_key=idempotency_key,
             params=params,
         )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Account":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/financial_connections/session.py
+++ b/stripe/api_resources/financial_connections/session.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import List, Optional
+from typing import List, Optional, cast
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -30,3 +30,31 @@ class Session(CreateableAPIResource["Session"]):
     permissions: List[str]
     prefetch: Optional[List[str]]
     return_url: str
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Session":
+        return cast(
+            "Session",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Session":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/identity/verification_report.py
+++ b/stripe/api_resources/identity/verification_report.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Optional
 from typing_extensions import Literal
@@ -34,3 +35,30 @@ class VerificationReport(ListableAPIResource["VerificationReport"]):
     selfie: StripeObject
     type: str
     verification_session: Optional[str]
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["VerificationReport"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "VerificationReport":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/identity/verification_session.py
+++ b/stripe/api_resources/identity/verification_session.py
@@ -13,6 +13,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Dict, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -132,34 +133,11 @@ class VerificationSession(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        session,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/identity/verification_sessions/{session}".format(
-                session=util.sanitize_id(session)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/identity/verification_sessions/{session}".format(
-                session=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "VerificationSession":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "VerificationSession",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/identity/verification_session.py
+++ b/stripe/api_resources/identity/verification_session.py
@@ -9,8 +9,9 @@ from stripe.api_resources.abstract import (
     UpdateableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Dict, Optional
+from typing import Dict, Optional, cast
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -88,6 +89,80 @@ class VerificationSession(
         )
 
     @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "VerificationSession":
+        return cast(
+            "VerificationSession",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["VerificationSession"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        session,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/identity/verification_sessions/{session}".format(
+                session=util.sanitize_id(session)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/identity/verification_sessions/{session}".format(
+                session=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
     def _cls_redact(
         cls,
         session,
@@ -117,3 +192,9 @@ class VerificationSession(
             idempotency_key=idempotency_key,
             params=params,
         )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "VerificationSession":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/invoice.py
+++ b/stripe/api_resources/invoice.py
@@ -279,32 +279,11 @@ class Invoice(
         )
 
     @classmethod
-    def _cls_modify(
-        cls,
-        invoice,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/invoices/{invoice}".format(invoice=util.sanitize_id(invoice)),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/invoices/{invoice}".format(
-                invoice=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "Invoice":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "Invoice",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/invoice_item.py
+++ b/stripe/api_resources/invoice_item.py
@@ -133,34 +133,11 @@ class InvoiceItem(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        invoiceitem,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/invoiceitems/{invoiceitem}".format(
-                invoiceitem=util.sanitize_id(invoiceitem)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/invoiceitems/{invoiceitem}".format(
-                invoiceitem=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "InvoiceItem":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "InvoiceItem",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/invoice_item.py
+++ b/stripe/api_resources/invoice_item.py
@@ -2,6 +2,7 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     DeletableAPIResource,
@@ -9,9 +10,11 @@ from stripe.api_resources.abstract import (
     UpdateableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -69,3 +72,99 @@ class InvoiceItem(
     test_clock: Optional[ExpandableField["TestClock"]]
     unit_amount: Optional[int]
     unit_amount_decimal: Optional[float]
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "InvoiceItem":
+        return cast(
+            "InvoiceItem",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def _cls_delete(cls, sid, **params) -> "InvoiceItem":
+        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        return cast(
+            "InvoiceItem",
+            cls._static_request("delete", url, params=params),
+        )
+
+    @util.class_method_variant("_cls_delete")
+    def delete(self, **params) -> "InvoiceItem":
+        return self._request_and_refresh(
+            "delete",
+            self.instance_url(),
+            params=params,
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["InvoiceItem"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        invoiceitem,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/invoiceitems/{invoiceitem}".format(
+                invoiceitem=util.sanitize_id(invoiceitem)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/invoiceitems/{invoiceitem}".format(
+                invoiceitem=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "InvoiceItem":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/issuing/authorization.py
+++ b/stripe/api_resources/issuing/authorization.py
@@ -8,6 +8,7 @@ from stripe.api_resources.abstract import (
     UpdateableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional
 from typing_extensions import Literal
@@ -120,3 +121,61 @@ class Authorization(
             idempotency_key=idempotency_key,
             params=params,
         )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Authorization"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        authorization,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/issuing/authorizations/{authorization}".format(
+                authorization=util.sanitize_id(authorization)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/issuing/authorizations/{authorization}".format(
+                authorization=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Authorization":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/issuing/authorization.py
+++ b/stripe/api_resources/issuing/authorization.py
@@ -10,8 +10,9 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -144,34 +145,11 @@ class Authorization(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        authorization,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/issuing/authorizations/{authorization}".format(
-                authorization=util.sanitize_id(authorization)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/issuing/authorizations/{authorization}".format(
-                authorization=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "Authorization":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "Authorization",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/issuing/card.py
+++ b/stripe/api_resources/issuing/card.py
@@ -10,8 +10,9 @@ from stripe.api_resources.abstract import (
     UpdateableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Dict, Optional
+from typing import Dict, Optional, cast
 from typing_extensions import Literal, Type
 
 from typing_extensions import TYPE_CHECKING
@@ -53,6 +54,84 @@ class Card(
     status: str
     type: str
     wallets: Optional[StripeObject]
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Card":
+        return cast(
+            "Card",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Card"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        card,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/issuing/cards/{card}".format(card=util.sanitize_id(card)),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/issuing/cards/{card}".format(
+                card=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Card":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance
 
     class TestHelpers(APIResourceTestHelpers["Card"]):
         _resource_cls: Type["Card"]

--- a/stripe/api_resources/issuing/card.py
+++ b/stripe/api_resources/issuing/card.py
@@ -14,6 +14,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Dict, Optional, cast
 from typing_extensions import Literal, Type
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -99,32 +100,11 @@ class Card(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        card,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/issuing/cards/{card}".format(card=util.sanitize_id(card)),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/issuing/cards/{card}".format(
-                card=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "Card":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "Card",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/issuing/cardholder.py
+++ b/stripe/api_resources/issuing/cardholder.py
@@ -2,13 +2,15 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     ListableAPIResource,
     UpdateableAPIResource,
 )
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, cast
 from typing_extensions import Literal
 
 
@@ -40,3 +42,83 @@ class Cardholder(
     spending_controls: Optional[StripeObject]
     status: str
     type: str
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Cardholder":
+        return cast(
+            "Cardholder",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Cardholder"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        cardholder,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/issuing/cardholders/{cardholder}".format(
+                cardholder=util.sanitize_id(cardholder)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/issuing/cardholders/{cardholder}".format(
+                cardholder=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Cardholder":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/issuing/cardholder.py
+++ b/stripe/api_resources/issuing/cardholder.py
@@ -2,7 +2,6 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
-from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     ListableAPIResource,
@@ -12,6 +11,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 
 class Cardholder(
@@ -87,34 +87,11 @@ class Cardholder(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        cardholder,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/issuing/cardholders/{cardholder}".format(
-                cardholder=util.sanitize_id(cardholder)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/issuing/cardholders/{cardholder}".format(
-                cardholder=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "Cardholder":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "Cardholder",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/issuing/dispute.py
+++ b/stripe/api_resources/issuing/dispute.py
@@ -9,8 +9,9 @@ from stripe.api_resources.abstract import (
     UpdateableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, cast
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -44,6 +45,86 @@ class Dispute(
     status: str
     transaction: ExpandableField["Transaction"]
     treasury: Optional[StripeObject]
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Dispute":
+        return cast(
+            "Dispute",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Dispute"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        dispute,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/issuing/disputes/{dispute}".format(
+                dispute=util.sanitize_id(dispute)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/issuing/disputes/{dispute}".format(
+                dispute=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Dispute":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance
 
     @classmethod
     def _cls_submit(

--- a/stripe/api_resources/issuing/dispute.py
+++ b/stripe/api_resources/issuing/dispute.py
@@ -13,6 +13,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -90,34 +91,11 @@ class Dispute(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        dispute,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/issuing/disputes/{dispute}".format(
-                dispute=util.sanitize_id(dispute)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/issuing/disputes/{dispute}".format(
-                dispute=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "Dispute":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "Dispute",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/issuing/transaction.py
+++ b/stripe/api_resources/issuing/transaction.py
@@ -2,11 +2,13 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import (
     ListableAPIResource,
     UpdateableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Dict, Optional
 from typing_extensions import Literal
@@ -54,3 +56,61 @@ class Transaction(
     treasury: Optional[StripeObject]
     type: str
     wallet: Optional[str]
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Transaction"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        transaction,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/issuing/transactions/{transaction}".format(
+                transaction=util.sanitize_id(transaction)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/issuing/transactions/{transaction}".format(
+                transaction=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Transaction":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/issuing/transaction.py
+++ b/stripe/api_resources/issuing/transaction.py
@@ -2,7 +2,6 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
-from stripe import util
 from stripe.api_resources.abstract import (
     ListableAPIResource,
     UpdateableAPIResource,
@@ -10,8 +9,9 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Dict, Optional
+from typing import Dict, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -79,34 +79,11 @@ class Transaction(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        transaction,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/issuing/transactions/{transaction}".format(
-                transaction=util.sanitize_id(transaction)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/issuing/transactions/{transaction}".format(
-                transaction=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "Transaction":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "Transaction",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/mandate.py
+++ b/stripe/api_resources/mandate.py
@@ -30,3 +30,9 @@ class Mandate(APIResource["Mandate"]):
     single_use: StripeObject
     status: str
     type: str
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Mandate":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/payment_intent.py
+++ b/stripe/api_resources/payment_intent.py
@@ -14,6 +14,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -286,34 +287,11 @@ class PaymentIntent(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        intent,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/payment_intents/{intent}".format(
-                intent=util.sanitize_id(intent)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/payment_intents/{intent}".format(
-                intent=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "PaymentIntent":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "PaymentIntent",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/payment_link.py
+++ b/stripe/api_resources/payment_link.py
@@ -13,6 +13,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -142,34 +143,11 @@ class PaymentLink(
         )
 
     @classmethod
-    def _cls_modify(
-        cls,
-        payment_link,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/payment_links/{payment_link}".format(
-                payment_link=util.sanitize_id(payment_link)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/payment_links/{payment_link}".format(
-                payment_link=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "PaymentLink":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "PaymentLink",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/payment_link.py
+++ b/stripe/api_resources/payment_link.py
@@ -11,7 +11,7 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -68,6 +68,49 @@ class PaymentLink(
     url: str
 
     @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "PaymentLink":
+        return cast(
+            "PaymentLink",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["PaymentLink"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
     def _cls_list_line_items(
         cls,
         payment_link,
@@ -97,3 +140,40 @@ class PaymentLink(
             idempotency_key=idempotency_key,
             params=params,
         )
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        payment_link,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/payment_links/{payment_link}".format(
+                payment_link=util.sanitize_id(payment_link)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/payment_links/{payment_link}".format(
+                payment_link=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "PaymentLink":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/payment_method.py
+++ b/stripe/api_resources/payment_method.py
@@ -9,8 +9,9 @@ from stripe.api_resources.abstract import (
     UpdateableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Dict, Optional
+from typing import Dict, Optional, cast
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -108,6 +109,28 @@ class PaymentMethod(
         )
 
     @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "PaymentMethod":
+        return cast(
+            "PaymentMethod",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
     def _cls_detach(
         cls,
         payment_method,
@@ -137,3 +160,61 @@ class PaymentMethod(
             idempotency_key=idempotency_key,
             params=params,
         )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["PaymentMethod"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        payment_method,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/payment_methods/{payment_method}".format(
+                payment_method=util.sanitize_id(payment_method)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/payment_methods/{payment_method}".format(
+                payment_method=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "PaymentMethod":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/payment_method.py
+++ b/stripe/api_resources/payment_method.py
@@ -13,6 +13,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Dict, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -183,34 +184,11 @@ class PaymentMethod(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        payment_method,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/payment_methods/{payment_method}".format(
-                payment_method=util.sanitize_id(payment_method)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/payment_methods/{payment_method}".format(
-                payment_method=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "PaymentMethod":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "PaymentMethod",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/payment_method_domain.py
+++ b/stripe/api_resources/payment_method_domain.py
@@ -8,7 +8,9 @@ from stripe.api_resources.abstract import (
     ListableAPIResource,
     UpdateableAPIResource,
 )
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
+from typing import cast
 from typing_extensions import Literal
 
 
@@ -35,6 +37,86 @@ class PaymentMethodDomain(
     livemode: bool
     object: Literal["payment_method_domain"]
     paypal: StripeObject
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "PaymentMethodDomain":
+        return cast(
+            "PaymentMethodDomain",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["PaymentMethodDomain"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        payment_method_domain,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/payment_method_domains/{payment_method_domain}".format(
+                payment_method_domain=util.sanitize_id(payment_method_domain)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/payment_method_domains/{payment_method_domain}".format(
+                payment_method_domain=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "PaymentMethodDomain":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance
 
     @classmethod
     def _cls_validate(

--- a/stripe/api_resources/payment_method_domain.py
+++ b/stripe/api_resources/payment_method_domain.py
@@ -12,6 +12,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 
 class PaymentMethodDomain(
@@ -82,34 +83,11 @@ class PaymentMethodDomain(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        payment_method_domain,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/payment_method_domains/{payment_method_domain}".format(
-                payment_method_domain=util.sanitize_id(payment_method_domain)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/payment_method_domains/{payment_method_domain}".format(
-                payment_method_domain=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "PaymentMethodDomain":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "PaymentMethodDomain",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/payout.py
+++ b/stripe/api_resources/payout.py
@@ -9,7 +9,8 @@ from stripe.api_resources.abstract import (
     UpdateableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
-from typing import Any, Dict, Optional
+from stripe.api_resources.list_object import ListObject
+from typing import Any, Dict, Optional, cast
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -91,6 +92,84 @@ class Payout(
             idempotency_key=idempotency_key,
             params=params,
         )
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Payout":
+        return cast(
+            "Payout",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Payout"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        payout,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/payouts/{payout}".format(payout=util.sanitize_id(payout)),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/payouts/{payout}".format(
+                payout=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Payout":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance
 
     @classmethod
     def _cls_reverse(

--- a/stripe/api_resources/payout.py
+++ b/stripe/api_resources/payout.py
@@ -12,6 +12,7 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from typing import Any, Dict, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -137,32 +138,11 @@ class Payout(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        payout,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/payouts/{payout}".format(payout=util.sanitize_id(payout)),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/payouts/{payout}".format(
-                payout=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "Payout":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "Payout",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/plan.py
+++ b/stripe/api_resources/plan.py
@@ -116,30 +116,11 @@ class Plan(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        plan,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/plans/{plan}".format(plan=util.sanitize_id(plan)),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/plans/{plan}".format(plan=util.sanitize_id(self.get("id"))),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "Plan":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "Plan",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/plan.py
+++ b/stripe/api_resources/plan.py
@@ -2,6 +2,7 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     DeletableAPIResource,
@@ -9,9 +10,11 @@ from stripe.api_resources.abstract import (
     UpdateableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 
 class Plan(
@@ -52,3 +55,95 @@ class Plan(
     transform_usage: Optional[StripeObject]
     trial_period_days: Optional[int]
     usage_type: str
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Plan":
+        return cast(
+            "Plan",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def _cls_delete(cls, sid, **params) -> "Plan":
+        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        return cast(
+            "Plan",
+            cls._static_request("delete", url, params=params),
+        )
+
+    @util.class_method_variant("_cls_delete")
+    def delete(self, **params) -> "Plan":
+        return self._request_and_refresh(
+            "delete",
+            self.instance_url(),
+            params=params,
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Plan"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        plan,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/plans/{plan}".format(plan=util.sanitize_id(plan)),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/plans/{plan}".format(plan=util.sanitize_id(self.get("id"))),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Plan":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/price.py
+++ b/stripe/api_resources/price.py
@@ -2,6 +2,7 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     ListableAPIResource,
@@ -9,8 +10,9 @@ from stripe.api_resources.abstract import (
     UpdateableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
 
 
@@ -53,9 +55,87 @@ class Price(
     unit_amount_decimal: Optional[float]
 
     @classmethod
-    def search(cls, *args, **kwargs):
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Price":
+        return cast(
+            "Price",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Price"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        price,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/prices/{price}".format(price=util.sanitize_id(price)),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/prices/{price}".format(
+                price=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Price":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance
+
+    @classmethod
+    def search(cls, *args, **kwargs) -> Any:
         return cls._search(search_url="/v1/prices/search", *args, **kwargs)
 
     @classmethod
-    def search_auto_paging_iter(cls, *args, **kwargs):
+    def search_auto_paging_iter(cls, *args, **kwargs) -> Any:
         return cls.search(*args, **kwargs).auto_paging_iter()

--- a/stripe/api_resources/price.py
+++ b/stripe/api_resources/price.py
@@ -2,7 +2,6 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
-from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     ListableAPIResource,
@@ -14,6 +13,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 
 class Price(
@@ -98,32 +98,11 @@ class Price(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        price,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/prices/{price}".format(price=util.sanitize_id(price)),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/prices/{price}".format(
-                price=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "Price":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "Price",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/product.py
+++ b/stripe/api_resources/product.py
@@ -123,30 +123,11 @@ class Product(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        id,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/products/{id}".format(id=util.sanitize_id(id)),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/products/{id}".format(id=util.sanitize_id(self.get("id"))),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "Product":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "Product",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/product.py
+++ b/stripe/api_resources/product.py
@@ -2,6 +2,7 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     DeletableAPIResource,
@@ -10,9 +11,11 @@ from stripe.api_resources.abstract import (
     UpdateableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -61,9 +64,101 @@ class Product(
     url: Optional[str]
 
     @classmethod
-    def search(cls, *args, **kwargs):
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Product":
+        return cast(
+            "Product",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def _cls_delete(cls, sid, **params) -> "Product":
+        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        return cast(
+            "Product",
+            cls._static_request("delete", url, params=params),
+        )
+
+    @util.class_method_variant("_cls_delete")
+    def delete(self, **params) -> "Product":
+        return self._request_and_refresh(
+            "delete",
+            self.instance_url(),
+            params=params,
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Product"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        id,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/products/{id}".format(id=util.sanitize_id(id)),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/products/{id}".format(id=util.sanitize_id(self.get("id"))),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Product":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance
+
+    @classmethod
+    def search(cls, *args, **kwargs) -> Any:
         return cls._search(search_url="/v1/products/search", *args, **kwargs)
 
     @classmethod
-    def search_auto_paging_iter(cls, *args, **kwargs):
+    def search_auto_paging_iter(cls, *args, **kwargs) -> Any:
         return cls.search(*args, **kwargs).auto_paging_iter()

--- a/stripe/api_resources/promotion_code.py
+++ b/stripe/api_resources/promotion_code.py
@@ -2,7 +2,6 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
-from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     ListableAPIResource,
@@ -13,6 +12,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Any, Dict, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -89,34 +89,11 @@ class PromotionCode(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        promotion_code,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/promotion_codes/{promotion_code}".format(
-                promotion_code=util.sanitize_id(promotion_code)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/promotion_codes/{promotion_code}".format(
-                promotion_code=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "PromotionCode":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "PromotionCode",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/promotion_code.py
+++ b/stripe/api_resources/promotion_code.py
@@ -2,14 +2,16 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     ListableAPIResource,
     UpdateableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -42,3 +44,83 @@ class PromotionCode(
     object: Literal["promotion_code"]
     restrictions: StripeObject
     times_redeemed: int
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "PromotionCode":
+        return cast(
+            "PromotionCode",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["PromotionCode"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        promotion_code,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/promotion_codes/{promotion_code}".format(
+                promotion_code=util.sanitize_id(promotion_code)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/promotion_codes/{promotion_code}".format(
+                promotion_code=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "PromotionCode":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/quote.py
+++ b/stripe/api_resources/quote.py
@@ -12,7 +12,7 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
 from urllib.parse import quote_plus
 
@@ -134,6 +134,28 @@ class Quote(
         )
 
     @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Quote":
+        return cast(
+            "Quote",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
     def _cls_finalize_quote(
         cls,
         quote,
@@ -163,6 +185,27 @@ class Quote(
             idempotency_key=idempotency_key,
             params=params,
         )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Quote"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
 
     @classmethod
     def _cls_list_computed_upfront_line_items(
@@ -225,6 +268,41 @@ class Quote(
             idempotency_key=idempotency_key,
             params=params,
         )
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        quote,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/quotes/{quote}".format(quote=util.sanitize_id(quote)),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/quotes/{quote}".format(
+                quote=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Quote":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance
 
     @classmethod
     def _cls_pdf(

--- a/stripe/api_resources/quote.py
+++ b/stripe/api_resources/quote.py
@@ -270,32 +270,11 @@ class Quote(
         )
 
     @classmethod
-    def _cls_modify(
-        cls,
-        quote,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/quotes/{quote}".format(quote=util.sanitize_id(quote)),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/quotes/{quote}".format(
-                quote=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "Quote":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "Quote",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/radar/early_fraud_warning.py
+++ b/stripe/api_resources/radar/early_fraud_warning.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -30,3 +31,30 @@ class EarlyFraudWarning(ListableAPIResource["EarlyFraudWarning"]):
     livemode: bool
     object: Literal["radar.early_fraud_warning"]
     payment_intent: ExpandableField["PaymentIntent"]
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["EarlyFraudWarning"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "EarlyFraudWarning":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/radar/value_list.py
+++ b/stripe/api_resources/radar/value_list.py
@@ -2,6 +2,7 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     DeletableAPIResource,
@@ -9,8 +10,9 @@ from stripe.api_resources.abstract import (
     UpdateableAPIResource,
 )
 from stripe.api_resources.list_object import ListObject
-from typing import Dict
+from typing import Dict, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -41,3 +43,99 @@ class ValueList(
     metadata: Dict[str, str]
     name: str
     object: Literal["radar.value_list"]
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "ValueList":
+        return cast(
+            "ValueList",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def _cls_delete(cls, sid, **params) -> "ValueList":
+        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        return cast(
+            "ValueList",
+            cls._static_request("delete", url, params=params),
+        )
+
+    @util.class_method_variant("_cls_delete")
+    def delete(self, **params) -> "ValueList":
+        return self._request_and_refresh(
+            "delete",
+            self.instance_url(),
+            params=params,
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["ValueList"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        value_list,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/radar/value_lists/{value_list}".format(
+                value_list=util.sanitize_id(value_list)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/radar/value_lists/{value_list}".format(
+                value_list=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "ValueList":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/radar/value_list.py
+++ b/stripe/api_resources/radar/value_list.py
@@ -104,34 +104,11 @@ class ValueList(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        value_list,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/radar/value_lists/{value_list}".format(
-                value_list=util.sanitize_id(value_list)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/radar/value_lists/{value_list}".format(
-                value_list=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "ValueList":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "ValueList",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/radar/value_list_item.py
+++ b/stripe/api_resources/radar/value_list_item.py
@@ -2,12 +2,16 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     DeletableAPIResource,
     ListableAPIResource,
 )
+from stripe.api_resources.list_object import ListObject
+from typing import cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 
 class ValueListItem(
@@ -29,3 +33,68 @@ class ValueListItem(
     object: Literal["radar.value_list_item"]
     value: str
     value_list: str
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "ValueListItem":
+        return cast(
+            "ValueListItem",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def _cls_delete(cls, sid, **params) -> "ValueListItem":
+        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        return cast(
+            "ValueListItem",
+            cls._static_request("delete", url, params=params),
+        )
+
+    @util.class_method_variant("_cls_delete")
+    def delete(self, **params) -> "ValueListItem":
+        return self._request_and_refresh(
+            "delete",
+            self.instance_url(),
+            params=params,
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["ValueListItem"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "ValueListItem":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/refund.py
+++ b/stripe/api_resources/refund.py
@@ -14,6 +14,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Dict, Optional, cast
 from typing_extensions import Literal, Type
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -133,32 +134,11 @@ class Refund(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        refund,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/refunds/{refund}".format(refund=util.sanitize_id(refund)),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/refunds/{refund}".format(
-                refund=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "Refund":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "Refund",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/refund.py
+++ b/stripe/api_resources/refund.py
@@ -10,8 +10,9 @@ from stripe.api_resources.abstract import (
     UpdateableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Dict, Optional
+from typing import Dict, Optional, cast
 from typing_extensions import Literal, Type
 
 from typing_extensions import TYPE_CHECKING
@@ -87,6 +88,84 @@ class Refund(
             idempotency_key=idempotency_key,
             params=params,
         )
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Refund":
+        return cast(
+            "Refund",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Refund"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        refund,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/refunds/{refund}".format(refund=util.sanitize_id(refund)),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/refunds/{refund}".format(
+                refund=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Refund":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance
 
     class TestHelpers(APIResourceTestHelpers["Refund"]):
         _resource_cls: Type["Refund"]

--- a/stripe/api_resources/reporting/report_run.py
+++ b/stripe/api_resources/reporting/report_run.py
@@ -6,8 +6,9 @@ from stripe.api_resources.abstract import (
     CreateableAPIResource,
     ListableAPIResource,
 )
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Optional
+from typing import Optional, cast
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -42,3 +43,52 @@ class ReportRun(
     result: Optional["File"]
     status: str
     succeeded_at: Optional[str]
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "ReportRun":
+        return cast(
+            "ReportRun",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["ReportRun"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "ReportRun":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/reporting/report_type.py
+++ b/stripe/api_resources/reporting/report_type.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.list_object import ListObject
 from typing import List, Optional
 from typing_extensions import Literal
 
@@ -29,3 +30,30 @@ class ReportType(ListableAPIResource["ReportType"]):
     object: Literal["reporting.report_type"]
     updated: str
     version: int
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["ReportType"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "ReportType":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/review.py
+++ b/stripe/api_resources/review.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe import util
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Optional
 from typing_extensions import Literal
@@ -70,3 +71,30 @@ class Review(ListableAPIResource["Review"]):
             idempotency_key=idempotency_key,
             params=params,
         )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Review"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Review":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/setup_attempt.py
+++ b/stripe/api_resources/setup_attempt.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Any, List, Optional
 from typing_extensions import Literal
@@ -41,3 +42,24 @@ class SetupAttempt(ListableAPIResource["SetupAttempt"]):
     setup_intent: ExpandableField["SetupIntent"]
     status: str
     usage: str
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["SetupAttempt"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result

--- a/stripe/api_resources/setup_intent.py
+++ b/stripe/api_resources/setup_intent.py
@@ -9,8 +9,9 @@ from stripe.api_resources.abstract import (
     UpdateableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -140,6 +141,86 @@ class SetupIntent(
             idempotency_key=idempotency_key,
             params=params,
         )
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "SetupIntent":
+        return cast(
+            "SetupIntent",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["SetupIntent"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        intent,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/setup_intents/{intent}".format(
+                intent=util.sanitize_id(intent)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/setup_intents/{intent}".format(
+                intent=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "SetupIntent":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance
 
     @classmethod
     def _cls_verify_microdeposits(

--- a/stripe/api_resources/setup_intent.py
+++ b/stripe/api_resources/setup_intent.py
@@ -13,6 +13,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -186,34 +187,11 @@ class SetupIntent(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        intent,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/setup_intents/{intent}".format(
-                intent=util.sanitize_id(intent)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/setup_intents/{intent}".format(
-                intent=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "SetupIntent":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "SetupIntent",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/shipping_rate.py
+++ b/stripe/api_resources/shipping_rate.py
@@ -2,7 +2,6 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
-from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     ListableAPIResource,
@@ -13,6 +12,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Dict, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -88,34 +88,11 @@ class ShippingRate(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        shipping_rate_token,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/shipping_rates/{shipping_rate_token}".format(
-                shipping_rate_token=util.sanitize_id(shipping_rate_token)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/shipping_rates/{shipping_rate_token}".format(
-                shipping_rate_token=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "ShippingRate":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "ShippingRate",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/shipping_rate.py
+++ b/stripe/api_resources/shipping_rate.py
@@ -2,14 +2,16 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     ListableAPIResource,
     UpdateableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Dict, Optional
+from typing import Dict, Optional, cast
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -41,3 +43,83 @@ class ShippingRate(
     tax_behavior: Optional[str]
     tax_code: Optional[ExpandableField["TaxCode"]]
     type: Literal["fixed_amount"]
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "ShippingRate":
+        return cast(
+            "ShippingRate",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["ShippingRate"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        shipping_rate_token,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/shipping_rates/{shipping_rate_token}".format(
+                shipping_rate_token=util.sanitize_id(shipping_rate_token)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/shipping_rates/{shipping_rate_token}".format(
+                shipping_rate_token=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "ShippingRate":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/sigma/scheduled_query_run.py
+++ b/stripe/api_resources/sigma/scheduled_query_run.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Optional
 from typing_extensions import Literal
@@ -33,6 +34,33 @@ class ScheduledQueryRun(ListableAPIResource["ScheduledQueryRun"]):
     sql: str
     status: str
     title: str
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["ScheduledQueryRun"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "ScheduledQueryRun":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance
 
     @classmethod
     def class_url(cls):

--- a/stripe/api_resources/source.py
+++ b/stripe/api_resources/source.py
@@ -9,7 +9,7 @@ from stripe.api_resources.abstract import (
     UpdateableAPIResource,
 )
 from stripe.stripe_object import StripeObject
-from typing import Dict, Optional
+from typing import Dict, Optional, cast
 from typing_extensions import Literal
 from urllib.parse import quote_plus
 
@@ -69,6 +69,28 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
     wechat: StripeObject
 
     @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Source":
+        return cast(
+            "Source",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
     def _cls_list_source_transactions(
         cls,
         source,
@@ -98,6 +120,41 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
             idempotency_key=idempotency_key,
             params=params,
         )
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        source,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/sources/{source}".format(source=util.sanitize_id(source)),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/sources/{source}".format(
+                source=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Source":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance
 
     @classmethod
     def _cls_verify(

--- a/stripe/api_resources/source.py
+++ b/stripe/api_resources/source.py
@@ -122,32 +122,11 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
         )
 
     @classmethod
-    def _cls_modify(
-        cls,
-        source,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/sources/{source}".format(source=util.sanitize_id(source)),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/sources/{source}".format(
-                source=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "Source":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "Source",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/subscription.py
+++ b/stripe/api_resources/subscription.py
@@ -15,6 +15,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -198,36 +199,11 @@ class Subscription(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        subscription_exposed_id,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/subscriptions/{subscription_exposed_id}".format(
-                subscription_exposed_id=util.sanitize_id(
-                    subscription_exposed_id
-                )
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/subscriptions/{subscription_exposed_id}".format(
-                subscription_exposed_id=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "Subscription":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "Subscription",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/subscription.py
+++ b/stripe/api_resources/subscription.py
@@ -13,7 +13,7 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -122,6 +122,28 @@ class Subscription(
         )
 
     @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Subscription":
+        return cast(
+            "Subscription",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
     def _cls_delete_discount(
         cls,
         subscription_exposed_id,
@@ -148,6 +170,60 @@ class Subscription(
         return self._request(
             "delete",
             "/v1/subscriptions/{subscription_exposed_id}/discount".format(
+                subscription_exposed_id=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Subscription"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        subscription_exposed_id,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/subscriptions/{subscription_exposed_id}".format(
+                subscription_exposed_id=util.sanitize_id(
+                    subscription_exposed_id
+                )
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/subscriptions/{subscription_exposed_id}".format(
                 subscription_exposed_id=util.sanitize_id(self.get("id"))
             ),
             idempotency_key=idempotency_key,
@@ -186,11 +262,17 @@ class Subscription(
         )
 
     @classmethod
-    def search(cls, *args, **kwargs):
+    def retrieve(cls, id, api_key=None, **params) -> "Subscription":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance
+
+    @classmethod
+    def search(cls, *args, **kwargs) -> Any:
         return cls._search(
             search_url="/v1/subscriptions/search", *args, **kwargs
         )
 
     @classmethod
-    def search_auto_paging_iter(cls, *args, **kwargs):
+    def search_auto_paging_iter(cls, *args, **kwargs) -> Any:
         return cls.search(*args, **kwargs).auto_paging_iter()

--- a/stripe/api_resources/subscription_item.py
+++ b/stripe/api_resources/subscription_item.py
@@ -116,34 +116,11 @@ class SubscriptionItem(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        item,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/subscription_items/{item}".format(
-                item=util.sanitize_id(item)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/subscription_items/{item}".format(
-                item=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "SubscriptionItem":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "SubscriptionItem",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/subscription_item.py
+++ b/stripe/api_resources/subscription_item.py
@@ -2,6 +2,7 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     DeletableAPIResource,
@@ -9,9 +10,11 @@ from stripe.api_resources.abstract import (
     UpdateableAPIResource,
     nested_resource_class_methods,
 )
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -52,3 +55,99 @@ class SubscriptionItem(
     quantity: int
     subscription: str
     tax_rates: Optional[List["TaxRate"]]
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "SubscriptionItem":
+        return cast(
+            "SubscriptionItem",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def _cls_delete(cls, sid, **params) -> "SubscriptionItem":
+        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        return cast(
+            "SubscriptionItem",
+            cls._static_request("delete", url, params=params),
+        )
+
+    @util.class_method_variant("_cls_delete")
+    def delete(self, **params) -> "SubscriptionItem":
+        return self._request_and_refresh(
+            "delete",
+            self.instance_url(),
+            params=params,
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["SubscriptionItem"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        item,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/subscription_items/{item}".format(
+                item=util.sanitize_id(item)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/subscription_items/{item}".format(
+                item=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "SubscriptionItem":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/subscription_schedule.py
+++ b/stripe/api_resources/subscription_schedule.py
@@ -9,8 +9,9 @@ from stripe.api_resources.abstract import (
     UpdateableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -83,6 +84,80 @@ class SubscriptionSchedule(
         )
 
     @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "SubscriptionSchedule":
+        return cast(
+            "SubscriptionSchedule",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["SubscriptionSchedule"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        schedule,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/subscription_schedules/{schedule}".format(
+                schedule=util.sanitize_id(schedule)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/subscription_schedules/{schedule}".format(
+                schedule=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
     def _cls_release(
         cls,
         schedule,
@@ -112,3 +187,9 @@ class SubscriptionSchedule(
             idempotency_key=idempotency_key,
             params=params,
         )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "SubscriptionSchedule":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/subscription_schedule.py
+++ b/stripe/api_resources/subscription_schedule.py
@@ -13,6 +13,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -127,34 +128,11 @@ class SubscriptionSchedule(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        schedule,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/subscription_schedules/{schedule}".format(
-                schedule=util.sanitize_id(schedule)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/subscription_schedules/{schedule}".format(
-                schedule=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "SubscriptionSchedule":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "SubscriptionSchedule",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/tax/calculation.py
+++ b/stripe/api_resources/tax/calculation.py
@@ -6,7 +6,7 @@ from stripe import util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import List, Optional
+from typing import List, Optional, cast
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -39,6 +39,28 @@ class Calculation(CreateableAPIResource["Calculation"]):
     tax_amount_inclusive: int
     tax_breakdown: List[StripeObject]
     tax_date: str
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Calculation":
+        return cast(
+            "Calculation",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
 
     @classmethod
     def _cls_list_line_items(

--- a/stripe/api_resources/tax/settings.py
+++ b/stripe/api_resources/tax/settings.py
@@ -7,8 +7,9 @@ from stripe.api_resources.abstract import (
     UpdateableAPIResource,
 )
 from stripe.stripe_object import StripeObject
-from typing import Optional
+from typing import Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 
 class Settings(
@@ -30,16 +31,11 @@ class Settings(
     status_details: StripeObject
 
     @classmethod
-    def modify(
-        cls, api_key=None, stripe_version=None, stripe_account=None, **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/tax/settings",
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
+    def modify(cls, id, **params) -> "Settings":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "Settings",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/tax/settings.py
+++ b/stripe/api_resources/tax/settings.py
@@ -30,5 +30,24 @@ class Settings(
     status_details: StripeObject
 
     @classmethod
+    def modify(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/tax/settings",
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, **params) -> "Settings":
+        instance = cls(None, **params)
+        instance.refresh()
+        return instance
+
+    @classmethod
     def class_url(cls):
         return "/v1/tax/settings"

--- a/stripe/api_resources/tax/transaction.py
+++ b/stripe/api_resources/tax/transaction.py
@@ -96,3 +96,9 @@ class Transaction(APIResource["Transaction"]):
             idempotency_key=idempotency_key,
             params=params,
         )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Transaction":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/tax_code.py
+++ b/stripe/api_resources/tax_code.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.list_object import ListObject
 from typing_extensions import Literal
 
 
@@ -16,3 +17,30 @@ class TaxCode(ListableAPIResource["TaxCode"]):
     id: str
     name: str
     object: Literal["tax_code"]
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["TaxCode"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "TaxCode":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/tax_rate.py
+++ b/stripe/api_resources/tax_rate.py
@@ -2,7 +2,6 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
-from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     ListableAPIResource,
@@ -11,6 +10,7 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from typing import Dict, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 
 class TaxRate(
@@ -85,34 +85,11 @@ class TaxRate(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        tax_rate,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/tax_rates/{tax_rate}".format(
-                tax_rate=util.sanitize_id(tax_rate)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/tax_rates/{tax_rate}".format(
-                tax_rate=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "TaxRate":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "TaxRate",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/tax_rate.py
+++ b/stripe/api_resources/tax_rate.py
@@ -2,12 +2,14 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     ListableAPIResource,
     UpdateableAPIResource,
 )
-from typing import Dict, Optional
+from stripe.api_resources.list_object import ListObject
+from typing import Dict, Optional, cast
 from typing_extensions import Literal
 
 
@@ -38,3 +40,83 @@ class TaxRate(
     percentage: float
     state: Optional[str]
     tax_type: Optional[str]
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "TaxRate":
+        return cast(
+            "TaxRate",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["TaxRate"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        tax_rate,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/tax_rates/{tax_rate}".format(
+                tax_rate=util.sanitize_id(tax_rate)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/tax_rates/{tax_rate}".format(
+                tax_rate=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "TaxRate":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/terminal/configuration.py
+++ b/stripe/api_resources/terminal/configuration.py
@@ -95,34 +95,11 @@ class Configuration(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        configuration,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/terminal/configurations/{configuration}".format(
-                configuration=util.sanitize_id(configuration)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/terminal/configurations/{configuration}".format(
-                configuration=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> Any:
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            Any,
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/terminal/configuration.py
+++ b/stripe/api_resources/terminal/configuration.py
@@ -2,15 +2,18 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     DeletableAPIResource,
     ListableAPIResource,
     UpdateableAPIResource,
 )
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Optional
+from typing import Any, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 
 class Configuration(
@@ -31,3 +34,99 @@ class Configuration(
     object: Literal["terminal.configuration"]
     tipping: StripeObject
     verifone_p400: StripeObject
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Configuration":
+        return cast(
+            "Configuration",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def _cls_delete(cls, sid, **params) -> "Configuration":
+        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        return cast(
+            "Configuration",
+            cls._static_request("delete", url, params=params),
+        )
+
+    @util.class_method_variant("_cls_delete")
+    def delete(self, **params) -> "Configuration":
+        return self._request_and_refresh(
+            "delete",
+            self.instance_url(),
+            params=params,
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Configuration"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        configuration,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/terminal/configurations/{configuration}".format(
+                configuration=util.sanitize_id(configuration)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/terminal/configurations/{configuration}".format(
+                configuration=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> Any:
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/terminal/connection_token.py
+++ b/stripe/api_resources/terminal/connection_token.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import CreateableAPIResource
+from typing import cast
 from typing_extensions import Literal
 
 
@@ -17,3 +18,25 @@ class ConnectionToken(CreateableAPIResource["ConnectionToken"]):
     location: str
     object: Literal["terminal.connection_token"]
     secret: str
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "ConnectionToken":
+        return cast(
+            "ConnectionToken",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )

--- a/stripe/api_resources/terminal/location.py
+++ b/stripe/api_resources/terminal/location.py
@@ -2,15 +2,18 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     DeletableAPIResource,
     ListableAPIResource,
     UpdateableAPIResource,
 )
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Dict
+from typing import Any, Dict, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 
 class Location(
@@ -33,3 +36,99 @@ class Location(
     livemode: bool
     metadata: Dict[str, str]
     object: Literal["terminal.location"]
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Location":
+        return cast(
+            "Location",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def _cls_delete(cls, sid, **params) -> "Location":
+        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        return cast(
+            "Location",
+            cls._static_request("delete", url, params=params),
+        )
+
+    @util.class_method_variant("_cls_delete")
+    def delete(self, **params) -> "Location":
+        return self._request_and_refresh(
+            "delete",
+            self.instance_url(),
+            params=params,
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Location"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        location,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/terminal/locations/{location}".format(
+                location=util.sanitize_id(location)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/terminal/locations/{location}".format(
+                location=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> Any:
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/terminal/location.py
+++ b/stripe/api_resources/terminal/location.py
@@ -97,34 +97,11 @@ class Location(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        location,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/terminal/locations/{location}".format(
-                location=util.sanitize_id(location)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/terminal/locations/{location}".format(
-                location=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> Any:
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            Any,
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/terminal/reader.py
+++ b/stripe/api_resources/terminal/reader.py
@@ -11,9 +11,11 @@ from stripe.api_resources.abstract import (
     UpdateableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Dict, Optional
+from typing import Any, Dict, Optional, cast
 from typing_extensions import Literal, Type
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -72,6 +74,96 @@ class Reader(
         return self._request(
             "post",
             "/v1/terminal/readers/{reader}/cancel_action".format(
+                reader=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Reader":
+        return cast(
+            "Reader",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def _cls_delete(cls, sid, **params) -> "Reader":
+        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        return cast(
+            "Reader",
+            cls._static_request("delete", url, params=params),
+        )
+
+    @util.class_method_variant("_cls_delete")
+    def delete(self, **params) -> "Reader":
+        return self._request_and_refresh(
+            "delete",
+            self.instance_url(),
+            params=params,
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Reader"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        reader,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/terminal/readers/{reader}".format(
+                reader=util.sanitize_id(reader)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/terminal/readers/{reader}".format(
                 reader=util.sanitize_id(self.get("id"))
             ),
             idempotency_key=idempotency_key,
@@ -170,6 +262,12 @@ class Reader(
             idempotency_key=idempotency_key,
             params=params,
         )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> Any:
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance
 
     @classmethod
     def _cls_set_reader_display(

--- a/stripe/api_resources/terminal/reader.py
+++ b/stripe/api_resources/terminal/reader.py
@@ -140,34 +140,11 @@ class Reader(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        reader,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/terminal/readers/{reader}".format(
-                reader=util.sanitize_id(reader)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/terminal/readers/{reader}".format(
-                reader=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> Any:
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            Any,
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/test_helpers/test_clock.py
+++ b/stripe/api_resources/test_helpers/test_clock.py
@@ -8,8 +8,10 @@ from stripe.api_resources.abstract import (
     DeletableAPIResource,
     ListableAPIResource,
 )
-from typing import Optional
+from stripe.api_resources.list_object import ListObject
+from typing import Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 
 class TestClock(
@@ -63,3 +65,68 @@ class TestClock(
             idempotency_key=idempotency_key,
             params=params,
         )
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "TestClock":
+        return cast(
+            "TestClock",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def _cls_delete(cls, sid, **params) -> "TestClock":
+        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        return cast(
+            "TestClock",
+            cls._static_request("delete", url, params=params),
+        )
+
+    @util.class_method_variant("_cls_delete")
+    def delete(self, **params) -> "TestClock":
+        return self._request_and_refresh(
+            "delete",
+            self.instance_url(),
+            params=params,
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["TestClock"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "TestClock":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/token.py
+++ b/stripe/api_resources/token.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import CreateableAPIResource
-from typing import Optional
+from typing import Optional, cast
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -47,3 +47,31 @@ class Token(CreateableAPIResource["Token"]):
     object: Literal["token"]
     type: str
     used: bool
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Token":
+        return cast(
+            "Token",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Token":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/topup.py
+++ b/stripe/api_resources/topup.py
@@ -9,7 +9,8 @@ from stripe.api_resources.abstract import (
     UpdateableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
-from typing import Dict, Optional
+from stripe.api_resources.list_object import ListObject
+from typing import Dict, Optional, cast
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -78,3 +79,81 @@ class Topup(
             idempotency_key=idempotency_key,
             params=params,
         )
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Topup":
+        return cast(
+            "Topup",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Topup"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        topup,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/topups/{topup}".format(topup=util.sanitize_id(topup)),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/topups/{topup}".format(
+                topup=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Topup":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/topup.py
+++ b/stripe/api_resources/topup.py
@@ -12,6 +12,7 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from typing import Dict, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -124,32 +125,11 @@ class Topup(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        topup,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/topups/{topup}".format(topup=util.sanitize_id(topup)),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/topups/{topup}".format(
-                topup=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "Topup":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "Topup",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/transfer.py
+++ b/stripe/api_resources/transfer.py
@@ -2,6 +2,7 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     ListableAPIResource,
@@ -10,7 +11,7 @@ from stripe.api_resources.abstract import (
 )
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
-from typing import Dict, Optional
+from typing import Dict, Optional, cast
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -62,3 +63,83 @@ class Transfer(
     source_transaction: Optional[ExpandableField["Charge"]]
     source_type: str
     transfer_group: Optional[str]
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "Transfer":
+        return cast(
+            "Transfer",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Transfer"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        transfer,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/transfers/{transfer}".format(
+                transfer=util.sanitize_id(transfer)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/transfers/{transfer}".format(
+                transfer=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Transfer":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/transfer.py
+++ b/stripe/api_resources/transfer.py
@@ -2,7 +2,6 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
-from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     ListableAPIResource,
@@ -13,6 +12,7 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from typing import Dict, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -108,34 +108,11 @@ class Transfer(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        transfer,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/transfers/{transfer}".format(
-                transfer=util.sanitize_id(transfer)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/transfers/{transfer}".format(
-                transfer=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "Transfer":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "Transfer",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/treasury/credit_reversal.py
+++ b/stripe/api_resources/treasury/credit_reversal.py
@@ -7,8 +7,9 @@ from stripe.api_resources.abstract import (
     ListableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Dict, Optional
+from typing import Dict, Optional, cast
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -40,3 +41,52 @@ class CreditReversal(
     status: str
     status_transitions: StripeObject
     transaction: Optional[ExpandableField["Transaction"]]
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "CreditReversal":
+        return cast(
+            "CreditReversal",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["CreditReversal"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "CreditReversal":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/treasury/debit_reversal.py
+++ b/stripe/api_resources/treasury/debit_reversal.py
@@ -7,8 +7,9 @@ from stripe.api_resources.abstract import (
     ListableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Dict, Optional
+from typing import Dict, Optional, cast
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
@@ -41,3 +42,52 @@ class DebitReversal(
     status: str
     status_transitions: StripeObject
     transaction: Optional[ExpandableField["Transaction"]]
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "DebitReversal":
+        return cast(
+            "DebitReversal",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["DebitReversal"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "DebitReversal":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/treasury/financial_account.py
+++ b/stripe/api_resources/treasury/financial_account.py
@@ -12,6 +12,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 from typing_extensions import TYPE_CHECKING
 
@@ -93,34 +94,11 @@ class FinancialAccount(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        financial_account,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/treasury/financial_accounts/{financial_account}".format(
-                financial_account=util.sanitize_id(financial_account)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/treasury/financial_accounts/{financial_account}".format(
-                financial_account=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "FinancialAccount":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "FinancialAccount",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod

--- a/stripe/api_resources/treasury/inbound_transfer.py
+++ b/stripe/api_resources/treasury/inbound_transfer.py
@@ -9,8 +9,9 @@ from stripe.api_resources.abstract import (
     ListableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Dict, Optional
+from typing import Dict, Optional, cast
 from typing_extensions import Literal, Type
 
 from typing_extensions import TYPE_CHECKING
@@ -79,6 +80,55 @@ class InboundTransfer(
             idempotency_key=idempotency_key,
             params=params,
         )
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "InboundTransfer":
+        return cast(
+            "InboundTransfer",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["InboundTransfer"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "InboundTransfer":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance
 
     class TestHelpers(APIResourceTestHelpers["InboundTransfer"]):
         _resource_cls: Type["InboundTransfer"]

--- a/stripe/api_resources/treasury/outbound_payment.py
+++ b/stripe/api_resources/treasury/outbound_payment.py
@@ -9,8 +9,9 @@ from stripe.api_resources.abstract import (
     ListableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Dict, Optional
+from typing import Dict, Optional, cast
 from typing_extensions import Literal, Type
 
 from typing_extensions import TYPE_CHECKING
@@ -82,6 +83,55 @@ class OutboundPayment(
             idempotency_key=idempotency_key,
             params=params,
         )
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "OutboundPayment":
+        return cast(
+            "OutboundPayment",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["OutboundPayment"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "OutboundPayment":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance
 
     class TestHelpers(APIResourceTestHelpers["OutboundPayment"]):
         _resource_cls: Type["OutboundPayment"]

--- a/stripe/api_resources/treasury/outbound_transfer.py
+++ b/stripe/api_resources/treasury/outbound_transfer.py
@@ -9,8 +9,9 @@ from stripe.api_resources.abstract import (
     ListableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing import Dict, Optional
+from typing import Dict, Optional, cast
 from typing_extensions import Literal, Type
 
 from typing_extensions import TYPE_CHECKING
@@ -80,6 +81,55 @@ class OutboundTransfer(
             idempotency_key=idempotency_key,
             params=params,
         )
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "OutboundTransfer":
+        return cast(
+            "OutboundTransfer",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["OutboundTransfer"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "OutboundTransfer":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance
 
     class TestHelpers(APIResourceTestHelpers["OutboundTransfer"]):
         _resource_cls: Type["OutboundTransfer"]

--- a/stripe/api_resources/treasury/received_credit.py
+++ b/stripe/api_resources/treasury/received_credit.py
@@ -7,6 +7,7 @@ from stripe.api_resources.abstract import (
     ListableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Optional
 from typing_extensions import Literal, Type
@@ -39,6 +40,33 @@ class ReceivedCredit(ListableAPIResource["ReceivedCredit"]):
     reversal_details: Optional[StripeObject]
     status: str
     transaction: Optional[ExpandableField["Transaction"]]
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["ReceivedCredit"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "ReceivedCredit":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance
 
     class TestHelpers(APIResourceTestHelpers["ReceivedCredit"]):
         _resource_cls: Type["ReceivedCredit"]

--- a/stripe/api_resources/treasury/received_debit.py
+++ b/stripe/api_resources/treasury/received_debit.py
@@ -7,6 +7,7 @@ from stripe.api_resources.abstract import (
     ListableAPIResource,
 )
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Optional
 from typing_extensions import Literal, Type
@@ -39,6 +40,33 @@ class ReceivedDebit(ListableAPIResource["ReceivedDebit"]):
     reversal_details: Optional[StripeObject]
     status: str
     transaction: Optional[ExpandableField["Transaction"]]
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["ReceivedDebit"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "ReceivedDebit":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance
 
     class TestHelpers(APIResourceTestHelpers["ReceivedDebit"]):
         _resource_cls: Type["ReceivedDebit"]

--- a/stripe/api_resources/treasury/transaction.py
+++ b/stripe/api_resources/treasury/transaction.py
@@ -37,3 +37,30 @@ class Transaction(ListableAPIResource["Transaction"]):
     object: Literal["treasury.transaction"]
     status: str
     status_transitions: StripeObject
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["Transaction"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "Transaction":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/treasury/transaction_entry.py
+++ b/stripe/api_resources/treasury/transaction_entry.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.expandable_field import ExpandableField
+from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Optional
 from typing_extensions import Literal
@@ -33,6 +34,33 @@ class TransactionEntry(ListableAPIResource["TransactionEntry"]):
     object: Literal["treasury.transaction_entry"]
     transaction: ExpandableField["Transaction"]
     type: str
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["TransactionEntry"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "TransactionEntry":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance
 
     @classmethod
     def class_url(cls):

--- a/stripe/api_resources/webhook_endpoint.py
+++ b/stripe/api_resources/webhook_endpoint.py
@@ -2,14 +2,17 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     DeletableAPIResource,
     ListableAPIResource,
     UpdateableAPIResource,
 )
-from typing import Dict, List, Optional
+from stripe.api_resources.list_object import ListObject
+from typing import Dict, List, Optional, cast
 from typing_extensions import Literal
+from urllib.parse import quote_plus
 
 
 class WebhookEndpoint(
@@ -41,3 +44,99 @@ class WebhookEndpoint(
     secret: str
     status: str
     url: str
+
+    @classmethod
+    def create(
+        cls,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ) -> "WebhookEndpoint":
+        return cast(
+            "WebhookEndpoint",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
+        )
+
+    @classmethod
+    def _cls_delete(cls, sid, **params) -> "WebhookEndpoint":
+        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        return cast(
+            "WebhookEndpoint",
+            cls._static_request("delete", url, params=params),
+        )
+
+    @util.class_method_variant("_cls_delete")
+    def delete(self, **params) -> "WebhookEndpoint":
+        return self._request_and_refresh(
+            "delete",
+            self.instance_url(),
+            params=params,
+        )
+
+    @classmethod
+    def list(
+        cls, api_key=None, stripe_version=None, stripe_account=None, **params
+    ) -> ListObject["WebhookEndpoint"]:
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
+
+    @classmethod
+    def _cls_modify(
+        cls,
+        webhook_endpoint,
+        api_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        return cls._static_request(
+            "post",
+            "/v1/webhook_endpoints/{webhook_endpoint}".format(
+                webhook_endpoint=util.sanitize_id(webhook_endpoint)
+            ),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            params=params,
+        )
+
+    @util.class_method_variant("_cls_modify")
+    def modify(self, idempotency_key=None, **params):
+        return self._request(
+            "post",
+            "/v1/webhook_endpoints/{webhook_endpoint}".format(
+                webhook_endpoint=util.sanitize_id(self.get("id"))
+            ),
+            idempotency_key=idempotency_key,
+            params=params,
+        )
+
+    @classmethod
+    def retrieve(cls, id, api_key=None, **params) -> "WebhookEndpoint":
+        instance = cls(id, api_key, **params)
+        instance.refresh()
+        return instance

--- a/stripe/api_resources/webhook_endpoint.py
+++ b/stripe/api_resources/webhook_endpoint.py
@@ -105,34 +105,11 @@ class WebhookEndpoint(
         return result
 
     @classmethod
-    def _cls_modify(
-        cls,
-        webhook_endpoint,
-        api_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        **params
-    ):
-        return cls._static_request(
-            "post",
-            "/v1/webhook_endpoints/{webhook_endpoint}".format(
-                webhook_endpoint=util.sanitize_id(webhook_endpoint)
-            ),
-            api_key=api_key,
-            stripe_version=stripe_version,
-            stripe_account=stripe_account,
-            params=params,
-        )
-
-    @util.class_method_variant("_cls_modify")
-    def modify(self, idempotency_key=None, **params):
-        return self._request(
-            "post",
-            "/v1/webhook_endpoints/{webhook_endpoint}".format(
-                webhook_endpoint=util.sanitize_id(self.get("id"))
-            ),
-            idempotency_key=idempotency_key,
-            params=params,
+    def modify(cls, id, **params) -> "WebhookEndpoint":
+        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        return cast(
+            "WebhookEndpoint",
+            cls._static_request("post", url, params=params),
         )
 
     @classmethod


### PR DESCRIPTION
Explicitly defines create, retrieve, update, delete, and list methods in the body of each resource, as an override of the "standard" implementation from `UpdateableApiResource` etc.

This makes the class definition serve as better documentation and removes indirection. Eventually it would be good to do this for the "nested_resource" methods, too.

Branched off #1046.

Compare the CRUDL methods in coupon.py (left) with the parent class methods (right). They should be identical except for concrete classes instead of the generic `T`.
<img width="413" alt="image" src="https://github.com/stripe/stripe-python/assets/52928443/9e1b46c3-6ddf-4b20-bdd8-3aa3fff49708">

<img width="780" alt="image" src="https://github.com/stripe/stripe-python/assets/52928443/68df47a7-c3a0-4981-ad27-001ef7558907">
<img width="525" alt="image" src="https://github.com/stripe/stripe-python/assets/52928443/f352e3f8-2118-4957-bb07-9b67090c1f50">

<img width="734" alt="image" src="https://github.com/stripe/stripe-python/assets/52928443/641abb26-dd79-4c2c-bceb-ba503ad3912a">

<img width="757" alt="image" src="https://github.com/stripe/stripe-python/assets/52928443/dab9cc8a-82d5-4c75-b972-e82692c56794">


