### PR TITLE
Add various type annotations

### DIFF
--- a/flake8_stripe/flake8_stripe.py
+++ b/flake8_stripe/flake8_stripe.py
@@ -42,6 +42,7 @@ class TypingImportsChecker:
         "Dict",
         "List",
         "Generic",
+        "Tuple",
     ]
 
     def __init__(self, tree: ast.AST):

--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -5,6 +5,7 @@ import datetime
 import json
 import platform
 import time
+from typing import Tuple
 import uuid
 import warnings
 from collections import OrderedDict
@@ -114,7 +115,9 @@ class APIRequestor(object):
             str += " (%s)" % (info["url"],)
         return str
 
-    def request(self, method, url, params=None, headers=None):
+    def request(
+        self, method, url, params=None, headers=None
+    ) -> Tuple[StripeResponse, str]:
         rbody, rcode, rheaders, my_api_key = self.request_raw(
             method.lower(), url, params, headers, is_streaming=False
         )
@@ -381,7 +384,7 @@ class APIRequestor(object):
     def _should_handle_code_as_error(self, rcode):
         return not 200 <= rcode < 300
 
-    def interpret_response(self, rbody, rcode, rheaders):
+    def interpret_response(self, rbody, rcode, rheaders) -> StripeResponse:
         try:
             if hasattr(rbody, "decode"):
                 rbody = rbody.decode("utf-8")

--- a/stripe/api_resources/abstract/api_resource.py
+++ b/stripe/api_resources/abstract/api_resource.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import, division, print_function
+from typing_extensions import Literal
 
 from stripe import api_requestor, error, util
 from stripe.stripe_object import StripeObject
 from urllib.parse import quote_plus
-from typing import ClassVar, Generic, TypeVar, cast
+from typing import Any, ClassVar, Dict, Generic, Optional, TypeVar, cast
 
 T = TypeVar("T", bound=StripeObject)
 
