### PR TITLE
More type annotations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     license="MIT",
     keywords="stripe api payments",
     packages=find_packages(exclude=["tests", "tests.*"]),
-    package_data={"stripe": ["data/ca-certificates.crt", "py.typed"]},
+    package_data={"stripe": ["data/ca-certificates.crt"]},
     zip_safe=False,
     install_requires=[
         'typing_extensions <= 4.2.0, > 3.7.2; python_version < "3.7"',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     license="MIT",
     keywords="stripe api payments",
     packages=find_packages(exclude=["tests", "tests.*"]),
-    package_data={"stripe": ["data/ca-certificates.crt"]},
+    package_data={"stripe": ["data/ca-certificates.crt", "py.typed"]},
     zip_safe=False,
     install_requires=[
         'typing_extensions <= 4.2.0, > 3.7.2; python_version < "3.7"',

--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -1,5 +1,5 @@
 from typing_extensions import TYPE_CHECKING, Literal
-from typing import Union, Optional
+from typing import Optional
 
 import os
 

--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -1,4 +1,4 @@
-from typing_extensions import Literal
+from typing_extensions import TYPE_CHECKING, Literal
 from typing import Union, Optional
 
 import os
@@ -15,24 +15,27 @@ from stripe.api_version import _ApiVersion
 
 from stripe.app_info import AppInfo
 
+if TYPE_CHECKING:
+    from stripe.http_client import HTTPClient
+
 api_key: Optional[str] = None
 client_id: Optional[str] = None
-api_base = "https://api.stripe.com"
-connect_api_base = "https://connect.stripe.com"
-upload_api_base = "https://files.stripe.com"
-api_version = _ApiVersion.CURRENT
-verify_ssl_certs = True
-proxy = None
-default_http_client = None
+api_base: str = "https://api.stripe.com"
+connect_api_base: str = "https://connect.stripe.com"
+upload_api_base: str = "https://files.stripe.com"
+api_version: str = _ApiVersion.CURRENT
+verify_ssl_certs: bool = True
+proxy: Optional[str] = None
+default_http_client: Optional["HTTPClient"] = None
 app_info: Optional[AppInfo] = None
-enable_telemetry = True
-max_network_retries = 0
-ca_bundle_path = os.path.join(
+enable_telemetry: bool = True
+max_network_retries: int = 0
+ca_bundle_path: str = os.path.join(
     os.path.dirname(__file__), "data", "ca-certificates.crt"
 )
 
 # Set to either 'debug' or 'info', controls console logging
-log: Optional[Union[Literal["debug"], Literal["info"]]] = None
+log: Optional[Literal["debug", "info"]] = None
 
 # API resources
 from stripe.api_resources import *  # pyright: ignore # noqa

--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -3,7 +3,7 @@ import datetime
 import json
 import platform
 import time
-from typing import Tuple
+from typing import Optional, Tuple
 import uuid
 import warnings
 from collections import OrderedDict
@@ -13,6 +13,8 @@ from stripe import error, oauth_error, http_client, version, util
 from stripe.multipart_data_generator import MultipartDataGenerator
 from urllib.parse import urlencode, urlsplit, urlunsplit
 from stripe.stripe_response import StripeResponse, StripeStreamResponse
+
+from stripe.http_client import HTTPClient
 
 
 def _encode_datetime(dttime):
@@ -65,6 +67,11 @@ def _build_api_url(url, query):
 
 
 class APIRequestor(object):
+    api_key: Optional[str]
+    api_base: str
+    api_version: str
+    stripe_account: Optional[str]
+
     def __init__(
         self,
         key=None,

--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -282,8 +282,7 @@ class APIRequestor(object):
             headers["Content-Type"] = "application/x-www-form-urlencoded"
             headers.setdefault("Idempotency-Key", str(uuid.uuid4()))
 
-        if self.api_version is not None:
-            headers["Stripe-Version"] = self.api_version
+        headers["Stripe-Version"] = self.api_version
 
         return headers
 

--- a/stripe/api_requestor.py
+++ b/stripe/api_requestor.py
@@ -14,8 +14,6 @@ from stripe.multipart_data_generator import MultipartDataGenerator
 from urllib.parse import urlencode, urlsplit, urlunsplit
 from stripe.stripe_response import StripeResponse, StripeStreamResponse
 
-from stripe.http_client import HTTPClient
-
 
 def _encode_datetime(dttime):
     if dttime.tzinfo and dttime.tzinfo.utcoffset(dttime) is not None:

--- a/stripe/error.py
+++ b/stripe/error.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, Union, cast
 import stripe
 from stripe.api_resources.error_object import ErrorObject
 
@@ -15,26 +15,27 @@ class StripeError(Exception):
 
     def __init__(
         self,
-        message=None,
-        http_body=None,
-        http_status=None,
-        json_body=None,
-        headers=None,
-        code=None,
+        message: Optional[str] = None,
+        http_body: Optional[Union[bytes, str]] = None,
+        http_status: Optional[int] = None,
+        json_body: Optional[object] = None,
+        headers: Optional[Dict[str, str]] = None,
+        code: Optional[str] = None,
     ):
         super(StripeError, self).__init__(message)
 
+        body: Optional[str] = None
         if http_body and hasattr(http_body, "decode"):
             try:
-                http_body = http_body.decode("utf-8")
+                body = cast(bytes, http_body).decode("utf-8")
             except BaseException:
-                http_body = (
+                body = (
                     "<Could not decode body as utf-8. "
                     "Please report to support@stripe.com>"
                 )
 
         self._message = message
-        self.http_body = http_body
+        self.http_body = body
         self.http_status = http_status
         self.json_body = json_body
         self.headers = headers or {}

--- a/stripe/http_client.py
+++ b/stripe/http_client.py
@@ -1,4 +1,3 @@
-from io import IOBase
 import sys
 import textwrap
 import warnings
@@ -12,8 +11,8 @@ import stripe
 from stripe import error, util
 from stripe.request_metrics import RequestMetrics
 
-from typing import Any, Optional, Tuple
-from typing_extensions import ClassVar, NoReturn, TypedDict
+from typing import Any, Optional, Tuple, ClassVar
+from typing_extensions import NoReturn, TypedDict
 
 # - Requests is the preferred HTTP library
 # - Google App Engine has urlfetch

--- a/stripe/http_client.py
+++ b/stripe/http_client.py
@@ -1,3 +1,4 @@
+from io import IOBase
 import sys
 import textwrap
 import warnings
@@ -126,7 +127,7 @@ class HTTPClient(object):
 
     def request_stream_with_retries(
         self, method, url, headers, post_data=None
-    ):
+    ) -> IOBase:
         return self._request_with_retries_internal(
             method, url, headers, post_data, is_streaming=True
         )
@@ -183,7 +184,7 @@ class HTTPClient(object):
             "HTTPClient subclasses must implement `request`"
         )
 
-    def request_stream(self, method, url, headers, post_data=None):
+    def request_stream(self, method, url, headers, post_data=None) -> IOBase:
         raise NotImplementedError(
             "HTTPClient subclasses must implement `request_stream`"
         )
@@ -309,7 +310,7 @@ class RequestsClient(HTTPClient):
             method, url, headers, post_data, is_streaming=False
         )
 
-    def request_stream(self, method, url, headers, post_data=None):
+    def request_stream(self, method, url, headers, post_data=None) -> IOBase:
         return self._request_internal(
             method, url, headers, post_data, is_streaming=True
         )
@@ -457,7 +458,7 @@ class UrlFetchClient(HTTPClient):
             method, url, headers, post_data, is_streaming=False
         )
 
-    def request_stream(self, method, url, headers, post_data=None):
+    def request_stream(self, method, url, headers, post_data=None) -> IOBase:
         return self._request_internal(
             method, url, headers, post_data, is_streaming=True
         )
@@ -556,7 +557,7 @@ class PycurlClient(HTTPClient):
             method, url, headers, post_data, is_streaming=False
         )
 
