### PR TITLE
Use latest pyright again

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,2 @@
 # cryptography 40.0.0 deprecates support for Python 3.6 and PyPy3 < 7.3.10
 cryptography<40
-# TODO (remove later): pyright 1.1.323 introduces false positive errors
-pyright<1.1.323

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,11 @@ exclude = '''
 )
 '''
 [tool.pyright]
+executionEnvironments=[
+  {"root" = "stripe"}
+]
 include=["stripe"]
+exclude=["build", "**/__pycache__"]
 reportMissingTypeArgument=true
 reportUnnecessaryCast=true
 reportUnnecessaryComparison=true


### PR DESCRIPTION
[Pyright 1.1.323](https://github.com/microsoft/pyright/releases/tag/1.1.323) fixed a bug in the resolver we had been relying on in our CI for `pyright` to pick up the types from our library.

Turns out, `pyright` assumes that your source files are in `src/` but we put our source files in `stripe/`. The way to handle this is by defining an "execution context". This PR does that and removes the version constraint on Pyright.