### PR TITLE
Types: ExpandableField

### DIFF
--- a/stripe/api_resources/application_fee.py
+++ b/stripe/api_resources/application_fee.py
@@ -5,14 +5,18 @@ from __future__ import absolute_import, division, print_function
 from stripe import util
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import nested_resource_class_methods
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
-from typing import Any
 from typing import Optional
 from typing_extensions import Literal
 
 from typing_extensions import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from stripe.api_resources.account import Account
+    from stripe.api_resources.application import Application
+    from stripe.api_resources.balance_transaction import BalanceTransaction
+    from stripe.api_resources.charge import Charge
     from stripe.api_resources.application_fee_refund import (
         ApplicationFeeRefund,
     )
@@ -24,18 +28,18 @@ if TYPE_CHECKING:
 )
 class ApplicationFee(ListableAPIResource["ApplicationFee"]):
     OBJECT_NAME = "application_fee"
-    account: Any
+    account: ExpandableField["Account"]
     amount: int
     amount_refunded: int
-    application: Any
-    balance_transaction: Optional[Any]
-    charge: Any
+    application: ExpandableField["Application"]
+    balance_transaction: Optional[ExpandableField["BalanceTransaction"]]
+    charge: ExpandableField["Charge"]
     created: str
     currency: str
     id: str
     livemode: bool
     object: Literal["application_fee"]
-    originating_transaction: Optional[Any]
+    originating_transaction: Optional[ExpandableField["Charge"]]
     refunded: bool
     refunds: ListObject["ApplicationFeeRefund"]
 

--- a/stripe/api_resources/application_fee_refund.py
+++ b/stripe/api_resources/application_fee_refund.py
@@ -4,11 +4,17 @@ from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources import ApplicationFee
 from stripe.api_resources.abstract import UpdateableAPIResource
-from typing import Any
+from stripe.api_resources.expandable_field import ExpandableField
 from typing import Dict
 from typing import Optional
 from typing_extensions import Literal
 from urllib.parse import quote_plus
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.balance_transaction import BalanceTransaction
+    from stripe.api_resources.application_fee import ApplicationFee
 
 
 class ApplicationFeeRefund(UpdateableAPIResource["ApplicationFeeRefund"]):
@@ -22,10 +28,10 @@ class ApplicationFeeRefund(UpdateableAPIResource["ApplicationFeeRefund"]):
 
     OBJECT_NAME = "fee_refund"
     amount: int
-    balance_transaction: Optional[Any]
+    balance_transaction: Optional[ExpandableField["BalanceTransaction"]]
     created: str
     currency: str
-    fee: Any
+    fee: ExpandableField["ApplicationFee"]
     id: str
     metadata: Optional[Dict[str, str]]
     object: Literal["fee_refund"]

--- a/stripe/api_resources/application_fee_refund.py
+++ b/stripe/api_resources/application_fee_refund.py
@@ -2,8 +2,8 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
-from stripe.api_resources import ApplicationFee
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.application_fee import ApplicationFee
 from stripe.api_resources.expandable_field import ExpandableField
 from typing import Dict
 from typing import Optional
@@ -14,7 +14,6 @@ from typing_extensions import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.balance_transaction import BalanceTransaction
-    from stripe.api_resources.application_fee import ApplicationFee
 
 
 class ApplicationFeeRefund(UpdateableAPIResource["ApplicationFeeRefund"]):

--- a/stripe/api_resources/balance_transaction.py
+++ b/stripe/api_resources/balance_transaction.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
 from typing import Any
 from typing import List
@@ -31,6 +32,6 @@ class BalanceTransaction(ListableAPIResource["BalanceTransaction"]):
     net: int
     object: Literal["balance_transaction"]
     reporting_category: str
-    source: Optional[Any]
+    source: Optional[ExpandableField[Any]]
     status: str
     type: str

--- a/stripe/api_resources/bank_account.py
+++ b/stripe/api_resources/bank_account.py
@@ -17,11 +17,6 @@ from typing import Optional
 from typing_extensions import Literal
 from urllib.parse import quote_plus
 