-    def request_stream(self, method, url, headers, post_data=None):
+    def request_stream(self, method, url, headers, post_data=None) -> IOBase:
         return self._request_internal(
             method, url, headers, post_data, is_streaming=True
         )
@@ -691,7 +692,7 @@ class Urllib2Client(HTTPClient):
             method, url, headers, post_data, is_streaming=False
         )
 
-    def request_stream(self, method, url, headers, post_data=None):
+    def request_stream(self, method, url, headers, post_data=None) -> IOBase:
         return self._request_internal(
             method, url, headers, post_data, is_streaming=True
         )

--- a/stripe/http_client.py
+++ b/stripe/http_client.py
@@ -699,7 +699,9 @@ class Urllib2Client(HTTPClient):
         if self._proxy:
             # We have to cast _Proxy to Dict[str, str] because pyright is not smart enough to
             # realize that all the value types are str.
-            proxy = urllibrequest.ProxyHandler(cast(Dict[str, str], self._proxy))
+            proxy = urllibrequest.ProxyHandler(
+                cast(Dict[str, str], self._proxy)
+            )
             self._opener = urllibrequest.build_opener(proxy)
 
     def request(self, method, url, headers, post_data=None):

--- a/stripe/http_client.py
+++ b/stripe/http_client.py
@@ -11,7 +11,7 @@ import stripe
 from stripe import error, util
 from stripe.request_metrics import RequestMetrics
 
