### PR TITLE
Types for CRUDL methods on parents

### DIFF
--- a/flake8_stripe/flake8_stripe.py
+++ b/flake8_stripe/flake8_stripe.py
@@ -41,6 +41,7 @@ class TypingImportsChecker:
         "overload",
         "Dict",
         "List",
+        "Generic",
     ]
 
     def __init__(self, tree: ast.AST):

--- a/stripe/api_resources/abstract/api_resource.py
+++ b/stripe/api_resources/abstract/api_resource.py
@@ -3,17 +3,19 @@ from __future__ import absolute_import, division, print_function
 from stripe import api_requestor, error, util
 from stripe.stripe_object import StripeObject
 from urllib.parse import quote_plus
-from typing import ClassVar
+from typing import ClassVar, Generic, TypeVar, cast
+
+T = TypeVar("T", bound="StripeObject")
 
 
-class APIResource(StripeObject):
+class APIResource(StripeObject, Generic[T]):
     OBJECT_NAME: ClassVar[str]
 
     @classmethod
-    def retrieve(cls, id, api_key=None, **params):
+    def retrieve(cls, id, api_key=None, **params) -> T:
         instance = cls(id, api_key, **params)
         instance.refresh()
-        return instance
+        return cast(T, instance)
 
     def refresh(self):
         return self._request_and_refresh("get", self.instance_url())

--- a/stripe/api_resources/abstract/api_resource.py
+++ b/stripe/api_resources/abstract/api_resource.py
@@ -5,7 +5,7 @@ from stripe.stripe_object import StripeObject
 from urllib.parse import quote_plus
 from typing import ClassVar, Generic, TypeVar, cast
 
-T = TypeVar("T", bound="StripeObject")
+T = TypeVar("T", bound=StripeObject)
 
 
 class APIResource(StripeObject, Generic[T]):

--- a/stripe/api_resources/abstract/createable_api_resource.py
+++ b/stripe/api_resources/abstract/createable_api_resource.py
@@ -1,9 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract.api_resource import APIResource
+from typing import TypeVar, cast
+from stripe.stripe_object import StripeObject
+
+T = TypeVar("T", bound="StripeObject")
 
 
-class CreateableAPIResource(APIResource):
+class CreateableAPIResource(APIResource[T]):
     @classmethod
     def create(
         cls,
@@ -12,13 +16,16 @@ class CreateableAPIResource(APIResource):
         stripe_version=None,
         stripe_account=None,
         **params
-    ):
-        return cls._static_request(
-            "post",
-            cls.class_url(),
-            api_key,
-            idempotency_key,
-            stripe_version,
-            stripe_account,
-            params,
+    ) -> T:
+        return cast(
+            T,
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                api_key,
+                idempotency_key,
+                stripe_version,
+                stripe_account,
+                params,
+            ),
         )

--- a/stripe/api_resources/abstract/createable_api_resource.py
+++ b/stripe/api_resources/abstract/createable_api_resource.py
@@ -4,7 +4,7 @@ from stripe.api_resources.abstract.api_resource import APIResource
 from typing import TypeVar, cast
 from stripe.stripe_object import StripeObject
 
-T = TypeVar("T", bound="StripeObject")
+T = TypeVar("T", bound=StripeObject)
 
 
 class CreateableAPIResource(APIResource[T]):

--- a/stripe/api_resources/abstract/deletable_api_resource.py
+++ b/stripe/api_resources/abstract/deletable_api_resource.py
@@ -13,7 +13,7 @@ class DeletableAPIResource(APIResource[T]):
     @classmethod
     def _cls_delete(cls, sid, **params) -> T:
         url = "%s/%s" % (cls.class_url(), quote_plus(sid))
-        return cls._static_request("delete", url, params=params)
+        return cast(T, cls._static_request("delete", url, params=params))
 
     @util.class_method_variant("_cls_delete")
     def delete(self, **params) -> T:

--- a/stripe/api_resources/abstract/deletable_api_resource.py
+++ b/stripe/api_resources/abstract/deletable_api_resource.py
@@ -3,16 +3,23 @@ from __future__ import absolute_import, division, print_function
 from stripe import util
 from stripe.api_resources.abstract.api_resource import APIResource
 from urllib.parse import quote_plus
+from typing import TypeVar, cast
+from stripe.stripe_object import StripeObject
+
+T = TypeVar("T", bound="StripeObject")
 
 
-class DeletableAPIResource(APIResource):
+class DeletableAPIResource(APIResource[T]):
     @classmethod
     def _cls_delete(cls, sid, **params):
         url = "%s/%s" % (cls.class_url(), quote_plus(sid))
         return cls._static_request("delete", url, params=params)
 
     @util.class_method_variant("_cls_delete")