-from typing_extensions import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from stripe.api_resources.account import Account
-
 
 class BankAccount(
     DeletableAPIResource["BankAccount"],

--- a/stripe/api_resources/bank_account.py
+++ b/stripe/api_resources/bank_account.py
@@ -8,6 +8,7 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import VerifyMixin
 from stripe.api_resources.account import Account
 from stripe.api_resources.customer import Customer
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
 from typing import Any
 from typing import Dict
@@ -15,6 +16,11 @@ from typing import List
 from typing import Optional
 from typing_extensions import Literal
 from urllib.parse import quote_plus
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.account import Account
 
 
 class BankAccount(
@@ -33,7 +39,7 @@ class BankAccount(
     """
 
     OBJECT_NAME = "bank_account"
-    account: Optional[Any]
+    account: Optional[ExpandableField["Account"]]
     account_holder_name: Optional[str]
     account_holder_type: Optional[str]
     account_type: Optional[str]
@@ -41,7 +47,7 @@ class BankAccount(
     bank_name: Optional[str]
     country: str
     currency: str
-    customer: Optional[Any]
+    customer: Optional[ExpandableField[Any]]
     default_for_currency: Optional[bool]
     fingerprint: Optional[str]
     future_requirements: Optional[StripeObject]
@@ -69,6 +75,8 @@ class BankAccount(
 
             base = Account.class_url()
             assert account is not None
+            if isinstance(account, Account):
+                account = account.id
             owner_extn = quote_plus(account)
             class_base = "external_accounts"
 

--- a/stripe/api_resources/billing_portal/configuration.py
+++ b/stripe/api_resources/billing_portal/configuration.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
 from typing import Any
 from typing import Dict
@@ -23,7 +24,7 @@ class Configuration(
 
     OBJECT_NAME = "billing_portal.configuration"
     active: bool
-    application: Optional[Any]
+    application: Optional[ExpandableField[Any]]
     business_profile: StripeObject
     created: str
     default_return_url: Optional[str]

--- a/stripe/api_resources/billing_portal/session.py
+++ b/stripe/api_resources/billing_portal/session.py
@@ -3,10 +3,15 @@
 from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import CreateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Optional
 from typing_extensions import Literal
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.billing_portal.configuration import Configuration
 
 
 class Session(CreateableAPIResource["Session"]):
@@ -28,7 +33,7 @@ class Session(CreateableAPIResource["Session"]):
     """
 
     OBJECT_NAME = "billing_portal.session"
-    configuration: Any
+    configuration: ExpandableField["Configuration"]
     created: str
     customer: str
     flow: Optional[StripeObject]

--- a/stripe/api_resources/capability.py
+++ b/stripe/api_resources/capability.py
@@ -4,11 +4,16 @@ from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.account import Account
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Optional
 from typing_extensions import Literal
 from urllib.parse import quote_plus
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.account import Account
 
 
 class Capability(UpdateableAPIResource["Capability"]):
@@ -19,7 +24,7 @@ class Capability(UpdateableAPIResource["Capability"]):
     """
 
     OBJECT_NAME = "capability"
-    account: Any
+    account: ExpandableField["Account"]
     future_requirements: StripeObject
     id: str
     object: Literal["capability"]
@@ -32,6 +37,8 @@ class Capability(UpdateableAPIResource["Capability"]):
         token = self.id
         account = self.account
         base = Account.class_url()
+        if isinstance(account, Account):
+            account = account.id
         acct_extn = quote_plus(account)
         extn = quote_plus(token)
         return "%s/%s/capabilities/%s" % (base, acct_extn, extn)

--- a/stripe/api_resources/capability.py
+++ b/stripe/api_resources/capability.py
@@ -10,11 +10,6 @@ from typing import Optional
 from typing_extensions import Literal
 from urllib.parse import quote_plus
 
-from typing_extensions import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from stripe.api_resources.account import Account
-
 
 class Capability(UpdateableAPIResource["Capability"]):
     """

--- a/stripe/api_resources/card.py
+++ b/stripe/api_resources/card.py
@@ -15,11 +15,6 @@ from typing import Optional
 from typing_extensions import Literal
 from urllib.parse import quote_plus
 
-from typing_extensions import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from stripe.api_resources.account import Account
-
 
 class Card(DeletableAPIResource["Card"], UpdateableAPIResource["Card"]):
     """

--- a/stripe/api_resources/card.py
+++ b/stripe/api_resources/card.py
@@ -7,12 +7,18 @@ from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.account import Account
 from stripe.api_resources.customer import Customer
+from stripe.api_resources.expandable_field import ExpandableField
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
 from typing_extensions import Literal
 from urllib.parse import quote_plus
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.account import Account
 
 
 class Card(DeletableAPIResource["Card"], UpdateableAPIResource["Card"]):
@@ -25,7 +31,7 @@ class Card(DeletableAPIResource["Card"], UpdateableAPIResource["Card"]):
     """
 
     OBJECT_NAME = "card"
-    account: Optional[Any]
+    account: Optional[ExpandableField["Account"]]
     address_city: Optional[str]
     address_country: Optional[str]
     address_line1: Optional[str]
@@ -38,7 +44,7 @@ class Card(DeletableAPIResource["Card"], UpdateableAPIResource["Card"]):
     brand: str
     country: Optional[str]
     currency: Optional[str]
-    customer: Optional[Any]
+    customer: Optional[ExpandableField[Any]]
     cvc_check: Optional[str]
     default_for_currency: Optional[bool]
     description: str
@@ -73,6 +79,8 @@ class Card(DeletableAPIResource["Card"], UpdateableAPIResource["Card"]):
 
             base = Account.class_url()
             assert account is not None
+            if isinstance(account, Account):
+                account = account.id
             owner_extn = quote_plus(account)
             class_base = "external_accounts"
 

--- a/stripe/api_resources/charge.py
+++ b/stripe/api_resources/charge.py
@@ -7,6 +7,7 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import SearchableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Any
@@ -17,7 +18,15 @@ from typing_extensions import Literal
 from typing_extensions import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from stripe.api_resources.application import Application
+    from stripe.api_resources.application_fee import ApplicationFee
+    from stripe.api_resources.balance_transaction import BalanceTransaction
+    from stripe.api_resources.invoice import Invoice
+    from stripe.api_resources.account import Account
+    from stripe.api_resources.payment_intent import PaymentIntent
     from stripe.api_resources.refund import Refund
+    from stripe.api_resources.review import Review
+    from stripe.api_resources.transfer import Transfer
 
 
 class Charge(
@@ -37,33 +46,35 @@ class Charge(
     amount: int
     amount_captured: int
     amount_refunded: int
-    application: Optional[Any]
-    application_fee: Optional[Any]
+    application: Optional[ExpandableField["Application"]]
+    application_fee: Optional[ExpandableField["ApplicationFee"]]
     application_fee_amount: Optional[int]
     authorization_code: str
-    balance_transaction: Optional[Any]
+    balance_transaction: Optional[ExpandableField["BalanceTransaction"]]
     billing_details: StripeObject
     calculated_statement_descriptor: Optional[str]
     captured: bool
     created: str
     currency: str
-    customer: Optional[Any]
+    customer: Optional[ExpandableField[Any]]
     description: Optional[str]
     disputed: bool
-    failure_balance_transaction: Optional[Any]
+    failure_balance_transaction: Optional[
+        ExpandableField["BalanceTransaction"]
+    ]
     failure_code: Optional[str]
     failure_message: Optional[str]
     fraud_details: Optional[StripeObject]
     id: str
-    invoice: Optional[Any]
+    invoice: Optional[ExpandableField["Invoice"]]
     level3: StripeObject
     livemode: bool
     metadata: Dict[str, str]
     object: Literal["charge"]
-    on_behalf_of: Optional[Any]
+    on_behalf_of: Optional[ExpandableField["Account"]]
     outcome: Optional[StripeObject]
     paid: bool
-    payment_intent: Optional[Any]
+    payment_intent: Optional[ExpandableField["PaymentIntent"]]
     payment_method: Optional[str]
     payment_method_details: Optional[StripeObject]
     radar_options: StripeObject
@@ -72,14 +83,14 @@ class Charge(
     receipt_url: Optional[str]
     refunded: bool
     refunds: Optional[ListObject["Refund"]]
-    review: Optional[Any]
+    review: Optional[ExpandableField["Review"]]
     shipping: Optional[StripeObject]
     source: Optional[Any]
-    source_transfer: Optional[Any]
+    source_transfer: Optional[ExpandableField["Transfer"]]
     statement_descriptor: Optional[str]
     statement_descriptor_suffix: Optional[str]
     status: str
-    transfer: Any
+    transfer: ExpandableField["Transfer"]
     transfer_data: Optional[StripeObject]
     transfer_group: Optional[str]
 

--- a/stripe/api_resources/checkout/session.py
+++ b/stripe/api_resources/checkout/session.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe import util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Any
@@ -16,7 +17,12 @@ from typing_extensions import Literal
 from typing_extensions import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from stripe.api_resources.invoice import Invoice
     from stripe.api_resources.line_item import LineItem
+    from stripe.api_resources.payment_intent import PaymentIntent
+    from stripe.api_resources.payment_link import PaymentLink
+    from stripe.api_resources.setup_intent import SetupIntent
+    from stripe.api_resources.subscription import Subscription
 
 
 class Session(
@@ -55,13 +61,13 @@ class Session(
     currency_conversion: Optional[StripeObject]
     custom_fields: List[StripeObject]
     custom_text: StripeObject
-    customer: Optional[Any]
+    customer: Optional[ExpandableField[Any]]
     customer_creation: Optional[str]
     customer_details: Optional[StripeObject]
     customer_email: Optional[str]
     expires_at: str
     id: str
-    invoice: Optional[Any]
+    invoice: Optional[ExpandableField["Invoice"]]
     invoice_creation: Optional[StripeObject]
     line_items: ListObject["LineItem"]
     livemode: bool
@@ -69,22 +75,22 @@ class Session(
     metadata: Optional[Dict[str, str]]
     mode: str
     object: Literal["checkout.session"]
-    payment_intent: Optional[Any]
-    payment_link: Optional[Any]
+    payment_intent: Optional[ExpandableField["PaymentIntent"]]
+    payment_link: Optional[ExpandableField["PaymentLink"]]
     payment_method_collection: Optional[str]
     payment_method_options: Optional[StripeObject]
     payment_method_types: List[str]
     payment_status: str
     phone_number_collection: StripeObject
     recovered_from: Optional[str]
-    setup_intent: Optional[Any]
+    setup_intent: Optional[ExpandableField["SetupIntent"]]
     shipping_address_collection: Optional[StripeObject]
     shipping_cost: Optional[StripeObject]
     shipping_details: Optional[StripeObject]
     shipping_options: List[StripeObject]
     status: Optional[str]
     submit_type: Optional[str]
-    subscription: Optional[Any]
+    subscription: Optional[ExpandableField["Subscription"]]
     success_url: Optional[str]
     tax_id_collection: StripeObject
     total_details: Optional[StripeObject]

--- a/stripe/api_resources/connect_collection_transfer.py
+++ b/stripe/api_resources/connect_collection_transfer.py
@@ -2,16 +2,21 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing_extensions import Literal
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.account import Account
 
 
 class ConnectCollectionTransfer(StripeObject):
     OBJECT_NAME = "connect_collection_transfer"
     amount: int
     currency: str
-    destination: Any
+    destination: ExpandableField["Account"]
     id: str
     livemode: bool
     object: Literal["connect_collection_transfer"]

--- a/stripe/api_resources/credit_note.py
+++ b/stripe/api_resources/credit_note.py
@@ -7,6 +7,7 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import nested_resource_class_methods
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Any
@@ -18,7 +19,12 @@ from typing_extensions import Literal
 from typing_extensions import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from stripe.api_resources.customer_balance_transaction import (
+        CustomerBalanceTransaction,
+    )
+    from stripe.api_resources.invoice import Invoice
     from stripe.api_resources.credit_note_line_item import CreditNoteLineItem
+    from stripe.api_resources.refund import Refund
 
 
 @nested_resource_class_methods(
@@ -41,13 +47,15 @@ class CreditNote(
     amount_shipping: int
     created: str
     currency: str
-    customer: Any
-    customer_balance_transaction: Optional[Any]
+    customer: ExpandableField[Any]
+    customer_balance_transaction: Optional[
+        ExpandableField["CustomerBalanceTransaction"]
+    ]
     discount_amount: int
     discount_amounts: List[StripeObject]
     effective_at: Optional[str]
     id: str
-    invoice: Any
+    invoice: ExpandableField["Invoice"]
     lines: ListObject["CreditNoteLineItem"]
     livemode: bool
     memo: Optional[str]
@@ -57,7 +65,7 @@ class CreditNote(
     out_of_band_amount: Optional[int]
     pdf: str
     reason: Optional[str]
-    refund: Optional[Any]
+    refund: Optional[ExpandableField["Refund"]]
     shipping_cost: Optional[StripeObject]
     status: str
     subtotal: int

--- a/stripe/api_resources/customer.py
+++ b/stripe/api_resources/customer.py
@@ -10,6 +10,7 @@ from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import SearchableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import nested_resource_class_methods
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Any
@@ -26,6 +27,7 @@ if TYPE_CHECKING:
     from stripe.api_resources.discount import Discount
     from stripe.api_resources.subscription import Subscription
     from stripe.api_resources.tax_id import TaxId
+    from stripe.api_resources.test_helpers.test_clock import TestClock
 
 
 @nested_resource_class_methods(
@@ -63,7 +65,7 @@ class Customer(
     cash_balance: Optional["CashBalance"]
     created: str
     currency: Optional[str]
-    default_source: Optional[Any]
+    default_source: Optional[ExpandableField[Any]]
     delinquent: Optional[bool]
     description: Optional[str]
     discount: Optional["Discount"]
@@ -85,7 +87,7 @@ class Customer(
     tax: StripeObject
     tax_exempt: Optional[str]
     tax_ids: ListObject["TaxId"]
-    test_clock: Optional[Any]
+    test_clock: Optional[ExpandableField["TestClock"]]
 
     @classmethod
     def _cls_create_funding_instructions(

--- a/stripe/api_resources/customer_balance_transaction.py
+++ b/stripe/api_resources/customer_balance_transaction.py
@@ -14,7 +14,6 @@ from typing_extensions import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.credit_note import CreditNote
-    from stripe.api_resources.customer import Customer
     from stripe.api_resources.invoice import Invoice
 
 

--- a/stripe/api_resources/customer_balance_transaction.py
+++ b/stripe/api_resources/customer_balance_transaction.py
@@ -4,11 +4,18 @@ from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import APIResource
 from stripe.api_resources.customer import Customer
-from typing import Any
+from stripe.api_resources.expandable_field import ExpandableField
 from typing import Dict
 from typing import Optional
 from typing_extensions import Literal
 from urllib.parse import quote_plus
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.credit_note import CreditNote
+    from stripe.api_resources.customer import Customer
+    from stripe.api_resources.invoice import Invoice
 
 
 class CustomerBalanceTransaction(APIResource["CustomerBalanceTransaction"]):
@@ -24,13 +31,13 @@ class CustomerBalanceTransaction(APIResource["CustomerBalanceTransaction"]):
     OBJECT_NAME = "customer_balance_transaction"
     amount: int
     created: str
-    credit_note: Optional[Any]
+    credit_note: Optional[ExpandableField["CreditNote"]]
     currency: str
-    customer: Any
+    customer: ExpandableField["Customer"]
     description: Optional[str]
     ending_balance: int
     id: str
-    invoice: Optional[Any]
+    invoice: Optional[ExpandableField["Invoice"]]
     livemode: bool
     metadata: Optional[Dict[str, str]]
     object: Literal["customer_balance_transaction"]
@@ -39,6 +46,8 @@ class CustomerBalanceTransaction(APIResource["CustomerBalanceTransaction"]):
     def instance_url(self):
         token = self.id
         customer = self.customer
+        if isinstance(customer, Customer):
+            customer = customer.id
         base = Customer.class_url()
         cust_extn = quote_plus(customer)
         extn = quote_plus(token)

--- a/stripe/api_resources/customer_cash_balance_transaction.py
+++ b/stripe/api_resources/customer_cash_balance_transaction.py
@@ -3,9 +3,14 @@
 from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing_extensions import Literal
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.customer import Customer
 
 
 class CustomerCashBalanceTransaction(
@@ -23,7 +28,7 @@ class CustomerCashBalanceTransaction(
     applied_to_payment: StripeObject
     created: str
     currency: str
-    customer: Any
+    customer: ExpandableField["Customer"]
     ending_balance: int
     funded: StripeObject
     id: str

--- a/stripe/api_resources/discount.py
+++ b/stripe/api_resources/discount.py
@@ -2,6 +2,7 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
 from typing import Any
 from typing import Optional
@@ -11,6 +12,7 @@ from typing_extensions import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.coupon import Coupon
+    from stripe.api_resources.promotion_code import PromotionCode
 
 
 class Discount(StripeObject):
@@ -24,12 +26,12 @@ class Discount(StripeObject):
     OBJECT_NAME = "discount"
     checkout_session: Optional[str]
     coupon: "Coupon"
-    customer: Optional[Any]
+    customer: Optional[ExpandableField[Any]]
     end: Optional[str]
     id: str
     invoice: Optional[str]
     invoice_item: Optional[str]
     object: Literal["discount"]
-    promotion_code: Optional[Any]
+    promotion_code: Optional[ExpandableField["PromotionCode"]]
     start: str
     subscription: Optional[str]

--- a/stripe/api_resources/dispute.py
+++ b/stripe/api_resources/dispute.py
@@ -5,8 +5,8 @@ from __future__ import absolute_import, division, print_function
 from stripe import util
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -16,6 +16,8 @@ from typing_extensions import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.balance_transaction import BalanceTransaction
+    from stripe.api_resources.charge import Charge
+    from stripe.api_resources.payment_intent import PaymentIntent
 
 
 class Dispute(
@@ -34,7 +36,7 @@ class Dispute(
     OBJECT_NAME = "dispute"
     amount: int
     balance_transactions: List["BalanceTransaction"]
-    charge: Any
+    charge: ExpandableField["Charge"]
     created: str
     currency: str
     evidence: StripeObject
@@ -45,7 +47,7 @@ class Dispute(
     metadata: Dict[str, str]
     network_reason_code: Optional[str]
     object: Literal["dispute"]
-    payment_intent: Optional[Any]
+    payment_intent: Optional[ExpandableField["PaymentIntent"]]
     payment_method_details: StripeObject
     reason: str
     status: str

--- a/stripe/api_resources/expandable_field.py
+++ b/stripe/api_resources/expandable_field.py
@@ -1,0 +1,4 @@
+from typing import Union, TypeVar
+
+T = TypeVar('T')
+ExpandableField = Union[str, T]

--- a/stripe/api_resources/expandable_field.py
+++ b/stripe/api_resources/expandable_field.py
@@ -1,4 +1,4 @@
 from typing import Union, TypeVar
 
-T = TypeVar('T')
+T = TypeVar("T")
 ExpandableField = Union[str, T]

--- a/stripe/api_resources/file_link.py
+++ b/stripe/api_resources/file_link.py
@@ -5,10 +5,15 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
-from typing import Any
+from stripe.api_resources.expandable_field import ExpandableField
 from typing import Dict
 from typing import Optional
 from typing_extensions import Literal
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.file import File
 
 
 class FileLink(
@@ -26,7 +31,7 @@ class FileLink(
     created: str
     expired: bool
     expires_at: Optional[str]
-    file: Any
+    file: ExpandableField["File"]
     id: str
     livemode: bool
     metadata: Dict[str, str]

--- a/stripe/api_resources/financial_connections/account.py
+++ b/stripe/api_resources/financial_connections/account.py
@@ -4,11 +4,18 @@ from __future__ import absolute_import, division, print_function
 
 from stripe import util
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import List
 from typing import Optional
 from typing_extensions import Literal
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.financial_connections.account_ownership import (
+        AccountOwnership,
+    )
 
 
 class Account(ListableAPIResource["Account"]):
@@ -28,7 +35,7 @@ class Account(ListableAPIResource["Account"]):
     last4: Optional[str]
     livemode: bool
     object: Literal["financial_connections.account"]
-    ownership: Optional[Any]
+    ownership: Optional[ExpandableField["AccountOwnership"]]
     ownership_refresh: Optional[StripeObject]
     permissions: Optional[List[str]]
     status: str

--- a/stripe/api_resources/identity/verification_session.py
+++ b/stripe/api_resources/identity/verification_session.py
@@ -6,11 +6,18 @@ from stripe import util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Dict
 from typing import Optional
 from typing_extensions import Literal
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.identity.verification_report import (
+        VerificationReport,
+    )
 
 
 class VerificationSession(
@@ -37,7 +44,7 @@ class VerificationSession(
     created: str
     id: str
     last_error: Optional[StripeObject]
-    last_verification_report: Optional[Any]
+    last_verification_report: Optional[ExpandableField["VerificationReport"]]
     livemode: bool
     metadata: Dict[str, str]
     object: Literal["identity.verification_session"]

--- a/stripe/api_resources/invoice.py
+++ b/stripe/api_resources/invoice.py
@@ -8,6 +8,7 @@ from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import SearchableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Any
@@ -19,9 +20,17 @@ from typing_extensions import Literal
 from typing_extensions import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from stripe.api_resources.charge import Charge
+    from stripe.api_resources.payment_method import PaymentMethod
     from stripe.api_resources.tax_rate import TaxRate
     from stripe.api_resources.discount import Discount
+    from stripe.api_resources.invoice import Invoice
     from stripe.api_resources.invoice_line_item import InvoiceLineItem
+    from stripe.api_resources.account import Account
+    from stripe.api_resources.payment_intent import PaymentIntent
+    from stripe.api_resources.quote import Quote
+    from stripe.api_resources.subscription import Subscription
+    from stripe.api_resources.test_helpers.test_clock import TestClock
 
 
 class Invoice(
@@ -69,24 +78,24 @@ class Invoice(
     OBJECT_NAME = "invoice"
     account_country: Optional[str]
     account_name: Optional[str]
-    account_tax_ids: Optional[List[Any]]
+    account_tax_ids: Optional[List[ExpandableField[Any]]]
     amount_due: int
     amount_paid: int
     amount_remaining: int
     amount_shipping: int
-    application: Optional[Any]
+    application: Optional[ExpandableField[Any]]
     application_fee_amount: Optional[int]
     attempt_count: int
     attempted: bool
     auto_advance: bool
     automatic_tax: StripeObject
     billing_reason: Optional[str]
-    charge: Optional[Any]
+    charge: Optional[ExpandableField["Charge"]]
     collection_method: str
     created: str
     currency: str
     custom_fields: Optional[List[StripeObject]]
-    customer: Optional[Any]
+    customer: Optional[ExpandableField[Any]]
     customer_address: Optional[StripeObject]
     customer_email: Optional[str]
     customer_name: Optional[str]
@@ -94,12 +103,12 @@ class Invoice(
     customer_shipping: Optional[StripeObject]
     customer_tax_exempt: Optional[str]
     customer_tax_ids: Optional[List[StripeObject]]
-    default_payment_method: Optional[Any]
-    default_source: Optional[Any]
+    default_payment_method: Optional[ExpandableField["PaymentMethod"]]
+    default_source: Optional[ExpandableField[Any]]
     default_tax_rates: List["TaxRate"]
     description: Optional[str]
     discount: Optional["Discount"]
-    discounts: Optional[List[Any]]
+    discounts: Optional[List[ExpandableField[Any]]]
     due_date: Optional[str]
     effective_at: Optional[str]
     ending_balance: Optional[int]
@@ -109,23 +118,23 @@ class Invoice(
     id: str
     invoice_pdf: Optional[str]
     last_finalization_error: Optional[StripeObject]
-    latest_revision: Optional[Any]
+    latest_revision: Optional[ExpandableField["Invoice"]]
     lines: ListObject["InvoiceLineItem"]
     livemode: bool
     metadata: Optional[Dict[str, str]]
     next_payment_attempt: Optional[str]
     number: Optional[str]
     object: Literal["invoice"]
-    on_behalf_of: Optional[Any]
+    on_behalf_of: Optional[ExpandableField["Account"]]
     paid: bool
     paid_out_of_band: bool
-    payment_intent: Optional[Any]
+    payment_intent: Optional[ExpandableField["PaymentIntent"]]
     payment_settings: StripeObject
     period_end: str
     period_start: str
     post_payment_credit_notes_amount: int
     pre_payment_credit_notes_amount: int
-    quote: Optional[Any]
+    quote: Optional[ExpandableField["Quote"]]
     receipt_number: Optional[str]
     rendering_options: Optional[StripeObject]
     shipping_cost: Optional[StripeObject]
@@ -134,13 +143,13 @@ class Invoice(
     statement_descriptor: Optional[str]
     status: Optional[str]
     status_transitions: StripeObject
-    subscription: Optional[Any]
+    subscription: Optional[ExpandableField["Subscription"]]
     subscription_details: Optional[StripeObject]
     subscription_proration_date: int
     subtotal: int
     subtotal_excluding_tax: Optional[int]
     tax: Optional[int]
-    test_clock: Optional[Any]
+    test_clock: Optional[ExpandableField["TestClock"]]
     threshold_reason: StripeObject
     total: int
     total_discount_amounts: Optional[List[StripeObject]]

--- a/stripe/api_resources/invoice.py
+++ b/stripe/api_resources/invoice.py
@@ -24,7 +24,6 @@ if TYPE_CHECKING:
     from stripe.api_resources.payment_method import PaymentMethod
     from stripe.api_resources.tax_rate import TaxRate
     from stripe.api_resources.discount import Discount
-    from stripe.api_resources.invoice import Invoice
     from stripe.api_resources.invoice_line_item import InvoiceLineItem
     from stripe.api_resources.account import Account
     from stripe.api_resources.payment_intent import PaymentIntent

--- a/stripe/api_resources/invoice_item.py
+++ b/stripe/api_resources/invoice_item.py
@@ -6,6 +6,7 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
 from typing import Any
 from typing import Dict
@@ -16,9 +17,13 @@ from typing_extensions import Literal
 from typing_extensions import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from stripe.api_resources.discount import Discount
+    from stripe.api_resources.invoice import Invoice
     from stripe.api_resources.plan import Plan
     from stripe.api_resources.price import Price
+    from stripe.api_resources.subscription import Subscription
     from stripe.api_resources.tax_rate import TaxRate
+    from stripe.api_resources.test_helpers.test_clock import TestClock
 
 
 class InvoiceItem(
@@ -44,13 +49,13 @@ class InvoiceItem(
     OBJECT_NAME = "invoiceitem"
     amount: int
     currency: str
-    customer: Any
+    customer: ExpandableField[Any]
     date: str
     description: Optional[str]
     discountable: bool
-    discounts: Optional[List[Any]]
+    discounts: Optional[List[ExpandableField["Discount"]]]
     id: str
-    invoice: Optional[Any]
+    invoice: Optional[ExpandableField["Invoice"]]
     livemode: bool
     metadata: Optional[Dict[str, str]]
     object: Literal["invoiceitem"]
@@ -59,9 +64,9 @@ class InvoiceItem(
     price: Optional["Price"]
     proration: bool
     quantity: int
-    subscription: Optional[Any]
+    subscription: Optional[ExpandableField["Subscription"]]
     subscription_item: str
     tax_rates: Optional[List["TaxRate"]]
-    test_clock: Optional[Any]
+    test_clock: Optional[ExpandableField["TestClock"]]
     unit_amount: Optional[int]
     unit_amount_decimal: Optional[float]

--- a/stripe/api_resources/invoice_line_item.py
+++ b/stripe/api_resources/invoice_line_item.py
@@ -2,8 +2,8 @@
 # File generated from our OpenAPI spec
 from __future__ import absolute_import, division, print_function
 
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -12,8 +12,12 @@ from typing_extensions import Literal
 from typing_extensions import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from stripe.api_resources.discount import Discount
+    from stripe.api_resources.invoice_item import InvoiceItem
     from stripe.api_resources.plan import Plan
     from stripe.api_resources.price import Price
+    from stripe.api_resources.subscription import Subscription
+    from stripe.api_resources.subscription_item import SubscriptionItem
     from stripe.api_resources.tax_rate import TaxRate
 
 
@@ -25,9 +29,9 @@ class InvoiceLineItem(StripeObject):
     description: Optional[str]
     discount_amounts: Optional[List[StripeObject]]
     discountable: bool
-    discounts: Optional[List[Any]]
+    discounts: Optional[List[ExpandableField["Discount"]]]
     id: str
-    invoice_item: Any
+    invoice_item: ExpandableField["InvoiceItem"]
     livemode: bool
     metadata: Dict[str, str]
     object: Literal["line_item"]
@@ -37,8 +41,8 @@ class InvoiceLineItem(StripeObject):
     proration: bool
     proration_details: Optional[StripeObject]
     quantity: Optional[int]
-    subscription: Optional[Any]
-    subscription_item: Any
+    subscription: Optional[ExpandableField["Subscription"]]
+    subscription_item: ExpandableField["SubscriptionItem"]
     tax_amounts: List[StripeObject]
     tax_rates: List["TaxRate"]
     type: str

--- a/stripe/api_resources/issuing/authorization.py
+++ b/stripe/api_resources/issuing/authorization.py
@@ -5,8 +5,8 @@ from __future__ import absolute_import, division, print_function
 from stripe import util
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -17,6 +17,7 @@ from typing_extensions import TYPE_CHECKING
 if TYPE_CHECKING:
     from stripe.api_resources.balance_transaction import BalanceTransaction
     from stripe.api_resources.issuing.card import Card
+    from stripe.api_resources.issuing.cardholder import Cardholder
     from stripe.api_resources.issuing.transaction import Transaction
 
 
@@ -39,7 +40,7 @@ class Authorization(
     authorization_method: str
     balance_transactions: List["BalanceTransaction"]
     card: "Card"
-    cardholder: Optional[Any]
+    cardholder: Optional[ExpandableField["Cardholder"]]
     created: str
     currency: str
     id: str

--- a/stripe/api_resources/issuing/card.py
+++ b/stripe/api_resources/issuing/card.py
@@ -7,8 +7,8 @@ from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Dict
 from typing import Optional
 from typing_extensions import Literal
@@ -18,6 +18,7 @@ from typing_extensions import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.issuing.cardholder import Cardholder
+    from stripe.api_resources.issuing.card import Card
 
 
 class Card(
@@ -45,8 +46,8 @@ class Card(
     metadata: Dict[str, str]
     number: str
     object: Literal["issuing.card"]
-    replaced_by: Optional[Any]
-    replacement_for: Optional[Any]
+    replaced_by: Optional[ExpandableField["Card"]]
+    replacement_for: Optional[ExpandableField["Card"]]
     replacement_reason: Optional[str]
     shipping: Optional[StripeObject]
     spending_controls: StripeObject

--- a/stripe/api_resources/issuing/card.py
+++ b/stripe/api_resources/issuing/card.py
@@ -18,7 +18,6 @@ from typing_extensions import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.issuing.cardholder import Cardholder
-    from stripe.api_resources.issuing.card import Card
 
 
 class Card(

--- a/stripe/api_resources/issuing/dispute.py
+++ b/stripe/api_resources/issuing/dispute.py
@@ -6,8 +6,8 @@ from stripe import util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -17,6 +17,7 @@ from typing_extensions import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.balance_transaction import BalanceTransaction
+    from stripe.api_resources.issuing.transaction import Transaction
 
 
 class Dispute(
@@ -41,7 +42,7 @@ class Dispute(
     metadata: Dict[str, str]
     object: Literal["issuing.dispute"]
     status: str
-    transaction: Any
+    transaction: ExpandableField["Transaction"]
     treasury: Optional[StripeObject]
 
     @classmethod

--- a/stripe/api_resources/issuing/transaction.py
+++ b/stripe/api_resources/issuing/transaction.py
@@ -4,11 +4,20 @@ from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Dict
 from typing import Optional
 from typing_extensions import Literal
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.issuing.authorization import Authorization
+    from stripe.api_resources.balance_transaction import BalanceTransaction
+    from stripe.api_resources.issuing.card import Card
+    from stripe.api_resources.issuing.cardholder import Cardholder
+    from stripe.api_resources.issuing.dispute import Dispute
 
 
 class Transaction(
@@ -26,13 +35,13 @@ class Transaction(
     OBJECT_NAME = "issuing.transaction"
     amount: int
     amount_details: Optional[StripeObject]
-    authorization: Optional[Any]
-    balance_transaction: Optional[Any]
-    card: Any
-    cardholder: Optional[Any]
+    authorization: Optional[ExpandableField["Authorization"]]
+    balance_transaction: Optional[ExpandableField["BalanceTransaction"]]
+    card: ExpandableField["Card"]
+    cardholder: Optional[ExpandableField["Cardholder"]]
     created: str
     currency: str
-    dispute: Optional[Any]
+    dispute: Optional[ExpandableField["Dispute"]]
     id: str
     livemode: bool
     merchant_amount: int

--- a/stripe/api_resources/mandate.py
+++ b/stripe/api_resources/mandate.py
@@ -3,9 +3,14 @@
 from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import APIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing_extensions import Literal
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.payment_method import PaymentMethod
 
 
 class Mandate(APIResource["Mandate"]):
@@ -20,7 +25,7 @@ class Mandate(APIResource["Mandate"]):
     multi_use: StripeObject
     object: Literal["mandate"]
     on_behalf_of: str
-    payment_method: Any
+    payment_method: ExpandableField["PaymentMethod"]
     payment_method_details: StripeObject
     single_use: StripeObject
     status: str

--- a/stripe/api_resources/payment_intent.py
+++ b/stripe/api_resources/payment_intent.py
@@ -7,12 +7,23 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import SearchableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
 from typing_extensions import Literal
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.application import Application
+    from stripe.api_resources.invoice import Invoice
+    from stripe.api_resources.charge import Charge
+    from stripe.api_resources.account import Account
+    from stripe.api_resources.payment_method import PaymentMethod
+    from stripe.api_resources.review import Review
 
 
 class PaymentIntent(
@@ -40,7 +51,7 @@ class PaymentIntent(
     amount_capturable: int
     amount_details: StripeObject
     amount_received: int
-    application: Optional[Any]
+    application: Optional[ExpandableField["Application"]]
     application_fee_amount: Optional[int]
     automatic_payment_methods: Optional[StripeObject]
     canceled_at: Optional[str]
@@ -50,26 +61,26 @@ class PaymentIntent(
     confirmation_method: str
     created: str
     currency: str
-    customer: Optional[Any]
+    customer: Optional[ExpandableField[Any]]
     description: Optional[str]
     id: str
-    invoice: Optional[Any]
+    invoice: Optional[ExpandableField["Invoice"]]
     last_payment_error: Optional[StripeObject]
-    latest_charge: Optional[Any]
+    latest_charge: Optional[ExpandableField["Charge"]]
     livemode: bool
     metadata: Dict[str, str]
     next_action: Optional[StripeObject]
     object: Literal["payment_intent"]
-    on_behalf_of: Optional[Any]
-    payment_method: Optional[Any]
+    on_behalf_of: Optional[ExpandableField["Account"]]
+    payment_method: Optional[ExpandableField["PaymentMethod"]]
     payment_method_options: Optional[StripeObject]
     payment_method_types: List[str]
     processing: Optional[StripeObject]
     receipt_email: Optional[str]
-    review: Optional[Any]
+    review: Optional[ExpandableField["Review"]]
     setup_future_usage: Optional[str]
     shipping: Optional[StripeObject]
-    source: Optional[Any]
+    source: Optional[ExpandableField[Any]]
     statement_descriptor: Optional[str]
     statement_descriptor_suffix: Optional[str]
     status: str

--- a/stripe/api_resources/payment_link.py
+++ b/stripe/api_resources/payment_link.py
@@ -6,6 +6,7 @@ from stripe import util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Any
@@ -18,6 +19,7 @@ from typing_extensions import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.line_item import LineItem
+    from stripe.api_resources.account import Account
 
 
 class PaymentLink(
@@ -37,7 +39,7 @@ class PaymentLink(
     active: bool
     after_completion: StripeObject
     allow_promotion_codes: bool
-    application: Optional[Any]
+    application: Optional[ExpandableField[Any]]
     application_fee_amount: Optional[int]
     application_fee_percent: Optional[float]
     automatic_tax: StripeObject
@@ -53,7 +55,7 @@ class PaymentLink(
     livemode: bool
     metadata: Dict[str, str]
     object: Literal["payment_link"]
-    on_behalf_of: Optional[Any]
+    on_behalf_of: Optional[ExpandableField["Account"]]
     payment_intent_data: Optional[StripeObject]
     payment_method_collection: str
     payment_method_types: Optional[List[str]]

--- a/stripe/api_resources/payment_method.py
+++ b/stripe/api_resources/payment_method.py
@@ -6,11 +6,16 @@ from stripe import util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Dict
 from typing import Optional
 from typing_extensions import Literal
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.customer import Customer
 
 
 class PaymentMethod(
@@ -41,7 +46,7 @@ class PaymentMethod(
     card_present: StripeObject
     cashapp: StripeObject
     created: str
-    customer: Optional[Any]
+    customer: Optional[ExpandableField["Customer"]]
     customer_balance: StripeObject
     eps: StripeObject
     fpx: StripeObject

--- a/stripe/api_resources/payout.py
+++ b/stripe/api_resources/payout.py
@@ -6,10 +6,17 @@ from stripe import util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from typing import Any
 from typing import Dict
 from typing import Optional
 from typing_extensions import Literal
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.balance_transaction import BalanceTransaction
+    from stripe.api_resources.payout import Payout
 
 
 class Payout(
@@ -32,12 +39,14 @@ class Payout(
     amount: int
     arrival_date: str
     automatic: bool
-    balance_transaction: Optional[Any]
+    balance_transaction: Optional[ExpandableField["BalanceTransaction"]]
     created: str
     currency: str
     description: Optional[str]
-    destination: Optional[Any]
-    failure_balance_transaction: Optional[Any]
+    destination: Optional[ExpandableField[Any]]
+    failure_balance_transaction: Optional[
+        ExpandableField["BalanceTransaction"]
+    ]
     failure_code: Optional[str]
     failure_message: Optional[str]
     id: str
@@ -45,9 +54,9 @@ class Payout(
     metadata: Optional[Dict[str, str]]
     method: str
     object: Literal["payout"]
-    original_payout: Optional[Any]
+    original_payout: Optional[ExpandableField["Payout"]]
     reconciliation_status: str
-    reversed_by: Optional[Any]
+    reversed_by: Optional[ExpandableField["Payout"]]
     source_type: str
     statement_descriptor: Optional[str]
     status: str

--- a/stripe/api_resources/payout.py
+++ b/stripe/api_resources/payout.py
@@ -16,7 +16,6 @@ from typing_extensions import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.balance_transaction import BalanceTransaction
-    from stripe.api_resources.payout import Payout
 
 
 class Payout(

--- a/stripe/api_resources/plan.py
+++ b/stripe/api_resources/plan.py
@@ -6,6 +6,7 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
 from typing import Any
 from typing import Dict
@@ -46,7 +47,7 @@ class Plan(
     metadata: Optional[Dict[str, str]]
     nickname: Optional[str]
     object: Literal["plan"]
-    product: Optional[Any]
+    product: Optional[ExpandableField[Any]]
     tiers: List[StripeObject]
     tiers_mode: Optional[str]
     transform_usage: Optional[StripeObject]

--- a/stripe/api_resources/price.py
+++ b/stripe/api_resources/price.py
@@ -6,6 +6,7 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import SearchableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
 from typing import Any
 from typing import Dict
@@ -42,7 +43,7 @@ class Price(
     metadata: Dict[str, str]
     nickname: Optional[str]
     object: Literal["price"]
-    product: Any
+    product: ExpandableField[Any]
     recurring: Optional[StripeObject]
     tax_behavior: Optional[str]
     tiers: List[StripeObject]

--- a/stripe/api_resources/product.py
+++ b/stripe/api_resources/product.py
@@ -7,12 +7,18 @@ from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import SearchableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
 from typing_extensions import Literal
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.price import Price
+    from stripe.api_resources.tax_code import TaxCode
 
 
 class Product(
@@ -36,7 +42,7 @@ class Product(
     OBJECT_NAME = "product"
     active: bool
     created: str
-    default_price: Optional[Any]
+    default_price: Optional[ExpandableField["Price"]]
     description: Optional[str]
     id: str
     images: List[str]
@@ -47,7 +53,7 @@ class Product(
     package_dimensions: Optional[StripeObject]
     shippable: Optional[bool]
     statement_descriptor: Optional[str]
-    tax_code: Optional[Any]
+    tax_code: Optional[ExpandableField["TaxCode"]]
     type: str
     unit_label: Optional[str]
     updated: str

--- a/stripe/api_resources/promotion_code.py
+++ b/stripe/api_resources/promotion_code.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
 from typing import Any
 from typing import Dict
@@ -32,7 +33,7 @@ class PromotionCode(
     code: str
     coupon: "Coupon"
     created: str
-    customer: Optional[Any]
+    customer: Optional[ExpandableField[Any]]
     expires_at: Optional[str]
     id: str
     livemode: bool

--- a/stripe/api_resources/quote.py
+++ b/stripe/api_resources/quote.py
@@ -8,6 +8,7 @@ from stripe import util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Any
@@ -20,7 +21,13 @@ from urllib.parse import quote_plus
 from typing_extensions import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from stripe.api_resources.tax_rate import TaxRate
+    from stripe.api_resources.discount import Discount
     from stripe.api_resources.line_item import LineItem
+    from stripe.api_resources.account import Account
+    from stripe.api_resources.subscription import Subscription
+    from stripe.api_resources.subscription_schedule import SubscriptionSchedule
+    from stripe.api_resources.test_helpers.test_clock import TestClock
 
 
 class Quote(
@@ -36,7 +43,7 @@ class Quote(
     OBJECT_NAME = "quote"
     amount_subtotal: int
     amount_total: int
-    application: Optional[Any]
+    application: Optional[ExpandableField[Any]]
     application_fee_amount: Optional[int]
     application_fee_percent: Optional[float]
     automatic_tax: StripeObject
@@ -44,29 +51,29 @@ class Quote(
     computed: StripeObject
     created: str
     currency: Optional[str]
-    customer: Optional[Any]
-    default_tax_rates: List[Any]
+    customer: Optional[ExpandableField[Any]]
+    default_tax_rates: List[ExpandableField["TaxRate"]]
     description: Optional[str]
-    discounts: List[Any]
+    discounts: List[ExpandableField["Discount"]]
     expires_at: str
     footer: Optional[str]
     from_quote: Optional[StripeObject]
     header: Optional[str]
     id: str
-    invoice: Optional[Any]
+    invoice: Optional[ExpandableField[Any]]
     invoice_settings: Optional[StripeObject]
     line_items: ListObject["LineItem"]
     livemode: bool
     metadata: Dict[str, str]
     number: Optional[str]
     object: Literal["quote"]
-    on_behalf_of: Optional[Any]
+    on_behalf_of: Optional[ExpandableField["Account"]]
     status: str
     status_transitions: StripeObject
-    subscription: Optional[Any]
+    subscription: Optional[ExpandableField["Subscription"]]
     subscription_data: StripeObject
-    subscription_schedule: Optional[Any]
-    test_clock: Optional[Any]
+    subscription_schedule: Optional[ExpandableField["SubscriptionSchedule"]]
+    test_clock: Optional[ExpandableField["TestClock"]]
     total_details: StripeObject
     transfer_data: Optional[StripeObject]
 

--- a/stripe/api_resources/radar/early_fraud_warning.py
+++ b/stripe/api_resources/radar/early_fraud_warning.py
@@ -3,8 +3,14 @@
 from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import ListableAPIResource
-from typing import Any
+from stripe.api_resources.expandable_field import ExpandableField
 from typing_extensions import Literal
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.charge import Charge
+    from stripe.api_resources.payment_intent import PaymentIntent
 
 
 class EarlyFraudWarning(ListableAPIResource["EarlyFraudWarning"]):
@@ -17,10 +23,10 @@ class EarlyFraudWarning(ListableAPIResource["EarlyFraudWarning"]):
 
     OBJECT_NAME = "radar.early_fraud_warning"
     actionable: bool
-    charge: Any
+    charge: ExpandableField["Charge"]
     created: str
     fraud_type: str
     id: str
     livemode: bool
     object: Literal["radar.early_fraud_warning"]
-    payment_intent: Any
+    payment_intent: ExpandableField["PaymentIntent"]

--- a/stripe/api_resources/refund.py
+++ b/stripe/api_resources/refund.py
@@ -7,12 +7,20 @@ from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Dict
 from typing import Optional
 from typing_extensions import Literal
 from typing_extensions import Type
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.balance_transaction import BalanceTransaction
+    from stripe.api_resources.charge import Charge
+    from stripe.api_resources.payment_intent import PaymentIntent
+    from stripe.api_resources.reversal import Reversal
 
 
 class Refund(
@@ -30,24 +38,24 @@ class Refund(
 
     OBJECT_NAME = "refund"
     amount: int
-    balance_transaction: Optional[Any]
-    charge: Optional[Any]
+    balance_transaction: Optional[ExpandableField["BalanceTransaction"]]
+    charge: Optional[ExpandableField["Charge"]]
     created: str
     currency: str
     description: str
-    failure_balance_transaction: Any
+    failure_balance_transaction: ExpandableField["BalanceTransaction"]
     failure_reason: str
     id: str
     instructions_email: str
     metadata: Optional[Dict[str, str]]
     next_action: StripeObject
     object: Literal["refund"]
-    payment_intent: Optional[Any]
+    payment_intent: Optional[ExpandableField["PaymentIntent"]]
     reason: Optional[str]
     receipt_number: Optional[str]
-    source_transfer_reversal: Optional[Any]
+    source_transfer_reversal: Optional[ExpandableField["Reversal"]]
     status: Optional[str]
-    transfer_reversal: Optional[Any]
+    transfer_reversal: Optional[ExpandableField["Reversal"]]
 
     @classmethod
     def _cls_cancel(

--- a/stripe/api_resources/reversal.py
+++ b/stripe/api_resources/reversal.py
@@ -3,12 +3,19 @@
 from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.transfer import Transfer
-from typing import Any
 from typing import Dict
 from typing import Optional
 from typing_extensions import Literal
 from urllib.parse import quote_plus
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.balance_transaction import BalanceTransaction
+    from stripe.api_resources.refund import Refund
+    from stripe.api_resources.transfer import Transfer
 
 
 class Reversal(UpdateableAPIResource["Reversal"]):
@@ -30,19 +37,21 @@ class Reversal(UpdateableAPIResource["Reversal"]):
 
     OBJECT_NAME = "transfer_reversal"
     amount: int
-    balance_transaction: Optional[Any]
+    balance_transaction: Optional[ExpandableField["BalanceTransaction"]]
     created: str
     currency: str
-    destination_payment_refund: Optional[Any]
+    destination_payment_refund: Optional[ExpandableField["Refund"]]
     id: str
     metadata: Optional[Dict[str, str]]
     object: Literal["transfer_reversal"]
-    source_refund: Optional[Any]
-    transfer: Any
+    source_refund: Optional[ExpandableField["Refund"]]
+    transfer: ExpandableField["Transfer"]
 
     def instance_url(self):
         token = self.id
         transfer = self.transfer
+        if isinstance(transfer, Transfer):
+            transfer = transfer.id
         base = Transfer.class_url()
         cust_extn = quote_plus(transfer)
         extn = quote_plus(token)

--- a/stripe/api_resources/reversal.py
+++ b/stripe/api_resources/reversal.py
@@ -15,7 +15,6 @@ from typing_extensions import TYPE_CHECKING
 if TYPE_CHECKING:
     from stripe.api_resources.balance_transaction import BalanceTransaction
     from stripe.api_resources.refund import Refund
-    from stripe.api_resources.transfer import Transfer
 
 
 class Reversal(UpdateableAPIResource["Reversal"]):

--- a/stripe/api_resources/review.py
+++ b/stripe/api_resources/review.py
@@ -4,10 +4,16 @@ from __future__ import absolute_import, division, print_function
 
 from stripe import util
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Optional
 from typing_extensions import Literal
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.charge import Charge
+    from stripe.api_resources.payment_intent import PaymentIntent
 
 
 class Review(ListableAPIResource["Review"]):
@@ -20,7 +26,7 @@ class Review(ListableAPIResource["Review"]):
 
     OBJECT_NAME = "review"
     billing_zip: Optional[str]
-    charge: Optional[Any]
+    charge: Optional[ExpandableField["Charge"]]
     closed_reason: Optional[str]
     created: str
     id: str
@@ -30,7 +36,7 @@ class Review(ListableAPIResource["Review"]):
     object: Literal["review"]
     open: bool
     opened_reason: str
-    payment_intent: Any
+    payment_intent: ExpandableField["PaymentIntent"]
     reason: str
     session: Optional[StripeObject]
 

--- a/stripe/api_resources/setup_attempt.py
+++ b/stripe/api_resources/setup_attempt.py
@@ -3,11 +3,20 @@
 from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
 from typing import Any
 from typing import List
 from typing import Optional
 from typing_extensions import Literal
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.application import Application
+    from stripe.api_resources.account import Account
+    from stripe.api_resources.payment_method import PaymentMethod
+    from stripe.api_resources.setup_intent import SetupIntent
 
 
 class SetupAttempt(ListableAPIResource["SetupAttempt"]):
@@ -19,18 +28,18 @@ class SetupAttempt(ListableAPIResource["SetupAttempt"]):
     """
 
     OBJECT_NAME = "setup_attempt"
-    application: Optional[Any]
+    application: Optional[ExpandableField["Application"]]
     attach_to_self: bool
     created: str
-    customer: Optional[Any]
+    customer: Optional[ExpandableField[Any]]
     flow_directions: Optional[List[str]]
     id: str
     livemode: bool
     object: Literal["setup_attempt"]
-    on_behalf_of: Optional[Any]
-    payment_method: Any
+    on_behalf_of: Optional[ExpandableField["Account"]]
+    payment_method: ExpandableField["PaymentMethod"]
     payment_method_details: StripeObject
     setup_error: Optional[StripeObject]
-    setup_intent: Any
+    setup_intent: ExpandableField["SetupIntent"]
     status: str
     usage: str

--- a/stripe/api_resources/setup_intent.py
+++ b/stripe/api_resources/setup_intent.py
@@ -6,12 +6,22 @@ from stripe import util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
 from typing_extensions import Literal
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.application import Application
+    from stripe.api_resources.setup_attempt import SetupAttempt
+    from stripe.api_resources.mandate import Mandate
+    from stripe.api_resources.account import Account
+    from stripe.api_resources.payment_method import PaymentMethod
 
 
 class SetupIntent(
@@ -45,28 +55,28 @@ class SetupIntent(
     """
 
     OBJECT_NAME = "setup_intent"
-    application: Optional[Any]
+    application: Optional[ExpandableField["Application"]]
     attach_to_self: bool
     automatic_payment_methods: Optional[StripeObject]
     cancellation_reason: Optional[str]
     client_secret: Optional[str]
     created: str
-    customer: Optional[Any]
+    customer: Optional[ExpandableField[Any]]
     description: Optional[str]
     flow_directions: Optional[List[str]]
     id: str
     last_setup_error: Optional[StripeObject]
-    latest_attempt: Optional[Any]
+    latest_attempt: Optional[ExpandableField["SetupAttempt"]]
     livemode: bool
-    mandate: Optional[Any]
+    mandate: Optional[ExpandableField["Mandate"]]
     metadata: Optional[Dict[str, str]]
     next_action: Optional[StripeObject]
     object: Literal["setup_intent"]
-    on_behalf_of: Optional[Any]
-    payment_method: Optional[Any]
+    on_behalf_of: Optional[ExpandableField["Account"]]
+    payment_method: Optional[ExpandableField["PaymentMethod"]]
     payment_method_options: Optional[StripeObject]
     payment_method_types: List[str]
-    single_use_mandate: Optional[Any]
+    single_use_mandate: Optional[ExpandableField["Mandate"]]
     status: str
     usage: str
 

--- a/stripe/api_resources/shipping_rate.py
+++ b/stripe/api_resources/shipping_rate.py
@@ -5,11 +5,16 @@ from __future__ import absolute_import, division, print_function
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Dict
 from typing import Optional
 from typing_extensions import Literal
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.tax_code import TaxCode
 
 
 class ShippingRate(
@@ -33,5 +38,5 @@ class ShippingRate(
     metadata: Dict[str, str]
     object: Literal["shipping_rate"]
     tax_behavior: Optional[str]
-    tax_code: Optional[Any]
+    tax_code: Optional[ExpandableField["TaxCode"]]
     type: Literal["fixed_amount"]

--- a/stripe/api_resources/subscription.py
+++ b/stripe/api_resources/subscription.py
@@ -8,6 +8,7 @@ from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import SearchableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
 from typing import Any
@@ -19,9 +20,15 @@ from typing_extensions import Literal
 from typing_extensions import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from stripe.api_resources.payment_method import PaymentMethod
     from stripe.api_resources.tax_rate import TaxRate
     from stripe.api_resources.discount import Discount
     from stripe.api_resources.subscription_item import SubscriptionItem
+    from stripe.api_resources.invoice import Invoice
+    from stripe.api_resources.account import Account
+    from stripe.api_resources.setup_intent import SetupIntent
+    from stripe.api_resources.subscription_schedule import SubscriptionSchedule
+    from stripe.api_resources.test_helpers.test_clock import TestClock
 
 
 class Subscription(
@@ -38,7 +45,7 @@ class Subscription(
     """
 
     OBJECT_NAME = "subscription"
-    application: Optional[Any]
+    application: Optional[ExpandableField[Any]]
     application_fee_percent: Optional[float]
     automatic_tax: StripeObject
     billing_cycle_anchor: str
@@ -52,31 +59,31 @@ class Subscription(
     currency: str
     current_period_end: str
     current_period_start: str
-    customer: Any
+    customer: ExpandableField[Any]
     days_until_due: Optional[int]
-    default_payment_method: Optional[Any]
-    default_source: Optional[Any]
+    default_payment_method: Optional[ExpandableField["PaymentMethod"]]
+    default_source: Optional[ExpandableField[Any]]
     default_tax_rates: Optional[List["TaxRate"]]
     description: Optional[str]
     discount: Optional["Discount"]
     ended_at: Optional[str]
     id: str
     items: ListObject["SubscriptionItem"]
-    latest_invoice: Optional[Any]
+    latest_invoice: Optional[ExpandableField["Invoice"]]
     livemode: bool
     metadata: Dict[str, str]
     next_pending_invoice_item_invoice: Optional[str]
     object: Literal["subscription"]
-    on_behalf_of: Optional[Any]
+    on_behalf_of: Optional[ExpandableField["Account"]]
     pause_collection: Optional[StripeObject]
     payment_settings: Optional[StripeObject]
     pending_invoice_item_interval: Optional[StripeObject]
-    pending_setup_intent: Optional[Any]
+    pending_setup_intent: Optional[ExpandableField["SetupIntent"]]
     pending_update: Optional[StripeObject]
-    schedule: Optional[Any]
+    schedule: Optional[ExpandableField["SubscriptionSchedule"]]
     start_date: str
     status: str
-    test_clock: Optional[Any]
+    test_clock: Optional[ExpandableField["TestClock"]]
     transfer_data: Optional[StripeObject]
     trial_end: Optional[str]
     trial_settings: Optional[StripeObject]

--- a/stripe/api_resources/subscription_schedule.py
+++ b/stripe/api_resources/subscription_schedule.py
@@ -6,12 +6,19 @@ from stripe import util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
 from typing_extensions import Literal
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.subscription import Subscription
+    from stripe.api_resources.test_helpers.test_clock import TestClock
 
 
 class SubscriptionSchedule(
@@ -26,12 +33,12 @@ class SubscriptionSchedule(
     """
 
     OBJECT_NAME = "subscription_schedule"
-    application: Optional[Any]
+    application: Optional[ExpandableField[Any]]
     canceled_at: Optional[str]
     completed_at: Optional[str]
     created: str
     current_phase: Optional[StripeObject]
-    customer: Any
+    customer: ExpandableField[Any]
     default_settings: StripeObject
     end_behavior: str
     id: str
@@ -42,8 +49,8 @@ class SubscriptionSchedule(
     released_at: Optional[str]
     released_subscription: Optional[str]
     status: str
-    subscription: Optional[Any]
-    test_clock: Optional[Any]
+    subscription: Optional[ExpandableField["Subscription"]]
+    test_clock: Optional[ExpandableField["TestClock"]]
 
     @classmethod
     def _cls_cancel(

--- a/stripe/api_resources/tax_id.py
+++ b/stripe/api_resources/tax_id.py
@@ -10,11 +10,6 @@ from typing import Optional
 from typing_extensions import Literal
 from urllib.parse import quote_plus
 
-from typing_extensions import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from stripe.api_resources.customer import Customer
-
 
 class TaxId(APIResource["TaxId"]):
     """

--- a/stripe/api_resources/tax_id.py
+++ b/stripe/api_resources/tax_id.py
@@ -4,11 +4,16 @@ from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import APIResource
 from stripe.api_resources.customer import Customer
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Optional
 from typing_extensions import Literal
 from urllib.parse import quote_plus
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.customer import Customer
 
 
 class TaxId(APIResource["TaxId"]):
@@ -22,7 +27,7 @@ class TaxId(APIResource["TaxId"]):
     OBJECT_NAME = "tax_id"
     country: Optional[str]
     created: str
-    customer: Optional[Any]
+    customer: Optional[ExpandableField["Customer"]]
     id: str
     livemode: bool
     object: Literal["tax_id"]
@@ -35,6 +40,8 @@ class TaxId(APIResource["TaxId"]):
         customer = self.customer
         base = Customer.class_url()
         assert customer is not None
+        if isinstance(customer, Customer):
+            customer = customer.id
         cust_extn = quote_plus(customer)
         extn = quote_plus(token)
         return "%s/%s/tax_ids/%s" % (base, cust_extn, extn)

--- a/stripe/api_resources/terminal/reader.py
+++ b/stripe/api_resources/terminal/reader.py
@@ -8,12 +8,17 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Dict
 from typing import Optional
 from typing_extensions import Literal
 from typing_extensions import Type
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.terminal.location import Location
 
 
 class Reader(
@@ -36,7 +41,7 @@ class Reader(
     ip_address: Optional[str]
     label: str
     livemode: bool
-    location: Optional[Any]
+    location: Optional[ExpandableField["Location"]]
     metadata: Dict[str, str]
     object: Literal["terminal.reader"]
     serial_number: str

--- a/stripe/api_resources/topup.py
+++ b/stripe/api_resources/topup.py
@@ -6,7 +6,7 @@ from stripe import util
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
-from typing import Any
+from stripe.api_resources.expandable_field import ExpandableField
 from typing import Dict
 from typing import Optional
 from typing_extensions import Literal
@@ -14,6 +14,7 @@ from typing_extensions import Literal
 from typing_extensions import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from stripe.api_resources.balance_transaction import BalanceTransaction
     from stripe.api_resources.source import Source
 
 
@@ -32,7 +33,7 @@ class Topup(
 
     OBJECT_NAME = "topup"
     amount: int
-    balance_transaction: Optional[Any]
+    balance_transaction: Optional[ExpandableField["BalanceTransaction"]]
     created: str
     currency: str
     description: Optional[str]

--- a/stripe/api_resources/transfer.py
+++ b/stripe/api_resources/transfer.py
@@ -6,8 +6,8 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.abstract import nested_resource_class_methods
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
-from typing import Any
 from typing import Dict
 from typing import Optional
 from typing_extensions import Literal
@@ -15,6 +15,9 @@ from typing_extensions import Literal
 from typing_extensions import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from stripe.api_resources.balance_transaction import BalanceTransaction
+    from stripe.api_resources.account import Account
+    from stripe.api_resources.charge import Charge
     from stripe.api_resources.reversal import Reversal
 
 
@@ -43,18 +46,18 @@ class Transfer(
     OBJECT_NAME = "transfer"
     amount: int
     amount_reversed: int
-    balance_transaction: Optional[Any]
+    balance_transaction: Optional[ExpandableField["BalanceTransaction"]]
     created: str
     currency: str
     description: Optional[str]
-    destination: Optional[Any]
-    destination_payment: Any
+    destination: Optional[ExpandableField["Account"]]
+    destination_payment: ExpandableField["Charge"]
     id: str
     livemode: bool
     metadata: Dict[str, str]
     object: Literal["transfer"]
     reversals: ListObject["Reversal"]
     reversed: bool
-    source_transaction: Optional[Any]
+    source_transaction: Optional[ExpandableField["Charge"]]
     source_type: str
     transfer_group: Optional[str]

--- a/stripe/api_resources/treasury/credit_reversal.py
+++ b/stripe/api_resources/treasury/credit_reversal.py
@@ -4,11 +4,16 @@ from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Dict
 from typing import Optional
 from typing_extensions import Literal
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.treasury.transaction import Transaction
 
 
 class CreditReversal(
@@ -33,4 +38,4 @@ class CreditReversal(
     received_credit: str
     status: str
     status_transitions: StripeObject
-    transaction: Optional[Any]
+    transaction: Optional[ExpandableField["Transaction"]]

--- a/stripe/api_resources/treasury/debit_reversal.py
+++ b/stripe/api_resources/treasury/debit_reversal.py
@@ -4,11 +4,16 @@ from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Dict
 from typing import Optional
 from typing_extensions import Literal
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.treasury.transaction import Transaction
 
 
 class DebitReversal(
@@ -34,4 +39,4 @@ class DebitReversal(
     received_debit: str
     status: str
     status_transitions: StripeObject
-    transaction: Optional[Any]
+    transaction: Optional[ExpandableField["Transaction"]]

--- a/stripe/api_resources/treasury/inbound_transfer.py
+++ b/stripe/api_resources/treasury/inbound_transfer.py
@@ -6,12 +6,17 @@ from stripe import util
 from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Dict
 from typing import Optional
 from typing_extensions import Literal
 from typing_extensions import Type
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.treasury.transaction import Transaction
 
 
 class InboundTransfer(
@@ -42,7 +47,7 @@ class InboundTransfer(
     statement_descriptor: str
     status: str
     status_transitions: StripeObject
-    transaction: Optional[Any]
+    transaction: Optional[ExpandableField["Transaction"]]
 
     @classmethod
     def _cls_cancel(

--- a/stripe/api_resources/treasury/outbound_payment.py
+++ b/stripe/api_resources/treasury/outbound_payment.py
@@ -6,12 +6,17 @@ from stripe import util
 from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Dict
 from typing import Optional
 from typing_extensions import Literal
 from typing_extensions import Type
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.treasury.transaction import Transaction
 
 
 class OutboundPayment(
@@ -45,7 +50,7 @@ class OutboundPayment(
     statement_descriptor: str
     status: str
     status_transitions: StripeObject
-    transaction: Any
+    transaction: ExpandableField["Transaction"]
 
     @classmethod
     def _cls_cancel(

--- a/stripe/api_resources/treasury/outbound_transfer.py
+++ b/stripe/api_resources/treasury/outbound_transfer.py
@@ -6,12 +6,17 @@ from stripe import util
 from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Dict
 from typing import Optional
 from typing_extensions import Literal
 from typing_extensions import Type
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.treasury.transaction import Transaction
 
 
 class OutboundTransfer(
@@ -43,7 +48,7 @@ class OutboundTransfer(
     statement_descriptor: str
     status: str
     status_transitions: StripeObject
-    transaction: Any
+    transaction: ExpandableField["Transaction"]
 
     @classmethod
     def _cls_cancel(

--- a/stripe/api_resources/treasury/received_credit.py
+++ b/stripe/api_resources/treasury/received_credit.py
@@ -4,11 +4,16 @@ from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Optional
 from typing_extensions import Literal
 from typing_extensions import Type
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.treasury.transaction import Transaction
 
 
 class ReceivedCredit(ListableAPIResource["ReceivedCredit"]):
@@ -32,7 +37,7 @@ class ReceivedCredit(ListableAPIResource["ReceivedCredit"]):
     object: Literal["treasury.received_credit"]
     reversal_details: Optional[StripeObject]
     status: str
-    transaction: Optional[Any]
+    transaction: Optional[ExpandableField["Transaction"]]
 
     class TestHelpers(APIResourceTestHelpers["ReceivedCredit"]):
         _resource_cls: Type["ReceivedCredit"]

--- a/stripe/api_resources/treasury/received_debit.py
+++ b/stripe/api_resources/treasury/received_debit.py
@@ -4,11 +4,16 @@ from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import APIResourceTestHelpers
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Optional
 from typing_extensions import Literal
 from typing_extensions import Type
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.treasury.transaction import Transaction
 
 
 class ReceivedDebit(ListableAPIResource["ReceivedDebit"]):
@@ -32,7 +37,7 @@ class ReceivedDebit(ListableAPIResource["ReceivedDebit"]):
     object: Literal["treasury.received_debit"]
     reversal_details: Optional[StripeObject]
     status: str
-    transaction: Optional[Any]
+    transaction: Optional[ExpandableField["Transaction"]]
 
     class TestHelpers(APIResourceTestHelpers["ReceivedDebit"]):
         _resource_cls: Type["ReceivedDebit"]

--- a/stripe/api_resources/treasury/transaction_entry.py
+++ b/stripe/api_resources/treasury/transaction_entry.py
@@ -3,10 +3,15 @@
 from __future__ import absolute_import, division, print_function
 
 from stripe.api_resources.abstract import ListableAPIResource
+from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Any
 from typing import Optional
 from typing_extensions import Literal
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe.api_resources.treasury.transaction import Transaction
 
 
 class TransactionEntry(ListableAPIResource["TransactionEntry"]):
@@ -26,7 +31,7 @@ class TransactionEntry(ListableAPIResource["TransactionEntry"]):
     id: str
     livemode: bool
     object: Literal["treasury.transaction_entry"]
-    transaction: Any
+    transaction: ExpandableField["Transaction"]
     type: str
 
     @classmethod


### PR DESCRIPTION
More precise types for "ExpandableField" resource properties. Commit-by-commit:

1. In [Expandable field](https://github.com/stripe/stripe-python/pull/1044/commits/a786c586daf14751b9f44328ff4945daab9ce7b6) I define an alias ExpandableField[T] = Union[T, str].
2. In [ExpandableField](https://github.com/stripe/stripe-python/pull/1044/commits/87a6e46acb67badaac1a4d57fe4c46240b6c4e86) I generate the annotations that use it.
3. In [Manual TransferReversal -> Reversal](https://github.com/stripe/stripe-python/pull/1044/commits/5d11320502aa3fa50608368477901509878b5ce5) I manually fix an issue in the generated code that should be solved by generator changes for #1043 
4. Deduped imports [Dedupe imports](https://github.com/stripe/stripe-python/pull/1044/commits/b6d15fd78422c33aa81ab91d2161f8d1fa9d9054)