-from typing import Any, Optional, Tuple, ClassVar
+from typing import Any, Dict, Optional, Tuple, ClassVar, Union, cast
 from typing_extensions import NoReturn, TypedDict
 
 # - Requests is the preferred HTTP library
@@ -104,14 +104,21 @@ class HTTPClient(object):
     MAX_DELAY = 2
     INITIAL_DELAY = 0.5
     MAX_RETRY_AFTER = 60
-    proxy: _Proxy
+    _proxy: Optional[_Proxy]
+    _verify_ssl_certs: bool
 
-    def __init__(self, verify_ssl_certs=True, proxy=None):
+    def __init__(
+        self,
+        verify_ssl_certs: bool = True,
+        proxy: Optional[Union[str, _Proxy]] = None,
+    ):
         self._verify_ssl_certs = verify_ssl_certs
         if proxy:
             if isinstance(proxy, str):
                 proxy = {"http": proxy, "https": proxy}
-            if not isinstance(proxy, dict):
+            if not isinstance(
+                proxy, dict
+            ):  # pyright: ignore[reportUnnecessaryIsInstance]
                 raise ValueError(
                     "Proxy(ies) must be specified as either a string "
                     "URL or a dict() with string URL under the"
@@ -545,13 +552,11 @@ class PycurlClient(HTTPClient):
         # need to urlparse the proxy, since PyCurl
         # consumes the proxy url in small pieces
         if self._proxy:
-            # now that we have the parser, get the proxy url pieces
-            # Note: self._proxy is actually dict[str, str] because this is the
-            # type on the superclass. Here, we reassign self._proxy into
-            # dict[str, ParseResult]
             proxy_ = self._proxy
             for scheme, value in proxy_.items():
-                self._parsed_proxy[scheme] = urlparse(value)
+                # In general, TypedDict.items() gives you (key: str, value: object)
+                # but we know value to be a string because all the value types on Proxy_ are strings.
+                self._parsed_proxy[scheme] = urlparse(cast(str, value))
 
     def parse_headers(self, data):
         if "\r\n" not in data:
@@ -692,7 +697,9 @@ class Urllib2Client(HTTPClient):
         # prepare and cache proxy tied opener here
         self._opener = None
         if self._proxy:
-            proxy = urllibrequest.ProxyHandler(self._proxy)
+            # We have to cast _Proxy to Dict[str, str] because pyright is not smart enough to
+            # realize that all the value types are str.
+            proxy = urllibrequest.ProxyHandler(cast(Dict[str, str], self._proxy))
             self._opener = urllibrequest.build_opener(proxy)
 
     def request(self, method, url, headers, post_data=None):

--- a/stripe/multipart_data_generator.py
+++ b/stripe/multipart_data_generator.py
@@ -10,7 +10,7 @@ class MultipartDataGenerator(object):
     boundary: int
     chunk_size: int
 
-    def __init__(self, chunk_size=1028):
+    def __init__(self, chunk_size: int = 1028):
         self.data = io.BytesIO()
         self.line_break = "\r\n"
         self.boundary = self._initialize_boundary()

--- a/stripe/multipart_data_generator.py
+++ b/stripe/multipart_data_generator.py
@@ -5,6 +5,11 @@ import stripe
 
 
 class MultipartDataGenerator(object):
+    data: io.BytesIO
+    line_break: str
+    boundary: int
+    chunk_size: int
+
     def __init__(self, chunk_size=1028):
         self.data = io.BytesIO()
         self.line_break = "\r\n"

--- a/stripe/stripe_object.py
+++ b/stripe/stripe_object.py
@@ -45,6 +45,10 @@ class StripeObject(Dict[str, Any]):
     _retrieve_params: Dict[str, Any]
     _previous: Optional[Dict[str, Any]]
 
+    api_key: Optional[str]
+    stripe_version: Optional[str]
+    stripe_account: Optional[str]
+
     def __init__(
         self,
         id=None,

--- a/stripe/stripe_response.py
+++ b/stripe/stripe_response.py
@@ -1,7 +1,7 @@
-from io import BufferedIOBase, IOBase
+from io import IOBase
 import json
 from collections import OrderedDict
-from typing import Any, Dict
+from typing import Dict
 
 
 class StripeResponseBase(object):

--- a/stripe/stripe_response.py
+++ b/stripe/stripe_response.py
@@ -8,7 +8,7 @@ class StripeResponseBase(object):
     code: int
     headers: Dict[str, str]
 
-    def __init__(self, code, headers):
+    def __init__(self, code: int, headers: Dict[str, str]):
         self.code = code
         self.headers = headers
 

--- a/stripe/stripe_response.py
+++ b/stripe/stripe_response.py
@@ -1,8 +1,13 @@
+from io import BufferedIOBase, IOBase
 import json
 from collections import OrderedDict
+from typing import Any, Dict
 
 
 class StripeResponseBase(object):
+    code: int
+    headers: Dict[str, str]
+
     def __init__(self, code, headers):
         self.code = code
         self.headers = headers
@@ -23,6 +28,9 @@ class StripeResponseBase(object):
 
 
 class StripeResponse(StripeResponseBase):
+    body: str
+    data: object
+
     def __init__(self, body, code, headers):
         StripeResponseBase.__init__(self, code, headers)
         self.body = body
@@ -30,6 +38,8 @@ class StripeResponse(StripeResponseBase):
 
 
 class StripeStreamResponse(StripeResponseBase):
+    io: IOBase
+
     def __init__(self, io, code, headers):
         StripeResponseBase.__init__(self, code, headers)
         self.io = io

--- a/stripe/util.py
+++ b/stripe/util.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 
 STRIPE_LOG = os.environ.get("STRIPE_LOG")
 
-logger = logging.getLogger("stripe")
+logger: logging.Logger = logging.getLogger("stripe")
 
 __all__ = [
     "io",
@@ -178,7 +178,7 @@ def convert_to_stripe_object(
 
     if isinstance(resp, stripe.stripe_response.StripeResponse):
         stripe_response = resp
-        resp = stripe_response.data
+        resp = cast(Resp, stripe_response.data)
 
     if isinstance(resp, list):
         return [


### PR DESCRIPTION
After this, `pyright --verifytypes stripe` doesn't report any of the "could be inferred differently by type checkers" messages, e.g. this message goes away:

```
error.py:27:14 - error: Type is missing type annotation and could be inferred differently by type checkers
    Inferred type is "Unknown | None"
```

Moves pyright's "Type completeness score" from 94.2% -> 94.3%