-    def delete(self, **params):
-        return self._request_and_refresh(
-            "delete", self.instance_url(), params=params
+    def delete(self, **params) -> T:
+        return cast(
+            T,
+            self._request_and_refresh(
+                "delete", self.instance_url(), params=params
+            ),
         )

--- a/stripe/api_resources/abstract/deletable_api_resource.py
+++ b/stripe/api_resources/abstract/deletable_api_resource.py
@@ -6,7 +6,7 @@ from urllib.parse import quote_plus
 from typing import TypeVar, cast
 from stripe.stripe_object import StripeObject
 
-T = TypeVar("T", bound="StripeObject")
+T = TypeVar("T", bound=StripeObject)
 
 
 class DeletableAPIResource(APIResource[T]):

--- a/stripe/api_resources/abstract/deletable_api_resource.py
+++ b/stripe/api_resources/abstract/deletable_api_resource.py
@@ -11,7 +11,7 @@ T = TypeVar("T", bound="StripeObject")
 
 class DeletableAPIResource(APIResource[T]):
     @classmethod
-    def _cls_delete(cls, sid, **params):
+    def _cls_delete(cls, sid, **params) -> T:
         url = "%s/%s" % (cls.class_url(), quote_plus(sid))
         return cls._static_request("delete", url, params=params)
 

--- a/stripe/api_resources/abstract/listable_api_resource.py
+++ b/stripe/api_resources/abstract/listable_api_resource.py
@@ -2,9 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract.api_resource import APIResource
 from stripe.api_resources.list_object import ListObject
+from stripe.stripe_object import StripeObject
+from typing import TypeVar
+
+T = TypeVar("T", bound="StripeObject")
 
 
-class ListableAPIResource(APIResource):
+class ListableAPIResource(APIResource[T]):
     @classmethod
     def auto_paging_iter(cls, *args, **params):
         return cls.list(*args, **params).auto_paging_iter()
@@ -12,7 +16,7 @@ class ListableAPIResource(APIResource):
     @classmethod
     def list(
         cls, api_key=None, stripe_version=None, stripe_account=None, **params
-    ) -> ListObject:
+    ) -> ListObject[T]:
         result = cls._static_request(
             "get",
             cls.class_url(),

--- a/stripe/api_resources/abstract/listable_api_resource.py
+++ b/stripe/api_resources/abstract/listable_api_resource.py
@@ -5,7 +5,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import TypeVar
 
-T = TypeVar("T", bound="StripeObject")
+T = TypeVar("T", bound=StripeObject)
 
 
 class ListableAPIResource(APIResource[T]):

--- a/stripe/api_resources/abstract/searchable_api_resource.py
+++ b/stripe/api_resources/abstract/searchable_api_resource.py
@@ -6,7 +6,7 @@ from typing import TypeVar
 from stripe.stripe_object import StripeObject
 
 
-T = TypeVar("T", bound="StripeObject")
+T = TypeVar("T", bound=StripeObject)
 
 
 class SearchableAPIResource(APIResource[T]):

--- a/stripe/api_resources/abstract/searchable_api_resource.py
+++ b/stripe/api_resources/abstract/searchable_api_resource.py
@@ -2,9 +2,14 @@ from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract.api_resource import APIResource
 from stripe.api_resources.search_result_object import SearchResultObject
+from typing import TypeVar
+from stripe.stripe_object import StripeObject
 
 
-class SearchableAPIResource(APIResource):
+T = TypeVar("T", bound="StripeObject")
+
+
+class SearchableAPIResource(APIResource[T]):
     @classmethod
     def _search(
         cls,

--- a/stripe/api_resources/abstract/singleton_api_resource.py
+++ b/stripe/api_resources/abstract/singleton_api_resource.py
@@ -2,10 +2,15 @@ from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract.api_resource import APIResource
 
+from typing import TypeVar
+from stripe.stripe_object import StripeObject
 
-class SingletonAPIResource(APIResource):
+T = TypeVar("T", bound="StripeObject")
+
+
+class SingletonAPIResource(APIResource[T]):
     @classmethod
-    def retrieve(cls, **params):
+    def retrieve(cls, **params) -> T:
         return super(SingletonAPIResource, cls).retrieve(None, **params)
 
     @classmethod

--- a/stripe/api_resources/abstract/singleton_api_resource.py
+++ b/stripe/api_resources/abstract/singleton_api_resource.py
@@ -5,7 +5,7 @@ from stripe.api_resources.abstract.api_resource import APIResource
 from typing import TypeVar
 from stripe.stripe_object import StripeObject
 
-T = TypeVar("T", bound="StripeObject")
+T = TypeVar("T", bound=StripeObject)
 
 
 class SingletonAPIResource(APIResource[T]):

--- a/stripe/api_resources/abstract/test_helpers.py
+++ b/stripe/api_resources/abstract/test_helpers.py
@@ -6,9 +6,7 @@ from urllib.parse import quote_plus
 from typing import TypeVar, ClassVar, Any
 from typing_extensions import Protocol
 
-from stripe.api_resources.abstract.api_resource import APIResource
-
-T = TypeVar("T", bound=APIResource)
+T = TypeVar("T")
 
 
 class APIResourceTestHelpers(Protocol[T]):

--- a/stripe/api_resources/abstract/test_helpers.py
+++ b/stripe/api_resources/abstract/test_helpers.py
@@ -5,8 +5,9 @@ from urllib.parse import quote_plus
 
 from typing import TypeVar, ClassVar, Any
 from typing_extensions import Protocol
+from stripe.api_resources.abstract import APIResource
 
-T = TypeVar("T")
+T = TypeVar("T", bound=APIResource[Any])
 
 
 class APIResourceTestHelpers(Protocol[T]):

--- a/stripe/api_resources/abstract/updateable_api_resource.py
+++ b/stripe/api_resources/abstract/updateable_api_resource.py
@@ -3,13 +3,13 @@ from __future__ import absolute_import, division, print_function
 from stripe import util
 from stripe.api_resources.abstract.api_resource import APIResource
 from urllib.parse import quote_plus
-from typing import Generic, TypeVar, cast
+from typing import TypeVar, cast
 from stripe.stripe_object import StripeObject
 
 T = TypeVar("T", bound="StripeObject")
 
 
-class UpdateableAPIResource(APIResource[T], Generic[T]):
+class UpdateableAPIResource(APIResource[T]):
     @classmethod
     def modify(cls, sid, **params) -> T:
         url = "%s/%s" % (cls.class_url(), quote_plus(sid))

--- a/stripe/api_resources/abstract/updateable_api_resource.py
+++ b/stripe/api_resources/abstract/updateable_api_resource.py
@@ -3,13 +3,17 @@ from __future__ import absolute_import, division, print_function
 from stripe import util
 from stripe.api_resources.abstract.api_resource import APIResource
 from urllib.parse import quote_plus
+from typing import Generic, TypeVar, cast
+from stripe.stripe_object import StripeObject
+
+T = TypeVar("T", bound="StripeObject")
 
 
-class UpdateableAPIResource(APIResource):
+class UpdateableAPIResource(APIResource[T], Generic[T]):
     @classmethod
-    def modify(cls, sid, **params):
+    def modify(cls, sid, **params) -> T:
         url = "%s/%s" % (cls.class_url(), quote_plus(sid))
-        return cls._static_request("post", url, params=params)
+        return cast(T, cls._static_request("post", url, params=params))
 
     def save(self, idempotency_key=None):
         """

--- a/stripe/api_resources/abstract/updateable_api_resource.py
+++ b/stripe/api_resources/abstract/updateable_api_resource.py
@@ -6,7 +6,7 @@ from urllib.parse import quote_plus
 from typing import TypeVar, cast
 from stripe.stripe_object import StripeObject
 
-T = TypeVar("T", bound="StripeObject")
+T = TypeVar("T", bound=StripeObject)
 
 
 class UpdateableAPIResource(APIResource[T]):

--- a/stripe/api_resources/account.py
+++ b/stripe/api_resources/account.py
@@ -31,10 +31,10 @@ from urllib.parse import quote_plus
     operations=["create", "retrieve", "update", "delete", "list"],
 )
 class Account(
-    CreateableAPIResource,
-    DeletableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["Account"],
+    DeletableAPIResource["Account"],
+    ListableAPIResource["Account"],
+    UpdateableAPIResource["Account"],
 ):
     """
     This is an object representing a Stripe account. You can retrieve it to see

--- a/stripe/api_resources/account_link.py
+++ b/stripe/api_resources/account_link.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import CreateableAPIResource
 
 
-class AccountLink(CreateableAPIResource):
+class AccountLink(CreateableAPIResource["AccountLink"]):
     """
     Account Links are the means by which a Connect platform grants a connected account permission to access
     Stripe-hosted applications, such as Connect Onboarding.

--- a/stripe/api_resources/apple_pay_domain.py
+++ b/stripe/api_resources/apple_pay_domain.py
@@ -8,9 +8,9 @@ from stripe.api_resources.abstract import ListableAPIResource
 
 
 class ApplePayDomain(
-    CreateableAPIResource,
-    DeletableAPIResource,
-    ListableAPIResource,
+    CreateableAPIResource["ApplePayDomain"],
+    DeletableAPIResource["ApplePayDomain"],
+    ListableAPIResource["ApplePayDomain"],
 ):
     OBJECT_NAME = "apple_pay_domain"
 

--- a/stripe/api_resources/application_fee.py
+++ b/stripe/api_resources/application_fee.py
@@ -11,7 +11,7 @@ from stripe.api_resources.abstract import nested_resource_class_methods
     "refund",
     operations=["create", "retrieve", "update", "list"],
 )
-class ApplicationFee(ListableAPIResource):
+class ApplicationFee(ListableAPIResource["ApplicationFee"]):
     OBJECT_NAME = "application_fee"
 
     @classmethod

--- a/stripe/api_resources/application_fee_refund.py
+++ b/stripe/api_resources/application_fee_refund.py
@@ -7,7 +7,7 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 from urllib.parse import quote_plus
 
 
-class ApplicationFeeRefund(UpdateableAPIResource):
+class ApplicationFeeRefund(UpdateableAPIResource["ApplicationFeeRefund"]):
     """
     `Application Fee Refund` objects allow you to refund an application fee that
     has previously been created but not yet refunded. Funds will be refunded to

--- a/stripe/api_resources/apps/secret.py
+++ b/stripe/api_resources/apps/secret.py
@@ -6,7 +6,7 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 
 
-class Secret(CreateableAPIResource, ListableAPIResource):
+class Secret(CreateableAPIResource["Secret"], ListableAPIResource["Secret"]):
     """
     Secret Store is an API that allows Stripe Apps developers to securely persist secrets for use by UI Extensions and app backends.
 

--- a/stripe/api_resources/balance.py
+++ b/stripe/api_resources/balance.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import SingletonAPIResource
 
 
-class Balance(SingletonAPIResource):
+class Balance(SingletonAPIResource["Balance"]):
     """
     This is an object representing your Stripe balance. You can retrieve it to see
     the balance currently on your Stripe account.

--- a/stripe/api_resources/balance_transaction.py
+++ b/stripe/api_resources/balance_transaction.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import ListableAPIResource
 
 
-class BalanceTransaction(ListableAPIResource):
+class BalanceTransaction(ListableAPIResource["BalanceTransaction"]):
     """
     Balance transactions represent funds moving through your Stripe account.
     They're created for every type of transaction that comes into or flows out of your Stripe account balance.

--- a/stripe/api_resources/bank_account.py
+++ b/stripe/api_resources/bank_account.py
@@ -11,7 +11,11 @@ from stripe.api_resources.customer import Customer
 from urllib.parse import quote_plus
 
 
-class BankAccount(DeletableAPIResource, UpdateableAPIResource, VerifyMixin):
+class BankAccount(
+    DeletableAPIResource["BankAccount"],
+    UpdateableAPIResource["BankAccount"],
+    VerifyMixin,
+):
     """
     These bank accounts are payment methods on `Customer` objects.
 

--- a/stripe/api_resources/billing_portal/configuration.py
+++ b/stripe/api_resources/billing_portal/configuration.py
@@ -8,9 +8,9 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class Configuration(
-    CreateableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["Configuration"],
+    ListableAPIResource["Configuration"],
+    UpdateableAPIResource["Configuration"],
 ):
     """
     A portal configuration describes the functionality and behavior of a portal session.

--- a/stripe/api_resources/billing_portal/session.py
+++ b/stripe/api_resources/billing_portal/session.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import CreateableAPIResource
 
 
-class Session(CreateableAPIResource):
+class Session(CreateableAPIResource["Session"]):
     """
     The Billing customer portal is a Stripe-hosted UI for subscription and
     billing management.

--- a/stripe/api_resources/capability.py
+++ b/stripe/api_resources/capability.py
@@ -7,7 +7,7 @@ from stripe.api_resources.account import Account
 from urllib.parse import quote_plus
 
 
-class Capability(UpdateableAPIResource):
+class Capability(UpdateableAPIResource["Capability"]):
     """
     This is an object representing a capability for a Stripe account.
 

--- a/stripe/api_resources/card.py
+++ b/stripe/api_resources/card.py
@@ -10,7 +10,7 @@ from stripe.api_resources.customer import Customer
 from urllib.parse import quote_plus
 
 
-class Card(DeletableAPIResource, UpdateableAPIResource):
+class Card(DeletableAPIResource["Card"], UpdateableAPIResource["Card"]):
     """
     You can store multiple cards on a customer in order to charge the customer
     later. You can also store multiple debit cards on a recipient in order to

--- a/stripe/api_resources/cash_balance.py
+++ b/stripe/api_resources/cash_balance.py
@@ -2,12 +2,12 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
-from stripe.api_resources.abstract import APIResource
 from stripe.api_resources.customer import Customer
+from stripe.stripe_object import StripeObject
 from urllib.parse import quote_plus
 
 
-class CashBalance(APIResource):
+class CashBalance(StripeObject):
     """
     A customer's `Cash balance` represents real funds. Customers can add funds to their cash balance by sending a bank transfer. These funds can be used for payment and can eventually be paid out to your bank account.
     """

--- a/stripe/api_resources/charge.py
+++ b/stripe/api_resources/charge.py
@@ -10,10 +10,10 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class Charge(
-    CreateableAPIResource,
-    ListableAPIResource,
-    SearchableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["Charge"],
+    ListableAPIResource["Charge"],
+    SearchableAPIResource["Charge"],
+    UpdateableAPIResource["Charge"],
 ):
     """
     The `Charge` object represents a single attempt to move money into your Stripe account.

--- a/stripe/api_resources/checkout/session.py
+++ b/stripe/api_resources/checkout/session.py
@@ -7,7 +7,9 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 
 
-class Session(CreateableAPIResource, ListableAPIResource):
+class Session(
+    CreateableAPIResource["Session"], ListableAPIResource["Session"]
+):
     """
     A Checkout Session represents your customer's session as they pay for
     one-time purchases or subscriptions through [Checkout](https://stripe.com/docs/payments/checkout)

--- a/stripe/api_resources/country_spec.py
+++ b/stripe/api_resources/country_spec.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import ListableAPIResource
 
 
-class CountrySpec(ListableAPIResource):
+class CountrySpec(ListableAPIResource["CountrySpec"]):
     """
     Stripe needs to collect certain pieces of information about each account
     created. These requirements can differ depending on the account's country. The

--- a/stripe/api_resources/coupon.py
+++ b/stripe/api_resources/coupon.py
@@ -9,10 +9,10 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class Coupon(
-    CreateableAPIResource,
-    DeletableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["Coupon"],
+    DeletableAPIResource["Coupon"],
+    ListableAPIResource["Coupon"],
+    UpdateableAPIResource["Coupon"],
 ):
     """
     A coupon contains information about a percent-off or amount-off discount you

--- a/stripe/api_resources/credit_note.py
+++ b/stripe/api_resources/credit_note.py
@@ -14,9 +14,9 @@ from stripe.api_resources.abstract import nested_resource_class_methods
     operations=["list"],
 )
 class CreditNote(
-    CreateableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["CreditNote"],
+    ListableAPIResource["CreditNote"],
+    UpdateableAPIResource["CreditNote"],
 ):
     """
     Issue a credit note to adjust an invoice's amount after the invoice is finalized.

--- a/stripe/api_resources/credit_note_line_item.py
+++ b/stripe/api_resources/credit_note_line_item.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import ListableAPIResource
 
 
-class CreditNoteLineItem(ListableAPIResource):
+class CreditNoteLineItem(ListableAPIResource["CreditNoteLineItem"]):
     """
     The credit note line item object
     """

--- a/stripe/api_resources/customer.py
+++ b/stripe/api_resources/customer.py
@@ -30,11 +30,11 @@ from typing_extensions import Type
     operations=["create", "retrieve", "delete", "list"],
 )
 class Customer(
-    CreateableAPIResource,
-    DeletableAPIResource,
-    ListableAPIResource,
-    SearchableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["Customer"],
+    DeletableAPIResource["Customer"],
+    ListableAPIResource["Customer"],
+    SearchableAPIResource["Customer"],
+    UpdateableAPIResource["Customer"],
 ):
     """
     This object represents a customer of your business. It lets you create recurring charges and track payments that belong to the same customer.

--- a/stripe/api_resources/customer_balance_transaction.py
+++ b/stripe/api_resources/customer_balance_transaction.py
@@ -7,7 +7,7 @@ from stripe.api_resources.customer import Customer
 from urllib.parse import quote_plus
 
 
-class CustomerBalanceTransaction(APIResource):
+class CustomerBalanceTransaction(APIResource["CustomerBalanceTransaction"]):
     """
     Each customer has a [Balance](https://stripe.com/docs/api/customers/object#customer_object-balance) value,
     which denotes a debit or credit that's automatically applied to their next invoice upon finalization.

--- a/stripe/api_resources/customer_cash_balance_transaction.py
+++ b/stripe/api_resources/customer_cash_balance_transaction.py
@@ -5,7 +5,9 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import ListableAPIResource
 
 
-class CustomerCashBalanceTransaction(ListableAPIResource):
+class CustomerCashBalanceTransaction(
+    ListableAPIResource["CustomerCashBalanceTransaction"],
+):
     """
     Customers with certain payments enabled have a cash balance, representing funds that were paid
     by the customer to a merchant, but have not yet been allocated to a payment. Cash Balance Transactions

--- a/stripe/api_resources/dispute.py
+++ b/stripe/api_resources/dispute.py
@@ -7,7 +7,9 @@ from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 
 
-class Dispute(ListableAPIResource, UpdateableAPIResource):
+class Dispute(
+    ListableAPIResource["Dispute"], UpdateableAPIResource["Dispute"]
+):
     """
     A dispute occurs when a customer questions your charge with their card issuer.
     When this happens, you're given the opportunity to respond to the dispute with

--- a/stripe/api_resources/ephemeral_key.py
+++ b/stripe/api_resources/ephemeral_key.py
@@ -7,7 +7,7 @@ from stripe import util
 from stripe.api_resources.abstract import DeletableAPIResource
 
 
-class EphemeralKey(DeletableAPIResource):
+class EphemeralKey(DeletableAPIResource["EphemeralKey"]):
     OBJECT_NAME = "ephemeral_key"
 
     @classmethod

--- a/stripe/api_resources/event.py
+++ b/stripe/api_resources/event.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import ListableAPIResource
 
 
-class Event(ListableAPIResource):
+class Event(ListableAPIResource["Event"]):
     """
     Events are our way of letting you know when something interesting happens in
     your account. When an interesting event occurs, we create a new `Event`

--- a/stripe/api_resources/exchange_rate.py
+++ b/stripe/api_resources/exchange_rate.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import ListableAPIResource
 
 
-class ExchangeRate(ListableAPIResource):
+class ExchangeRate(ListableAPIResource["ExchangeRate"]):
     """
     `Exchange Rate` objects allow you to determine the rates that Stripe is
     currently using to convert from one currency to another. Since this number is

--- a/stripe/api_resources/file.py
+++ b/stripe/api_resources/file.py
@@ -8,7 +8,7 @@ from stripe import util
 from stripe.api_resources.abstract import ListableAPIResource
 
 
-class File(ListableAPIResource):
+class File(ListableAPIResource["File"]):
     """
     This is an object representing a file hosted on Stripe's servers. The
     file may have been uploaded by yourself using the [create file](https://stripe.com/docs/api#create_file)

--- a/stripe/api_resources/file_link.py
+++ b/stripe/api_resources/file_link.py
@@ -8,9 +8,9 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class FileLink(
-    CreateableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["FileLink"],
+    ListableAPIResource["FileLink"],
+    UpdateableAPIResource["FileLink"],
 ):
     """
     To share the contents of a `File` object with non-Stripe users, you can

--- a/stripe/api_resources/financial_connections/account.py
+++ b/stripe/api_resources/financial_connections/account.py
@@ -6,7 +6,7 @@ from stripe import util
 from stripe.api_resources.abstract import ListableAPIResource
 
 
-class Account(ListableAPIResource):
+class Account(ListableAPIResource["Account"]):
     """
     A Financial Connections Account represents an account that exists outside of Stripe, to which you have been granted some degree of access.
     """

--- a/stripe/api_resources/financial_connections/session.py
+++ b/stripe/api_resources/financial_connections/session.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import CreateableAPIResource
 
 
-class Session(CreateableAPIResource):
+class Session(CreateableAPIResource["Session"]):
     """
     A Financial Connections Session is the secure way to programmatically launch the client-side Stripe.js modal that lets your users link their accounts.
     """

--- a/stripe/api_resources/identity/verification_report.py
+++ b/stripe/api_resources/identity/verification_report.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import ListableAPIResource
 
 
-class VerificationReport(ListableAPIResource):
+class VerificationReport(ListableAPIResource["VerificationReport"]):
     """
     A VerificationReport is the result of an attempt to collect and verify data from a user.
     The collection of verification checks performed is determined from the `type` and `options`

--- a/stripe/api_resources/identity/verification_session.py
+++ b/stripe/api_resources/identity/verification_session.py
@@ -9,9 +9,9 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class VerificationSession(
-    CreateableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["VerificationSession"],
+    ListableAPIResource["VerificationSession"],
+    UpdateableAPIResource["VerificationSession"],
 ):
     """
     A VerificationSession guides you through the process of collecting and verifying the identities

--- a/stripe/api_resources/invoice.py
+++ b/stripe/api_resources/invoice.py
@@ -11,11 +11,11 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class Invoice(
-    CreateableAPIResource,
-    DeletableAPIResource,
-    ListableAPIResource,
-    SearchableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["Invoice"],
+    DeletableAPIResource["Invoice"],
+    ListableAPIResource["Invoice"],
+    SearchableAPIResource["Invoice"],
+    UpdateableAPIResource["Invoice"],
 ):
     """
     Invoices are statements of amounts owed by a customer, and are either

--- a/stripe/api_resources/invoice_item.py
+++ b/stripe/api_resources/invoice_item.py
@@ -9,10 +9,10 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class InvoiceItem(
-    CreateableAPIResource,
-    DeletableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["InvoiceItem"],
+    DeletableAPIResource["InvoiceItem"],
+    ListableAPIResource["InvoiceItem"],
+    UpdateableAPIResource["InvoiceItem"],
 ):
     """
     Invoice Items represent the component lines of an [invoice](https://stripe.com/docs/api/invoices). An invoice item is added to an

--- a/stripe/api_resources/issuing/authorization.py
+++ b/stripe/api_resources/issuing/authorization.py
@@ -7,7 +7,10 @@ from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 
 
-class Authorization(ListableAPIResource, UpdateableAPIResource):
+class Authorization(
+    ListableAPIResource["Authorization"],
+    UpdateableAPIResource["Authorization"],
+):
     """
     When an [issued card](https://stripe.com/docs/issuing) is used to make a purchase, an Issuing `Authorization`
     object is created. [Authorizations](https://stripe.com/docs/issuing/purchases/authorizations) must be approved for the

--- a/stripe/api_resources/issuing/card.py
+++ b/stripe/api_resources/issuing/card.py
@@ -10,7 +10,11 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 from typing_extensions import Type
 
 
-class Card(CreateableAPIResource, ListableAPIResource, UpdateableAPIResource):
+class Card(
+    CreateableAPIResource["Card"],
+    ListableAPIResource["Card"],
+    UpdateableAPIResource["Card"],
+):
     """
     You can [create physical or virtual cards](https://stripe.com/docs/issuing/cards) that are issued to cardholders.
     """

--- a/stripe/api_resources/issuing/cardholder.py
+++ b/stripe/api_resources/issuing/cardholder.py
@@ -8,9 +8,9 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class Cardholder(
-    CreateableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["Cardholder"],
+    ListableAPIResource["Cardholder"],
+    UpdateableAPIResource["Cardholder"],
 ):
     """
     An Issuing `Cardholder` object represents an individual or business entity who is [issued](https://stripe.com/docs/issuing) cards.

--- a/stripe/api_resources/issuing/dispute.py
+++ b/stripe/api_resources/issuing/dispute.py
@@ -9,9 +9,9 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class Dispute(
-    CreateableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["Dispute"],
+    ListableAPIResource["Dispute"],
+    UpdateableAPIResource["Dispute"],
 ):
     """
     As a [card issuer](https://stripe.com/docs/issuing), you can dispute transactions that the cardholder does not recognize, suspects to be fraudulent, or has other issues with.

--- a/stripe/api_resources/issuing/transaction.py
+++ b/stripe/api_resources/issuing/transaction.py
@@ -6,7 +6,10 @@ from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 
 
-class Transaction(ListableAPIResource, UpdateableAPIResource):
+class Transaction(
+    ListableAPIResource["Transaction"],
+    UpdateableAPIResource["Transaction"],
+):
     """
     Any use of an [issued card](https://stripe.com/docs/issuing) that results in funds entering or leaving
     your Stripe account, such as a completed purchase or refund, is represented by an Issuing

--- a/stripe/api_resources/list_object.py
+++ b/stripe/api_resources/list_object.py
@@ -6,7 +6,7 @@ from stripe.stripe_object import StripeObject
 
 from urllib.parse import quote_plus
 
-T = TypeVar("T", bound="StripeObject")
+T = TypeVar("T", bound=StripeObject)
 
 
 class ListObject(StripeObject, Generic[T]):

--- a/stripe/api_resources/list_object.py
+++ b/stripe/api_resources/list_object.py
@@ -1,15 +1,17 @@
 from __future__ import absolute_import, division, print_function
 from typing_extensions import Self
-from typing import List
 
+from typing import List, Generic, TypeVar
 from stripe.stripe_object import StripeObject
 
 from urllib.parse import quote_plus
 
+T = TypeVar("T", bound="StripeObject")
 
-class ListObject(StripeObject):
+
+class ListObject(StripeObject, Generic[T]):
     OBJECT_NAME = "list"
-    data: List[StripeObject]
+    data: List[T]
     has_more: bool
     url: str
 

--- a/stripe/api_resources/mandate.py
+++ b/stripe/api_resources/mandate.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import APIResource
 
 
-class Mandate(APIResource):
+class Mandate(APIResource["Mandate"]):
     """
     A Mandate is a record of the permission a customer has given you to debit their payment method.
     """

--- a/stripe/api_resources/payment_intent.py
+++ b/stripe/api_resources/payment_intent.py
@@ -10,10 +10,10 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class PaymentIntent(
-    CreateableAPIResource,
-    ListableAPIResource,
-    SearchableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["PaymentIntent"],
+    ListableAPIResource["PaymentIntent"],
+    SearchableAPIResource["PaymentIntent"],
+    UpdateableAPIResource["PaymentIntent"],
 ):
     """
     A PaymentIntent guides you through the process of collecting a payment from your customer.

--- a/stripe/api_resources/payment_link.py
+++ b/stripe/api_resources/payment_link.py
@@ -9,9 +9,9 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class PaymentLink(
-    CreateableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["PaymentLink"],
+    ListableAPIResource["PaymentLink"],
+    UpdateableAPIResource["PaymentLink"],
 ):
     """
     A payment link is a shareable URL that will take your customers to a hosted payment page. A payment link can be shared and used multiple times.

--- a/stripe/api_resources/payment_method.py
+++ b/stripe/api_resources/payment_method.py
@@ -9,9 +9,9 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class PaymentMethod(
-    CreateableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["PaymentMethod"],
+    ListableAPIResource["PaymentMethod"],
+    UpdateableAPIResource["PaymentMethod"],
 ):
     """
     PaymentMethod objects represent your customer's payment instruments.

--- a/stripe/api_resources/payout.py
+++ b/stripe/api_resources/payout.py
@@ -9,7 +9,9 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class Payout(
-    CreateableAPIResource, ListableAPIResource, UpdateableAPIResource
+    CreateableAPIResource["Payout"],
+    ListableAPIResource["Payout"],
+    UpdateableAPIResource["Payout"],
 ):
     """
     A `Payout` object is created when you receive funds from Stripe, or when you

--- a/stripe/api_resources/person.py
+++ b/stripe/api_resources/person.py
@@ -7,7 +7,7 @@ from stripe.api_resources.account import Account
 from urllib.parse import quote_plus
 
 
-class Person(UpdateableAPIResource):
+class Person(UpdateableAPIResource["Person"]):
     """
     This is an object representing a person associated with a Stripe account.
 

--- a/stripe/api_resources/plan.py
+++ b/stripe/api_resources/plan.py
@@ -9,10 +9,10 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class Plan(
-    CreateableAPIResource,
-    DeletableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["Plan"],
+    DeletableAPIResource["Plan"],
+    ListableAPIResource["Plan"],
+    UpdateableAPIResource["Plan"],
 ):
     """
     You can now model subscriptions more flexibly using the [Prices API](https://stripe.com/docs/api#prices). It replaces the Plans API and is backwards compatible to simplify your migration.

--- a/stripe/api_resources/price.py
+++ b/stripe/api_resources/price.py
@@ -9,10 +9,10 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class Price(
-    CreateableAPIResource,
-    ListableAPIResource,
-    SearchableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["Price"],
+    ListableAPIResource["Price"],
+    SearchableAPIResource["Price"],
+    UpdateableAPIResource["Price"],
 ):
     """
     Prices define the unit cost, currency, and (optional) billing cycle for both recurring and one-time purchases of products.

--- a/stripe/api_resources/product.py
+++ b/stripe/api_resources/product.py
@@ -10,11 +10,11 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class Product(
-    CreateableAPIResource,
-    DeletableAPIResource,
-    ListableAPIResource,
-    SearchableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["Product"],
+    DeletableAPIResource["Product"],
+    ListableAPIResource["Product"],
+    SearchableAPIResource["Product"],
+    UpdateableAPIResource["Product"],
 ):
     """
     Products describe the specific goods or services you offer to your customers.

--- a/stripe/api_resources/promotion_code.py
+++ b/stripe/api_resources/promotion_code.py
@@ -8,9 +8,9 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class PromotionCode(
-    CreateableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["PromotionCode"],
+    ListableAPIResource["PromotionCode"],
+    UpdateableAPIResource["PromotionCode"],
 ):
     """
     A Promotion Code represents a customer-redeemable code for a [coupon](https://stripe.com/docs/api#coupons). It can be used to

--- a/stripe/api_resources/quote.py
+++ b/stripe/api_resources/quote.py
@@ -11,7 +11,11 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 from urllib.parse import quote_plus
 
 
-class Quote(CreateableAPIResource, ListableAPIResource, UpdateableAPIResource):
+class Quote(
+    CreateableAPIResource["Quote"],
+    ListableAPIResource["Quote"],
+    UpdateableAPIResource["Quote"],
+):
     """
     A Quote is a way to model prices that you'd like to provide to a customer.
     Once accepted, it will automatically create an invoice, subscription or subscription schedule.

--- a/stripe/api_resources/radar/early_fraud_warning.py
+++ b/stripe/api_resources/radar/early_fraud_warning.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import ListableAPIResource
 
 
-class EarlyFraudWarning(ListableAPIResource):
+class EarlyFraudWarning(ListableAPIResource["EarlyFraudWarning"]):
     """
     An early fraud warning indicates that the card issuer has notified us that a
     charge may be fraudulent.

--- a/stripe/api_resources/radar/value_list.py
+++ b/stripe/api_resources/radar/value_list.py
@@ -9,10 +9,10 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class ValueList(
-    CreateableAPIResource,
-    DeletableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["ValueList"],
+    DeletableAPIResource["ValueList"],
+    ListableAPIResource["ValueList"],
+    UpdateableAPIResource["ValueList"],
 ):
     """
     Value lists allow you to group values together which can then be referenced in rules.

--- a/stripe/api_resources/radar/value_list_item.py
+++ b/stripe/api_resources/radar/value_list_item.py
@@ -8,9 +8,9 @@ from stripe.api_resources.abstract import ListableAPIResource
 
 
 class ValueListItem(
-    CreateableAPIResource,
-    DeletableAPIResource,
-    ListableAPIResource,
+    CreateableAPIResource["ValueListItem"],
+    DeletableAPIResource["ValueListItem"],
+    ListableAPIResource["ValueListItem"],
 ):
     """
     Value list items allow you to add specific values to a given Radar value list, which can then be used in rules.

--- a/stripe/api_resources/refund.py
+++ b/stripe/api_resources/refund.py
@@ -11,7 +11,9 @@ from typing_extensions import Type
 
 
 class Refund(
-    CreateableAPIResource, ListableAPIResource, UpdateableAPIResource
+    CreateableAPIResource["Refund"],
+    ListableAPIResource["Refund"],
+    UpdateableAPIResource["Refund"],
 ):
     """
     `Refund` objects allow you to refund a charge that has previously been created

--- a/stripe/api_resources/reporting/report_run.py
+++ b/stripe/api_resources/reporting/report_run.py
@@ -6,7 +6,10 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 
 
-class ReportRun(CreateableAPIResource, ListableAPIResource):
+class ReportRun(
+    CreateableAPIResource["ReportRun"],
+    ListableAPIResource["ReportRun"],
+):
     """
     The Report Run object represents an instance of a report type generated with
     specific run parameters. Once the object is created, Stripe begins processing the report.

--- a/stripe/api_resources/reporting/report_type.py
+++ b/stripe/api_resources/reporting/report_type.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import ListableAPIResource
 
 
-class ReportType(ListableAPIResource):
+class ReportType(ListableAPIResource["ReportType"]):
     """
     The Report Type resource corresponds to a particular type of report, such as
     the "Activity summary" or "Itemized payouts" reports. These objects are

--- a/stripe/api_resources/reversal.py
+++ b/stripe/api_resources/reversal.py
@@ -7,7 +7,7 @@ from stripe.api_resources.transfer import Transfer
 from urllib.parse import quote_plus
 
 
-class Reversal(UpdateableAPIResource):
+class Reversal(UpdateableAPIResource["Reversal"]):
     """
     [Stripe Connect](https://stripe.com/docs/connect) platforms can reverse transfers made to a
     connected account, either entirely or partially, and can also specify whether

--- a/stripe/api_resources/review.py
+++ b/stripe/api_resources/review.py
@@ -6,7 +6,7 @@ from stripe import util
 from stripe.api_resources.abstract import ListableAPIResource
 
 
-class Review(ListableAPIResource):
+class Review(ListableAPIResource["Review"]):
     """
     Reviews can be used to supplement automated fraud detection with human expertise.
 

--- a/stripe/api_resources/setup_attempt.py
+++ b/stripe/api_resources/setup_attempt.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import ListableAPIResource
 
 
-class SetupAttempt(ListableAPIResource):
+class SetupAttempt(ListableAPIResource["SetupAttempt"]):
     """
     A SetupAttempt describes one attempted confirmation of a SetupIntent,
     whether that confirmation was successful or unsuccessful. You can use

--- a/stripe/api_resources/setup_intent.py
+++ b/stripe/api_resources/setup_intent.py
@@ -9,9 +9,9 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class SetupIntent(
-    CreateableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["SetupIntent"],
+    ListableAPIResource["SetupIntent"],
+    UpdateableAPIResource["SetupIntent"],
 ):
     """
     A SetupIntent guides you through the process of setting up and saving a customer's payment credentials for future payments.

--- a/stripe/api_resources/shipping_rate.py
+++ b/stripe/api_resources/shipping_rate.py
@@ -8,9 +8,9 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class ShippingRate(
-    CreateableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["ShippingRate"],
+    ListableAPIResource["ShippingRate"],
+    UpdateableAPIResource["ShippingRate"],
 ):
     """
     Shipping rates describe the price of shipping presented to your customers and

--- a/stripe/api_resources/sigma/scheduled_query_run.py
+++ b/stripe/api_resources/sigma/scheduled_query_run.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import ListableAPIResource
 
 
-class ScheduledQueryRun(ListableAPIResource):
+class ScheduledQueryRun(ListableAPIResource["ScheduledQueryRun"]):
     """
     If you have [scheduled a Sigma query](https://stripe.com/docs/sigma/scheduled-queries), you'll
     receive a `sigma.scheduled_query_run.created` webhook each time the query

--- a/stripe/api_resources/source.py
+++ b/stripe/api_resources/source.py
@@ -10,7 +10,7 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 from urllib.parse import quote_plus
 
 
-class Source(CreateableAPIResource, UpdateableAPIResource):
+class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
     """
     `Source` objects allow you to accept a variety of payment methods. They
     represent a customer's payment instrument, and can be used with the Stripe API

--- a/stripe/api_resources/subscription.py
+++ b/stripe/api_resources/subscription.py
@@ -11,11 +11,11 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class Subscription(
-    CreateableAPIResource,
-    DeletableAPIResource,
-    ListableAPIResource,
-    SearchableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["Subscription"],
+    DeletableAPIResource["Subscription"],
+    ListableAPIResource["Subscription"],
+    SearchableAPIResource["Subscription"],
+    UpdateableAPIResource["Subscription"],
 ):
     """
     Subscriptions allow you to charge a customer on a recurring basis.

--- a/stripe/api_resources/subscription_item.py
+++ b/stripe/api_resources/subscription_item.py
@@ -19,10 +19,10 @@ from stripe.api_resources.abstract import nested_resource_class_methods
     resource_plural="usage_record_summaries",
 )
 class SubscriptionItem(
-    CreateableAPIResource,
-    DeletableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["SubscriptionItem"],
+    DeletableAPIResource["SubscriptionItem"],
+    ListableAPIResource["SubscriptionItem"],
+    UpdateableAPIResource["SubscriptionItem"],
 ):
     """
     Subscription items allow you to create customer subscriptions with more than

--- a/stripe/api_resources/subscription_schedule.py
+++ b/stripe/api_resources/subscription_schedule.py
@@ -9,9 +9,9 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class SubscriptionSchedule(
-    CreateableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["SubscriptionSchedule"],
+    ListableAPIResource["SubscriptionSchedule"],
+    UpdateableAPIResource["SubscriptionSchedule"],
 ):
     """
     A subscription schedule allows you to create and manage the lifecycle of a subscription by predefining expected changes.

--- a/stripe/api_resources/tax/calculation.py
+++ b/stripe/api_resources/tax/calculation.py
@@ -6,7 +6,7 @@ from stripe import util
 from stripe.api_resources.abstract import CreateableAPIResource
 
 
-class Calculation(CreateableAPIResource):
+class Calculation(CreateableAPIResource["Calculation"]):
     """
     A Tax Calculation allows you to calculate the tax to collect from your customer.
 

--- a/stripe/api_resources/tax/settings.py
+++ b/stripe/api_resources/tax/settings.py
@@ -6,7 +6,10 @@ from stripe.api_resources.abstract import SingletonAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 
 
-class Settings(SingletonAPIResource, UpdateableAPIResource):
+class Settings(
+    SingletonAPIResource["Settings"],
+    UpdateableAPIResource["Settings"],
+):
     """
     You can use Tax `Settings` to manage configurations used by Stripe Tax calculations.
 

--- a/stripe/api_resources/tax/transaction.py
+++ b/stripe/api_resources/tax/transaction.py
@@ -6,7 +6,7 @@ from stripe import util
 from stripe.api_resources.abstract import APIResource
 
 
-class Transaction(APIResource):
+class Transaction(APIResource["Transaction"]):
     """
     A Tax Transaction records the tax collected from or refunded to your customer.
 

--- a/stripe/api_resources/tax_code.py
+++ b/stripe/api_resources/tax_code.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import ListableAPIResource
 
 
-class TaxCode(ListableAPIResource):
+class TaxCode(ListableAPIResource["TaxCode"]):
     """
     [Tax codes](https://stripe.com/docs/tax/tax-categories) classify goods and services for tax purposes.
     """

--- a/stripe/api_resources/tax_id.py
+++ b/stripe/api_resources/tax_id.py
@@ -7,7 +7,7 @@ from stripe.api_resources.customer import Customer
 from urllib.parse import quote_plus
 
 
-class TaxId(APIResource):
+class TaxId(APIResource["TaxId"]):
     """
     You can add one or multiple tax IDs to a [customer](https://stripe.com/docs/api/customers).
     A customer's tax IDs are displayed on invoices and credit notes issued for the customer.

--- a/stripe/api_resources/tax_rate.py
+++ b/stripe/api_resources/tax_rate.py
@@ -8,9 +8,9 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class TaxRate(
-    CreateableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["TaxRate"],
+    ListableAPIResource["TaxRate"],
+    UpdateableAPIResource["TaxRate"],
 ):
     """
     Tax rates can be applied to [invoices](https://stripe.com/docs/billing/invoices/tax-rates), [subscriptions](https://stripe.com/docs/billing/subscriptions/taxes) and [Checkout Sessions](https://stripe.com/docs/payments/checkout/set-up-a-subscription#tax-rates) to collect tax.

--- a/stripe/api_resources/terminal/configuration.py
+++ b/stripe/api_resources/terminal/configuration.py
@@ -9,10 +9,10 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class Configuration(
-    CreateableAPIResource,
-    DeletableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["Configuration"],
+    DeletableAPIResource["Configuration"],
+    ListableAPIResource["Configuration"],
+    UpdateableAPIResource["Configuration"],
 ):
     """
     A Configurations object represents how features should be configured for terminal readers.

--- a/stripe/api_resources/terminal/connection_token.py
+++ b/stripe/api_resources/terminal/connection_token.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import CreateableAPIResource
 
 
-class ConnectionToken(CreateableAPIResource):
+class ConnectionToken(CreateableAPIResource["ConnectionToken"]):
     """
     A Connection Token is used by the Stripe Terminal SDK to connect to a reader.
 

--- a/stripe/api_resources/terminal/location.py
+++ b/stripe/api_resources/terminal/location.py
@@ -9,10 +9,10 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class Location(
-    CreateableAPIResource,
-    DeletableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["Location"],
+    DeletableAPIResource["Location"],
+    ListableAPIResource["Location"],
+    UpdateableAPIResource["Location"],
 ):
     """
     A Location represents a grouping of readers.

--- a/stripe/api_resources/terminal/reader.py
+++ b/stripe/api_resources/terminal/reader.py
@@ -12,10 +12,10 @@ from typing_extensions import Type
 
 
 class Reader(
-    CreateableAPIResource,
-    DeletableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["Reader"],
+    DeletableAPIResource["Reader"],
+    ListableAPIResource["Reader"],
+    UpdateableAPIResource["Reader"],
 ):
     """
     A Reader represents a physical device for accepting payment details.

--- a/stripe/api_resources/test_helpers/test_clock.py
+++ b/stripe/api_resources/test_helpers/test_clock.py
@@ -9,9 +9,9 @@ from stripe.api_resources.abstract import ListableAPIResource
 
 
 class TestClock(
-    CreateableAPIResource,
-    DeletableAPIResource,
-    ListableAPIResource,
+    CreateableAPIResource["TestClock"],
+    DeletableAPIResource["TestClock"],
+    ListableAPIResource["TestClock"],
 ):
     """
     A test clock enables deterministic control over objects in testmode. With a test clock, you can create

--- a/stripe/api_resources/token.py
+++ b/stripe/api_resources/token.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import CreateableAPIResource
 
 
-class Token(CreateableAPIResource):
+class Token(CreateableAPIResource["Token"]):
     """
     Tokenization is the process Stripe uses to collect sensitive card or bank
     account details, or personally identifiable information (PII), directly from

--- a/stripe/api_resources/topup.py
+++ b/stripe/api_resources/topup.py
@@ -8,7 +8,11 @@ from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 
 
-class Topup(CreateableAPIResource, ListableAPIResource, UpdateableAPIResource):
+class Topup(
+    CreateableAPIResource["Topup"],
+    ListableAPIResource["Topup"],
+    UpdateableAPIResource["Topup"],
+):
     """
     To top up your Stripe balance, you create a top-up object. You can retrieve
     individual top-ups, as well as list all top-ups. Top-ups are identified by a

--- a/stripe/api_resources/transfer.py
+++ b/stripe/api_resources/transfer.py
@@ -13,9 +13,9 @@ from stripe.api_resources.abstract import nested_resource_class_methods
     operations=["create", "retrieve", "update", "list"],
 )
 class Transfer(
-    CreateableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["Transfer"],
+    ListableAPIResource["Transfer"],
+    UpdateableAPIResource["Transfer"],
 ):
     """
     A `Transfer` object is created when you move funds between Stripe accounts as

--- a/stripe/api_resources/treasury/credit_reversal.py
+++ b/stripe/api_resources/treasury/credit_reversal.py
@@ -6,7 +6,10 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 
 
-class CreditReversal(CreateableAPIResource, ListableAPIResource):
+class CreditReversal(
+    CreateableAPIResource["CreditReversal"],
+    ListableAPIResource["CreditReversal"],
+):
     """
     You can reverse some [ReceivedCredits](https://stripe.com/docs/api#received_credits) depending on their network and source flow. Reversing a ReceivedCredit leads to the creation of a new object known as a CreditReversal.
     """

--- a/stripe/api_resources/treasury/debit_reversal.py
+++ b/stripe/api_resources/treasury/debit_reversal.py
@@ -6,7 +6,10 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 
 
-class DebitReversal(CreateableAPIResource, ListableAPIResource):
+class DebitReversal(
+    CreateableAPIResource["DebitReversal"],
+    ListableAPIResource["DebitReversal"],
+):
     """
     You can reverse some [ReceivedDebits](https://stripe.com/docs/api#received_debits) depending on their network and source flow. Reversing a ReceivedDebit leads to the creation of a new object known as a DebitReversal.
     """

--- a/stripe/api_resources/treasury/financial_account.py
+++ b/stripe/api_resources/treasury/financial_account.py
@@ -9,9 +9,9 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class FinancialAccount(
-    CreateableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["FinancialAccount"],
+    ListableAPIResource["FinancialAccount"],
+    UpdateableAPIResource["FinancialAccount"],
 ):
     """
     Stripe Treasury provides users with a container for money called a FinancialAccount that is separate from their Payments balance.

--- a/stripe/api_resources/treasury/inbound_transfer.py
+++ b/stripe/api_resources/treasury/inbound_transfer.py
@@ -9,7 +9,10 @@ from stripe.api_resources.abstract import ListableAPIResource
 from typing_extensions import Type
 
 
-class InboundTransfer(CreateableAPIResource, ListableAPIResource):
+class InboundTransfer(
+    CreateableAPIResource["InboundTransfer"],
+    ListableAPIResource["InboundTransfer"],
+):
     """
     Use [InboundTransfers](https://stripe.com/docs/treasury/moving-money/financial-accounts/into/inbound-transfers) to add funds to your [FinancialAccount](https://stripe.com/docs/api#financial_accounts) via a PaymentMethod that is owned by you. The funds will be transferred via an ACH debit.
     """

--- a/stripe/api_resources/treasury/outbound_payment.py
+++ b/stripe/api_resources/treasury/outbound_payment.py
@@ -9,7 +9,10 @@ from stripe.api_resources.abstract import ListableAPIResource
 from typing_extensions import Type
 
 
-class OutboundPayment(CreateableAPIResource, ListableAPIResource):
+class OutboundPayment(
+    CreateableAPIResource["OutboundPayment"],
+    ListableAPIResource["OutboundPayment"],
+):
     """
     Use OutboundPayments to send funds to another party's external bank account or [FinancialAccount](https://stripe.com/docs/api#financial_accounts). To send money to an account belonging to the same user, use an [OutboundTransfer](https://stripe.com/docs/api#outbound_transfers).
 

--- a/stripe/api_resources/treasury/outbound_transfer.py
+++ b/stripe/api_resources/treasury/outbound_transfer.py
@@ -9,7 +9,10 @@ from stripe.api_resources.abstract import ListableAPIResource
 from typing_extensions import Type
 
 
-class OutboundTransfer(CreateableAPIResource, ListableAPIResource):
+class OutboundTransfer(
+    CreateableAPIResource["OutboundTransfer"],
+    ListableAPIResource["OutboundTransfer"],
+):
     """
     Use OutboundTransfers to transfer funds from a [FinancialAccount](https://stripe.com/docs/api#financial_accounts) to a PaymentMethod belonging to the same entity. To send funds to a different party, use [OutboundPayments](https://stripe.com/docs/api#outbound_payments) instead. You can send funds over ACH rails or through a domestic wire transfer to a user's own external bank account.
 

--- a/stripe/api_resources/treasury/received_credit.py
+++ b/stripe/api_resources/treasury/received_credit.py
@@ -7,7 +7,7 @@ from stripe.api_resources.abstract import ListableAPIResource
 from typing_extensions import Type
 
 
-class ReceivedCredit(ListableAPIResource):
+class ReceivedCredit(ListableAPIResource["ReceivedCredit"]):
     """
     ReceivedCredits represent funds sent to a [FinancialAccount](https://stripe.com/docs/api#financial_accounts) (for example, via ACH or wire). These money movements are not initiated from the FinancialAccount.
     """

--- a/stripe/api_resources/treasury/received_debit.py
+++ b/stripe/api_resources/treasury/received_debit.py
@@ -7,7 +7,7 @@ from stripe.api_resources.abstract import ListableAPIResource
 from typing_extensions import Type
 
 
-class ReceivedDebit(ListableAPIResource):
+class ReceivedDebit(ListableAPIResource["ReceivedDebit"]):
     """
     ReceivedDebits represent funds pulled from a [FinancialAccount](https://stripe.com/docs/api#financial_accounts). These are not initiated from the FinancialAccount.
     """

--- a/stripe/api_resources/treasury/transaction.py
+++ b/stripe/api_resources/treasury/transaction.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import ListableAPIResource
 
 
-class Transaction(ListableAPIResource):
+class Transaction(ListableAPIResource["Transaction"]):
     """
     Transactions represent changes to a [FinancialAccount's](https://stripe.com/docs/api#financial_accounts) balance.
     """

--- a/stripe/api_resources/treasury/transaction_entry.py
+++ b/stripe/api_resources/treasury/transaction_entry.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import ListableAPIResource
 
 
-class TransactionEntry(ListableAPIResource):
+class TransactionEntry(ListableAPIResource["TransactionEntry"]):
     """
     TransactionEntries represent individual units of money movements within a single [Transaction](https://stripe.com/docs/api#transactions).
     """

--- a/stripe/api_resources/usage_record.py
+++ b/stripe/api_resources/usage_record.py
@@ -6,7 +6,7 @@ from stripe import api_requestor, util
 from stripe.api_resources.abstract import APIResource
 
 
-class UsageRecord(APIResource):
+class UsageRecord(APIResource["UsageRecord"]):
     """
     Usage records allow you to report customer usage and metrics to Stripe for
     metered billing of subscription prices.

--- a/stripe/api_resources/webhook_endpoint.py
+++ b/stripe/api_resources/webhook_endpoint.py
@@ -9,10 +9,10 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 
 
 class WebhookEndpoint(
-    CreateableAPIResource,
-    DeletableAPIResource,
-    ListableAPIResource,
-    UpdateableAPIResource,
+    CreateableAPIResource["WebhookEndpoint"],
+    DeletableAPIResource["WebhookEndpoint"],
+    ListableAPIResource["WebhookEndpoint"],
+    UpdateableAPIResource["WebhookEndpoint"],
 ):
     """
     You can configure [webhook endpoints](https://stripe.com/docs/webhooks/) via the API to be


### PR DESCRIPTION
Add a type parameter to APIResource and related classes, and set that as the return type of

* APIResource.retrieve
* CreateableAPIResource.create
* DeleteableAPIResource.delete
* ListableAPIResource.list
* SingletonAPIResource.retrieve
* UpdateableAPIResource.modify