@@ -82,14 +83,14 @@ class APIResource(StripeObject, Generic[T]):
     # avoid conflicting with actual request parameters in `params`.
     def _request_and_refresh(
         self,
-        method_,
-        url_,
-        api_key=None,
-        idempotency_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        headers=None,
-        params=None,
+        method_: Literal["get", "post", "delete"],
+        url_: str,
+        api_key: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        headers: Optional[Dict[str, str]] = None,
+        params: Optional[Dict[str, Any]] = None,
     ):
         obj = StripeObject._request(
             self,

--- a/stripe/api_resources/list_object.py
+++ b/stripe/api_resources/list_object.py
@@ -18,9 +18,14 @@ class ListObject(StripeObject, Generic[T]):
     def list(
         self, api_key=None, stripe_version=None, stripe_account=None, **params
     ):
+        url = self.get("url")
+        if not isinstance(url, str):
+            raise ValueError(
+                'Cannot call .list on a list object without a string "url" property'
+            )
         return self._request(
             "get",
-            self.get("url"),
+            url,
             api_key=api_key,
             stripe_version=stripe_version,
             stripe_account=stripe_account,
@@ -35,9 +40,14 @@ class ListObject(StripeObject, Generic[T]):
         stripe_account=None,
         **params
     ):
+        url = self.get("url")
+        if not isinstance(url, str):
+            raise ValueError(
+                'Cannot call .create on a list object for the collection of an object without a string "url" property'
+            )
         return self._request(
             "post",
-            self.get("url"),
+            url,
             api_key=api_key,
             idempotency_key=idempotency_key,
             stripe_version=stripe_version,
@@ -53,6 +63,12 @@ class ListObject(StripeObject, Generic[T]):
         stripe_account=None,
         **params
     ):
+        url = self.get("url")
+        if not isinstance(url, str):
+            raise ValueError(
+                'Cannot call .retrieve on a list object for the collection of an object without a string "url" property'
+            )
+
         url = "%s/%s" % (self.get("url"), quote_plus(id))
         return self._request(
             "get",

--- a/stripe/api_resources/search_result_object.py
+++ b/stripe/api_resources/search_result_object.py
@@ -14,9 +14,14 @@ class SearchResultObject(StripeObject):
     def search(
         self, api_key=None, stripe_version=None, stripe_account=None, **params
     ):
+        url = self.get("url")
+        if not isinstance(url, str):
+            raise ValueError(
+                'Cannot call .list on a list object without a string "url" property'
+            )
         return self._request(
             "get",
-            self.get("url"),
+            url,
             api_key=api_key,
             stripe_version=stripe_version,
             stripe_account=stripe_account,

--- a/stripe/stripe_object.py
+++ b/stripe/stripe_object.py
@@ -3,11 +3,13 @@ from __future__ import absolute_import, division, print_function
 import datetime
 import json
 from copy import deepcopy
-from typing_extensions import TYPE_CHECKING
-from typing import Any, Dict
+from typing_extensions import TYPE_CHECKING, Literal
+from typing import Any, Dict, Optional
 
 import stripe
 from stripe import api_requestor, util
+
+from stripe.stripe_response import StripeResponse
 
 
 def _compute_diff(current, previous):
@@ -68,10 +70,10 @@ class StripeObject(Dict[str, Any]):
             self["id"] = id
 
     @property
-    def last_response(self):
+    def last_response(self) -> Optional[StripeResponse]:
         return self._last_response
 
-    def update(self, update_dict):
+    def update(self, update_dict: Dict[str, Any]):
         for k in update_dict:
             self._unsaved_values.add(k)
 
@@ -167,11 +169,11 @@ class StripeObject(Dict[str, Any]):
     @classmethod
     def construct_from(
         cls,
-        values,
-        key,
-        stripe_version=None,
-        stripe_account=None,
-        last_response=None,
+        values: Dict[str, Any],
+        key: Optional[str],
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        last_response: Optional[StripeResponse] = None,
     ):
         instance = cls(
             values.get("id"),
@@ -191,12 +193,12 @@ class StripeObject(Dict[str, Any]):
 
     def refresh_from(
         self,
-        values,
-        api_key=None,
-        partial=False,
-        stripe_version=None,
-        stripe_account=None,
-        last_response=None,
+        values: Dict[str, Any],
+        api_key: Optional[str] = None,
+        partial: Optional[bool] = False,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        last_response: Optional[StripeResponse] = None,
     ):
         self.api_key = api_key or getattr(values, "api_key", None)
         self.stripe_version = stripe_version or getattr(
@@ -236,7 +238,13 @@ class StripeObject(Dict[str, Any]):
     def api_base(cls):
         return None
 
-    def request(self, method, url, params=None, headers=None):
+    def request(
+        self,
+        method: Literal["get", "post", "delete"],
+        url: str,
+        params: Optional[Dict[str, Any]] = None,
+        headers=None,
+    ):
         return StripeObject._request(
             self, method, url, headers=headers, params=params
         )
@@ -245,14 +253,14 @@ class StripeObject(Dict[str, Any]):
     # avoid conflicting with actual request parameters in `params`.
     def _request(
         self,
-        method_,
-        url_,
-        api_key=None,
-        idempotency_key=None,
-        stripe_version=None,
-        stripe_account=None,
-        headers=None,
-        params=None,
+        method_: Literal["get", "post", "delete"],
+        url_: str,
+        api_key: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        headers: Optional[Dict[str, str]] = None,
+        params: Optional[Dict[str, Any]] = None,
     ):
         params = None if params is None else params.copy()
         api_key = util.read_special_variable(params, "api_key", api_key)

--- a/stripe/util.py
+++ b/stripe/util.py
@@ -185,7 +185,7 @@ def convert_to_stripe_object(
     if isinstance(resp, list):
         return [
             convert_to_stripe_object(
-                cast("StripeObject", i),
+                cast("StripeResponse", i),
                 api_key,
                 stripe_version,
                 stripe_account,

--- a/stripe/util.py
+++ b/stripe/util.py
@@ -185,7 +185,7 @@ def convert_to_stripe_object(
     if isinstance(resp, list):
         return [
             convert_to_stripe_object(
-                cast("Union[StripeObject, Dict[str, Any]]", i),
+                cast("Union[StripeResponse, Dict[str, Any]]", i),
                 api_key,
                 stripe_version,
                 stripe_account,

--- a/stripe/util.py
+++ b/stripe/util.py
@@ -185,7 +185,7 @@ def convert_to_stripe_object(
     if isinstance(resp, list):
         return [
             convert_to_stripe_object(
-                cast("StripeResponse", i),
+                cast("Union[StripeObject, Dict[str, Any]]", i),
                 api_key,
                 stripe_version,
                 stripe_account,


### PR DESCRIPTION
Adds type annotations to certain infrastructure methods:
  * The goal: better type for `util.convert_to_stripe_object` (since the team was just talking about this method feels uncomfortable).
    * Had to leave in a couple of `cast` to make the types line up because it's weird and recursive and polymorphic.
  * Typed `.request`, `._request`, `.construct_from` and `.refresh_from` on`StripeObject`, since these are called from `convert_to_stripe_object`.
    * Had to add some asserts in `ListObject` `.list`, `.create`, `.retrieve`, `SearchObject.search` to stop complaints about the new typed `StripeObject._request`