### PR TITLE
Type annotations for OBJECT_NAME

### DIFF
--- a/stripe/api_resources/account.py
+++ b/stripe/api_resources/account.py
@@ -13,6 +13,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, Union, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -48,7 +49,7 @@ class Account(
     below. Learn about the differences [between accounts](https://stripe.com/docs/connect/accounts).
     """
 
-    OBJECT_NAME = "account"
+    OBJECT_NAME: ClassVar[Literal["account"]] = "account"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/account.py
+++ b/stripe/api_resources/account.py
@@ -11,9 +11,8 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, Union, cast
+from typing import ClassVar, Dict, List, Optional, Union, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/account_link.py
+++ b/stripe/api_resources/account_link.py
@@ -2,14 +2,8 @@
 # File generated from our OpenAPI spec
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.request_options import RequestOptions
-from typing import List, Optional, cast
-from typing_extensions import (
-    ClassVar,
-    Literal,
-    NotRequired,
-    Unpack,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, List, Optional, cast
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 
 
 class AccountLink(CreateableAPIResource["AccountLink"]):

--- a/stripe/api_resources/account_link.py
+++ b/stripe/api_resources/account_link.py
@@ -3,7 +3,13 @@
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.request_options import RequestOptions
 from typing import List, Optional, cast
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    ClassVar,
+    Literal,
+    NotRequired,
+    Unpack,
+    TYPE_CHECKING,
+)
 
 
 class AccountLink(CreateableAPIResource["AccountLink"]):
@@ -14,7 +20,7 @@ class AccountLink(CreateableAPIResource["AccountLink"]):
     Related guide: [Connect Onboarding](https://stripe.com/docs/connect/custom/hosted-onboarding)
     """
 
-    OBJECT_NAME = "account_link"
+    OBJECT_NAME: ClassVar[Literal["account_link"]] = "account_link"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/account_session.py
+++ b/stripe/api_resources/account_session.py
@@ -5,6 +5,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -24,7 +25,7 @@ class AccountSession(CreateableAPIResource["AccountSession"]):
     Related guide: [Connect embedded components](https://stripe.com/docs/connect/get-started-connect-embedded-components)
     """
 
-    OBJECT_NAME = "account_session"
+    OBJECT_NAME: ClassVar[Literal["account_session"]] = "account_session"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/account_session.py
+++ b/stripe/api_resources/account_session.py
@@ -3,9 +3,8 @@
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional, cast
+from typing import ClassVar, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/apple_pay_domain.py
+++ b/stripe/api_resources/apple_pay_domain.py
@@ -9,7 +9,13 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from typing import List, Optional, cast
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    ClassVar,
+    Literal,
+    NotRequired,
+    Unpack,
+    TYPE_CHECKING,
+)
 from urllib.parse import quote_plus
 
 
@@ -18,7 +24,7 @@ class ApplePayDomain(
     DeletableAPIResource["ApplePayDomain"],
     ListableAPIResource["ApplePayDomain"],
 ):
-    OBJECT_NAME = "apple_pay_domain"
+    OBJECT_NAME: ClassVar[Literal["apple_pay_domain"]] = "apple_pay_domain"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/apple_pay_domain.py
+++ b/stripe/api_resources/apple_pay_domain.py
@@ -8,14 +8,8 @@ from stripe.api_resources.abstract import (
 )
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
-from typing import List, Optional, cast
-from typing_extensions import (
-    ClassVar,
-    Literal,
-    NotRequired,
-    Unpack,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, List, Optional, cast
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 

--- a/stripe/api_resources/application.py
+++ b/stripe/api_resources/application.py
@@ -2,11 +2,11 @@
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
 from typing import Optional
-from typing_extensions import Literal
+from typing_extensions import ClassVar, Literal
 
 
 class Application(StripeObject):
-    OBJECT_NAME = "application"
+    OBJECT_NAME: ClassVar[Literal["application"]] = "application"
     id: str
     name: Optional[str]
     object: Literal["application"]

--- a/stripe/api_resources/application.py
+++ b/stripe/api_resources/application.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
-from typing import Optional
-from typing_extensions import ClassVar, Literal
+from typing import ClassVar, Optional
+from typing_extensions import Literal
 
 
 class Application(StripeObject):

--- a/stripe/api_resources/application_fee.py
+++ b/stripe/api_resources/application_fee.py
@@ -8,9 +8,8 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
-from typing import Dict, List, Optional
+from typing import ClassVar, Dict, List, Optional
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/application_fee.py
+++ b/stripe/api_resources/application_fee.py
@@ -10,6 +10,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from typing import Dict, List, Optional
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -29,7 +30,7 @@ if TYPE_CHECKING:
 
 @nested_resource_class_methods("refund")
 class ApplicationFee(ListableAPIResource["ApplicationFee"]):
-    OBJECT_NAME = "application_fee"
+    OBJECT_NAME: ClassVar[Literal["application_fee"]] = "application_fee"
     if TYPE_CHECKING:
 
         class ListParams(RequestOptions):

--- a/stripe/api_resources/application_fee_refund.py
+++ b/stripe/api_resources/application_fee_refund.py
@@ -4,7 +4,7 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.application_fee import ApplicationFee
 from stripe.api_resources.expandable_field import ExpandableField
 from typing import Dict, Optional
-from typing_extensions import Literal, TYPE_CHECKING
+from typing_extensions import ClassVar, Literal, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
@@ -20,7 +20,7 @@ class ApplicationFeeRefund(UpdateableAPIResource["ApplicationFeeRefund"]):
     Related guide: [Refunding application fees](https://stripe.com/docs/connect/destination-charges#refunding-app-fee)
     """
 
-    OBJECT_NAME = "fee_refund"
+    OBJECT_NAME: ClassVar[Literal["fee_refund"]] = "fee_refund"
     amount: int
     balance_transaction: Optional[ExpandableField["BalanceTransaction"]]
     created: int

--- a/stripe/api_resources/application_fee_refund.py
+++ b/stripe/api_resources/application_fee_refund.py
@@ -3,8 +3,8 @@
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.application_fee import ApplicationFee
 from stripe.api_resources.expandable_field import ExpandableField
-from typing import Dict, Optional
-from typing_extensions import ClassVar, Literal, TYPE_CHECKING
+from typing import ClassVar, Dict, Optional
+from typing_extensions import Literal, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 if TYPE_CHECKING:

--- a/stripe/api_resources/apps/secret.py
+++ b/stripe/api_resources/apps/secret.py
@@ -7,9 +7,8 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional, cast
+from typing import ClassVar, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/apps/secret.py
+++ b/stripe/api_resources/apps/secret.py
@@ -9,6 +9,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -30,7 +31,7 @@ class Secret(CreateableAPIResource["Secret"], ListableAPIResource["Secret"]):
     Related guide: [Store data between page reloads](https://stripe.com/docs/stripe-apps/store-auth-data-custom-objects)
     """
 
-    OBJECT_NAME = "apps.secret"
+    OBJECT_NAME: ClassVar[Literal["apps.secret"]] = "apps.secret"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/balance.py
+++ b/stripe/api_resources/balance.py
@@ -3,14 +3,8 @@
 from stripe.api_resources.abstract import SingletonAPIResource
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional
-from typing_extensions import (
-    ClassVar,
-    Literal,
-    NotRequired,
-    Unpack,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, List, Optional
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 
 
 class Balance(SingletonAPIResource["Balance"]):

--- a/stripe/api_resources/balance.py
+++ b/stripe/api_resources/balance.py
@@ -4,7 +4,13 @@ from stripe.api_resources.abstract import SingletonAPIResource
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    ClassVar,
+    Literal,
+    NotRequired,
+    Unpack,
+    TYPE_CHECKING,
+)
 
 
 class Balance(SingletonAPIResource["Balance"]):
@@ -22,7 +28,7 @@ class Balance(SingletonAPIResource["Balance"]):
     Related guide: [Understanding Connect account balances](https://stripe.com/docs/connect/account-balances)
     """
 
-    OBJECT_NAME = "balance"
+    OBJECT_NAME: ClassVar[Literal["balance"]] = "balance"
     if TYPE_CHECKING:
 
         class RetrieveParams(RequestOptions):

--- a/stripe/api_resources/balance_transaction.py
+++ b/stripe/api_resources/balance_transaction.py
@@ -5,9 +5,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional, Union
+from typing import ClassVar, List, Optional, Union
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/balance_transaction.py
+++ b/stripe/api_resources/balance_transaction.py
@@ -7,6 +7,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional, Union
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -50,7 +51,9 @@ class BalanceTransaction(ListableAPIResource["BalanceTransaction"]):
     Related guide: [Balance transaction types](https://stripe.com/docs/reports/balance-transaction-types)
     """
 
-    OBJECT_NAME = "balance_transaction"
+    OBJECT_NAME: ClassVar[
+        Literal["balance_transaction"]
+    ] = "balance_transaction"
     if TYPE_CHECKING:
 
         class ListParams(RequestOptions):

--- a/stripe/api_resources/bank_account.py
+++ b/stripe/api_resources/bank_account.py
@@ -12,7 +12,7 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, Union, cast
-from typing_extensions import Literal, Unpack, TYPE_CHECKING
+from typing_extensions import ClassVar, Literal, Unpack, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
@@ -34,7 +34,7 @@ class BankAccount(
     Related guide: [Bank debits and transfers](https://stripe.com/docs/payments/bank-debits-transfers)
     """
 
-    OBJECT_NAME = "bank_account"
+    OBJECT_NAME: ClassVar[Literal["bank_account"]] = "bank_account"
     if TYPE_CHECKING:
 
         class DeleteParams(RequestOptions):

--- a/stripe/api_resources/bank_account.py
+++ b/stripe/api_resources/bank_account.py
@@ -11,8 +11,8 @@ from stripe.api_resources.customer import Customer
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, Union, cast
-from typing_extensions import ClassVar, Literal, Unpack, TYPE_CHECKING
+from typing import ClassVar, Dict, List, Optional, Union, cast
+from typing_extensions import Literal, Unpack, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 if TYPE_CHECKING:

--- a/stripe/api_resources/billing_portal/configuration.py
+++ b/stripe/api_resources/billing_portal/configuration.py
@@ -9,9 +9,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, Union, cast
+from typing import ClassVar, Dict, List, Optional, Union, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/billing_portal/configuration.py
+++ b/stripe/api_resources/billing_portal/configuration.py
@@ -11,6 +11,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, Union, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -32,7 +33,9 @@ class Configuration(
     A portal configuration describes the functionality and behavior of a portal session.
     """
 
-    OBJECT_NAME = "billing_portal.configuration"
+    OBJECT_NAME: ClassVar[
+        Literal["billing_portal.configuration"]
+    ] = "billing_portal.configuration"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/billing_portal/session.py
+++ b/stripe/api_resources/billing_portal/session.py
@@ -6,6 +6,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -35,7 +36,9 @@ class Session(CreateableAPIResource["Session"]):
     Learn more in the [integration guide](https://stripe.com/docs/billing/subscriptions/integrating-customer-portal).
     """
 
-    OBJECT_NAME = "billing_portal.session"
+    OBJECT_NAME: ClassVar[
+        Literal["billing_portal.session"]
+    ] = "billing_portal.session"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/billing_portal/session.py
+++ b/stripe/api_resources/billing_portal/session.py
@@ -4,9 +4,8 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional, cast
+from typing import ClassVar, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/capability.py
+++ b/stripe/api_resources/capability.py
@@ -5,7 +5,7 @@ from stripe.api_resources.account import Account
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
 from typing import Optional
-from typing_extensions import Literal
+from typing_extensions import ClassVar, Literal
 from urllib.parse import quote_plus
 
 
@@ -16,7 +16,7 @@ class Capability(UpdateableAPIResource["Capability"]):
     Related guide: [Account capabilities](https://stripe.com/docs/connect/account-capabilities)
     """
 
-    OBJECT_NAME = "capability"
+    OBJECT_NAME: ClassVar[Literal["capability"]] = "capability"
     account: ExpandableField["Account"]
     future_requirements: Optional[StripeObject]
     id: str

--- a/stripe/api_resources/capability.py
+++ b/stripe/api_resources/capability.py
@@ -4,8 +4,8 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.account import Account
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Optional
-from typing_extensions import ClassVar, Literal
+from typing import ClassVar, Optional
+from typing_extensions import Literal
 from urllib.parse import quote_plus
 
 

--- a/stripe/api_resources/card.py
+++ b/stripe/api_resources/card.py
@@ -9,8 +9,8 @@ from stripe.api_resources.account import Account
 from stripe.api_resources.customer import Customer
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.request_options import RequestOptions
-from typing import Dict, List, Optional, Union, cast
-from typing_extensions import ClassVar, Literal, Unpack, TYPE_CHECKING
+from typing import ClassVar, Dict, List, Optional, Union, cast
+from typing_extensions import Literal, Unpack, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 if TYPE_CHECKING:

--- a/stripe/api_resources/card.py
+++ b/stripe/api_resources/card.py
@@ -10,7 +10,7 @@ from stripe.api_resources.customer import Customer
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.request_options import RequestOptions
 from typing import Dict, List, Optional, Union, cast
-from typing_extensions import Literal, Unpack, TYPE_CHECKING
+from typing_extensions import ClassVar, Literal, Unpack, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
@@ -26,7 +26,7 @@ class Card(DeletableAPIResource["Card"], UpdateableAPIResource["Card"]):
     Related guide: [Card payments with Sources](https://stripe.com/docs/sources/cards)
     """
 
-    OBJECT_NAME = "card"
+    OBJECT_NAME: ClassVar[Literal["card"]] = "card"
     if TYPE_CHECKING:
 
         class DeleteParams(RequestOptions):

--- a/stripe/api_resources/cash_balance.py
+++ b/stripe/api_resources/cash_balance.py
@@ -3,7 +3,7 @@
 from stripe.api_resources.customer import Customer
 from stripe.stripe_object import StripeObject
 from typing import Dict, Optional
-from typing_extensions import Literal
+from typing_extensions import ClassVar, Literal
 from urllib.parse import quote_plus
 
 
@@ -12,7 +12,7 @@ class CashBalance(StripeObject):
     A customer's `Cash balance` represents real funds. Customers can add funds to their cash balance by sending a bank transfer. These funds can be used for payment and can eventually be paid out to your bank account.
     """
 
-    OBJECT_NAME = "cash_balance"
+    OBJECT_NAME: ClassVar[Literal["cash_balance"]] = "cash_balance"
     available: Optional[Dict[str, int]]
     customer: str
     livemode: bool

--- a/stripe/api_resources/cash_balance.py
+++ b/stripe/api_resources/cash_balance.py
@@ -2,8 +2,8 @@
 # File generated from our OpenAPI spec
 from stripe.api_resources.customer import Customer
 from stripe.stripe_object import StripeObject
-from typing import Dict, Optional
-from typing_extensions import ClassVar, Literal
+from typing import ClassVar, Dict, Optional
+from typing_extensions import Literal
 from urllib.parse import quote_plus
 
 

--- a/stripe/api_resources/charge.py
+++ b/stripe/api_resources/charge.py
@@ -12,9 +12,8 @@ from stripe.api_resources.list_object import ListObject
 from stripe.api_resources.search_result_object import SearchResultObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, Union, cast
+from typing import ClassVar, Dict, List, Optional, Union, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/charge.py
+++ b/stripe/api_resources/charge.py
@@ -14,6 +14,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, Union, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -51,7 +52,7 @@ class Charge(
     Some legacy payment flows create Charges directly, which is not recommended for new integrations.
     """
 
-    OBJECT_NAME = "charge"
+    OBJECT_NAME: ClassVar[Literal["charge"]] = "charge"
     if TYPE_CHECKING:
 
         class CaptureParams(RequestOptions):

--- a/stripe/api_resources/checkout/session.py
+++ b/stripe/api_resources/checkout/session.py
@@ -9,9 +9,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/checkout/session.py
+++ b/stripe/api_resources/checkout/session.py
@@ -11,6 +11,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -48,7 +49,7 @@ class Session(
     Related guide: [Checkout quickstart](https://stripe.com/docs/checkout/quickstart)
     """
 
-    OBJECT_NAME = "checkout.session"
+    OBJECT_NAME: ClassVar[Literal["checkout.session"]] = "checkout.session"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/connect_collection_transfer.py
+++ b/stripe/api_resources/connect_collection_transfer.py
@@ -2,7 +2,8 @@
 # File generated from our OpenAPI spec
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing_extensions import ClassVar, Literal, TYPE_CHECKING
+from typing import ClassVar
+from typing_extensions import Literal, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.account import Account

--- a/stripe/api_resources/connect_collection_transfer.py
+++ b/stripe/api_resources/connect_collection_transfer.py
@@ -2,14 +2,16 @@
 # File generated from our OpenAPI spec
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing_extensions import Literal, TYPE_CHECKING
+from typing_extensions import ClassVar, Literal, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.account import Account
 
 
 class ConnectCollectionTransfer(StripeObject):
-    OBJECT_NAME = "connect_collection_transfer"
+    OBJECT_NAME: ClassVar[
+        Literal["connect_collection_transfer"]
+    ] = "connect_collection_transfer"
     amount: int
     currency: str
     destination: ExpandableField["Account"]

--- a/stripe/api_resources/country_spec.py
+++ b/stripe/api_resources/country_spec.py
@@ -4,14 +4,8 @@ from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional
-from typing_extensions import (
-    ClassVar,
-    Literal,
-    NotRequired,
-    Unpack,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, Dict, List, Optional
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 
 
 class CountrySpec(ListableAPIResource["CountrySpec"]):

--- a/stripe/api_resources/country_spec.py
+++ b/stripe/api_resources/country_spec.py
@@ -5,7 +5,13 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    ClassVar,
+    Literal,
+    NotRequired,
+    Unpack,
+    TYPE_CHECKING,
+)
 
 
 class CountrySpec(ListableAPIResource["CountrySpec"]):
@@ -18,7 +24,7 @@ class CountrySpec(ListableAPIResource["CountrySpec"]):
     guide](https://stripe.com/docs/connect/required-verification-information).
     """
 
-    OBJECT_NAME = "country_spec"
+    OBJECT_NAME: ClassVar[Literal["country_spec"]] = "country_spec"
     if TYPE_CHECKING:
 
         class ListParams(RequestOptions):

--- a/stripe/api_resources/coupon.py
+++ b/stripe/api_resources/coupon.py
@@ -12,6 +12,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -33,7 +34,7 @@ class Coupon(
     [checkout sessions](https://stripe.com/docs/api/checkout/sessions), [quotes](https://stripe.com/docs/api#quotes), and more. Coupons do not work with conventional one-off [charges](https://stripe.com/docs/api#create_charge) or [payment intents](https://stripe.com/docs/api/payment_intents).
     """
 
-    OBJECT_NAME = "coupon"
+    OBJECT_NAME: ClassVar[Literal["coupon"]] = "coupon"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/coupon.py
+++ b/stripe/api_resources/coupon.py
@@ -10,9 +10,8 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/credit_note.py
+++ b/stripe/api_resources/credit_note.py
@@ -13,6 +13,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -43,7 +44,7 @@ class CreditNote(
     Related guide: [Credit notes](https://stripe.com/docs/billing/invoices/credit-notes)
     """
 
-    OBJECT_NAME = "credit_note"
+    OBJECT_NAME: ClassVar[Literal["credit_note"]] = "credit_note"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/credit_note.py
+++ b/stripe/api_resources/credit_note.py
@@ -11,9 +11,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/credit_note_line_item.py
+++ b/stripe/api_resources/credit_note_line_item.py
@@ -5,7 +5,13 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    ClassVar,
+    Literal,
+    NotRequired,
+    Unpack,
+    TYPE_CHECKING,
+)
 
 if TYPE_CHECKING:
     from stripe.api_resources.tax_rate import TaxRate
@@ -16,7 +22,9 @@ class CreditNoteLineItem(ListableAPIResource["CreditNoteLineItem"]):
     The credit note line item object
     """
 
-    OBJECT_NAME = "credit_note_line_item"
+    OBJECT_NAME: ClassVar[
+        Literal["credit_note_line_item"]
+    ] = "credit_note_line_item"
     if TYPE_CHECKING:
 
         class ListParams(RequestOptions):

--- a/stripe/api_resources/credit_note_line_item.py
+++ b/stripe/api_resources/credit_note_line_item.py
@@ -4,14 +4,8 @@ from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional
-from typing_extensions import (
-    ClassVar,
-    Literal,
-    NotRequired,
-    Unpack,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, List, Optional
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.tax_rate import TaxRate

--- a/stripe/api_resources/customer.py
+++ b/stripe/api_resources/customer.py
@@ -17,6 +17,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, Union, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     Type,
@@ -55,7 +56,7 @@ class Customer(
     Related guide: [Save a card during payment](https://stripe.com/docs/payments/save-during-payment)
     """
 
-    OBJECT_NAME = "customer"
+    OBJECT_NAME: ClassVar[Literal["customer"]] = "customer"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/customer.py
+++ b/stripe/api_resources/customer.py
@@ -15,9 +15,8 @@ from stripe.api_resources.list_object import ListObject
 from stripe.api_resources.search_result_object import SearchResultObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, Union, cast
+from typing import ClassVar, Dict, List, Optional, Union, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     Type,

--- a/stripe/api_resources/customer_balance_transaction.py
+++ b/stripe/api_resources/customer_balance_transaction.py
@@ -3,8 +3,8 @@
 from stripe.api_resources.abstract import APIResource
 from stripe.api_resources.customer import Customer
 from stripe.api_resources.expandable_field import ExpandableField
-from typing import Dict, Optional
-from typing_extensions import ClassVar, Literal, TYPE_CHECKING
+from typing import ClassVar, Dict, Optional
+from typing_extensions import Literal, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 if TYPE_CHECKING:

--- a/stripe/api_resources/customer_balance_transaction.py
+++ b/stripe/api_resources/customer_balance_transaction.py
@@ -4,7 +4,7 @@ from stripe.api_resources.abstract import APIResource
 from stripe.api_resources.customer import Customer
 from stripe.api_resources.expandable_field import ExpandableField
 from typing import Dict, Optional
-from typing_extensions import Literal, TYPE_CHECKING
+from typing_extensions import ClassVar, Literal, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
@@ -22,7 +22,9 @@ class CustomerBalanceTransaction(APIResource["CustomerBalanceTransaction"]):
     Related guide: [Customer balance](https://stripe.com/docs/billing/customer/balance)
     """
 
-    OBJECT_NAME = "customer_balance_transaction"
+    OBJECT_NAME: ClassVar[
+        Literal["customer_balance_transaction"]
+    ] = "customer_balance_transaction"
     amount: int
     created: int
     credit_note: Optional[ExpandableField["CreditNote"]]

--- a/stripe/api_resources/customer_cash_balance_transaction.py
+++ b/stripe/api_resources/customer_cash_balance_transaction.py
@@ -5,14 +5,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional
-from typing_extensions import (
-    ClassVar,
-    Literal,
-    NotRequired,
-    Unpack,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, List, Optional
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.customer import Customer

--- a/stripe/api_resources/customer_cash_balance_transaction.py
+++ b/stripe/api_resources/customer_cash_balance_transaction.py
@@ -6,7 +6,13 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    ClassVar,
+    Literal,
+    NotRequired,
+    Unpack,
+    TYPE_CHECKING,
+)
 
 if TYPE_CHECKING:
     from stripe.api_resources.customer import Customer
@@ -22,7 +28,9 @@ class CustomerCashBalanceTransaction(
     to payments, and refunds to the customer.
     """
 
-    OBJECT_NAME = "customer_cash_balance_transaction"
+    OBJECT_NAME: ClassVar[
+        Literal["customer_cash_balance_transaction"]
+    ] = "customer_cash_balance_transaction"
     if TYPE_CHECKING:
 
         class ListParams(RequestOptions):

--- a/stripe/api_resources/discount.py
+++ b/stripe/api_resources/discount.py
@@ -2,8 +2,8 @@
 # File generated from our OpenAPI spec
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Optional
-from typing_extensions import ClassVar, Literal, TYPE_CHECKING
+from typing import ClassVar, Optional
+from typing_extensions import Literal, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.coupon import Coupon

--- a/stripe/api_resources/discount.py
+++ b/stripe/api_resources/discount.py
@@ -3,7 +3,7 @@
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
 from typing import Optional
-from typing_extensions import Literal, TYPE_CHECKING
+from typing_extensions import ClassVar, Literal, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.coupon import Coupon
@@ -19,7 +19,7 @@ class Discount(StripeObject):
     Related guide: [Applying discounts to subscriptions](https://stripe.com/docs/billing/subscriptions/discounts)
     """
 
-    OBJECT_NAME = "discount"
+    OBJECT_NAME: ClassVar[Literal["discount"]] = "discount"
     checkout_session: Optional[str]
     coupon: "Coupon"
     customer: Optional[ExpandableField["Customer"]]

--- a/stripe/api_resources/dispute.py
+++ b/stripe/api_resources/dispute.py
@@ -9,9 +9,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/dispute.py
+++ b/stripe/api_resources/dispute.py
@@ -11,6 +11,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -36,7 +37,7 @@ class Dispute(
     Related guide: [Disputes and fraud](https://stripe.com/docs/disputes)
     """
 
-    OBJECT_NAME = "dispute"
+    OBJECT_NAME: ClassVar[Literal["dispute"]] = "dispute"
     if TYPE_CHECKING:
 
         class CloseParams(RequestOptions):

--- a/stripe/api_resources/ephemeral_key.py
+++ b/stripe/api_resources/ephemeral_key.py
@@ -3,14 +3,8 @@
 from stripe import api_requestor, util
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.request_options import RequestOptions
-from typing import List, Optional, cast
-from typing_extensions import (
-    ClassVar,
-    Literal,
-    NotRequired,
-    Unpack,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, List, Optional, cast
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 

--- a/stripe/api_resources/ephemeral_key.py
+++ b/stripe/api_resources/ephemeral_key.py
@@ -4,12 +4,18 @@ from stripe import api_requestor, util
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.request_options import RequestOptions
 from typing import List, Optional, cast
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    ClassVar,
+    Literal,
+    NotRequired,
+    Unpack,
+    TYPE_CHECKING,
+)
 from urllib.parse import quote_plus
 
 
 class EphemeralKey(DeletableAPIResource["EphemeralKey"]):
-    OBJECT_NAME = "ephemeral_key"
+    OBJECT_NAME: ClassVar[Literal["ephemeral_key"]] = "ephemeral_key"
     if TYPE_CHECKING:
 
         class DeleteParams(RequestOptions):

--- a/stripe/api_resources/event.py
+++ b/stripe/api_resources/event.py
@@ -4,9 +4,8 @@ from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/event.py
+++ b/stripe/api_resources/event.py
@@ -6,6 +6,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -48,7 +49,7 @@ class Event(ListableAPIResource["Event"]):
     for 30 days.
     """
 
-    OBJECT_NAME = "event"
+    OBJECT_NAME: ClassVar[Literal["event"]] = "event"
     if TYPE_CHECKING:
 
         class ListParams(RequestOptions):

--- a/stripe/api_resources/exchange_rate.py
+++ b/stripe/api_resources/exchange_rate.py
@@ -3,14 +3,8 @@
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
-from typing import Dict, List, Optional
-from typing_extensions import (
-    ClassVar,
-    Literal,
-    NotRequired,
-    Unpack,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, Dict, List, Optional
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 
 
 class ExchangeRate(ListableAPIResource["ExchangeRate"]):

--- a/stripe/api_resources/exchange_rate.py
+++ b/stripe/api_resources/exchange_rate.py
@@ -4,7 +4,13 @@ from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from typing import Dict, List, Optional
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    ClassVar,
+    Literal,
+    NotRequired,
+    Unpack,
+    TYPE_CHECKING,
+)
 
 
 class ExchangeRate(ListableAPIResource["ExchangeRate"]):
@@ -22,7 +28,7 @@ class ExchangeRate(ListableAPIResource["ExchangeRate"]):
     details.
     """
 
-    OBJECT_NAME = "exchange_rate"
+    OBJECT_NAME: ClassVar[Literal["exchange_rate"]] = "exchange_rate"
     if TYPE_CHECKING:
 
         class ListParams(RequestOptions):

--- a/stripe/api_resources/file.py
+++ b/stripe/api_resources/file.py
@@ -5,9 +5,8 @@ from stripe import api_requestor, util
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/file.py
+++ b/stripe/api_resources/file.py
@@ -7,6 +7,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from typing import List, Optional
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -29,7 +30,7 @@ class File(ListableAPIResource["File"]):
     Related guide: [File upload guide](https://stripe.com/docs/file-upload)
     """
 
-    OBJECT_NAME = "file"
+    OBJECT_NAME: ClassVar[Literal["file"]] = "file"
     if TYPE_CHECKING:
 
         class ListParams(RequestOptions):

--- a/stripe/api_resources/file_link.py
+++ b/stripe/api_resources/file_link.py
@@ -10,6 +10,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -33,7 +34,7 @@ class FileLink(
     retrieve the contents of the file without authentication.
     """
 
-    OBJECT_NAME = "file_link"
+    OBJECT_NAME: ClassVar[Literal["file_link"]] = "file_link"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/file_link.py
+++ b/stripe/api_resources/file_link.py
@@ -8,9 +8,8 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/financial_connections/account.py
+++ b/stripe/api_resources/financial_connections/account.py
@@ -6,9 +6,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/financial_connections/account.py
+++ b/stripe/api_resources/financial_connections/account.py
@@ -8,6 +8,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -26,7 +27,9 @@ class Account(ListableAPIResource["Account"]):
     A Financial Connections Account represents an account that exists outside of Stripe, to which you have been granted some degree of access.
     """
 
-    OBJECT_NAME = "financial_connections.account"
+    OBJECT_NAME: ClassVar[
+        Literal["financial_connections.account"]
+    ] = "financial_connections.account"
     if TYPE_CHECKING:
 
         class DisconnectParams(RequestOptions):

--- a/stripe/api_resources/financial_connections/account_owner.py
+++ b/stripe/api_resources/financial_connections/account_owner.py
@@ -2,7 +2,7 @@
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
 from typing import Optional
-from typing_extensions import Literal
+from typing_extensions import ClassVar, Literal
 
 
 class AccountOwner(StripeObject):
@@ -10,7 +10,9 @@ class AccountOwner(StripeObject):
     Describes an owner of an account.
     """
 
-    OBJECT_NAME = "financial_connections.account_owner"
+    OBJECT_NAME: ClassVar[
+        Literal["financial_connections.account_owner"]
+    ] = "financial_connections.account_owner"
     email: Optional[str]
     id: str
     name: str

--- a/stripe/api_resources/financial_connections/account_owner.py
+++ b/stripe/api_resources/financial_connections/account_owner.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
-from typing import Optional
-from typing_extensions import ClassVar, Literal
+from typing import ClassVar, Optional
+from typing_extensions import Literal
 
 
 class AccountOwner(StripeObject):

--- a/stripe/api_resources/financial_connections/account_ownership.py
+++ b/stripe/api_resources/financial_connections/account_ownership.py
@@ -2,7 +2,8 @@
 # File generated from our OpenAPI spec
 from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing_extensions import ClassVar, Literal, TYPE_CHECKING
+from typing import ClassVar
+from typing_extensions import Literal, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.financial_connections.account_owner import (

--- a/stripe/api_resources/financial_connections/account_ownership.py
+++ b/stripe/api_resources/financial_connections/account_ownership.py
@@ -2,7 +2,7 @@
 # File generated from our OpenAPI spec
 from stripe.api_resources.list_object import ListObject
 from stripe.stripe_object import StripeObject
-from typing_extensions import Literal, TYPE_CHECKING
+from typing_extensions import ClassVar, Literal, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.financial_connections.account_owner import (
@@ -15,7 +15,9 @@ class AccountOwnership(StripeObject):
     Describes a snapshot of the owners of an account at a particular point in time.
     """
 
-    OBJECT_NAME = "financial_connections.account_ownership"
+    OBJECT_NAME: ClassVar[
+        Literal["financial_connections.account_ownership"]
+    ] = "financial_connections.account_ownership"
     created: int
     id: str
     object: Literal["financial_connections.account_ownership"]

--- a/stripe/api_resources/financial_connections/session.py
+++ b/stripe/api_resources/financial_connections/session.py
@@ -4,9 +4,8 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional, cast
+from typing import ClassVar, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/financial_connections/session.py
+++ b/stripe/api_resources/financial_connections/session.py
@@ -6,6 +6,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -22,7 +23,9 @@ class Session(CreateableAPIResource["Session"]):
     A Financial Connections Session is the secure way to programmatically launch the client-side Stripe.js modal that lets your users link their accounts.
     """
 
-    OBJECT_NAME = "financial_connections.session"
+    OBJECT_NAME: ClassVar[
+        Literal["financial_connections.session"]
+    ] = "financial_connections.session"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/funding_instructions.py
+++ b/stripe/api_resources/funding_instructions.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
-from typing_extensions import ClassVar, Literal
+from typing import ClassVar
+from typing_extensions import Literal
 
 
 class FundingInstructions(StripeObject):

--- a/stripe/api_resources/funding_instructions.py
+++ b/stripe/api_resources/funding_instructions.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
-from typing_extensions import Literal
+from typing_extensions import ClassVar, Literal
 
 
 class FundingInstructions(StripeObject):
@@ -13,7 +13,9 @@ class FundingInstructions(StripeObject):
     Related guide: [Customer balance funding instructions](https://stripe.com/docs/payments/customer-balance/funding-instructions)
     """
 
-    OBJECT_NAME = "funding_instructions"
+    OBJECT_NAME: ClassVar[
+        Literal["funding_instructions"]
+    ] = "funding_instructions"
     bank_transfer: StripeObject
     currency: str
     funding_type: Literal["bank_transfer"]

--- a/stripe/api_resources/identity/verification_report.py
+++ b/stripe/api_resources/identity/verification_report.py
@@ -4,9 +4,8 @@ from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/identity/verification_report.py
+++ b/stripe/api_resources/identity/verification_report.py
@@ -6,6 +6,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -29,7 +30,9 @@ class VerificationReport(ListableAPIResource["VerificationReport"]):
     Related guides: [Accessing verification results](https://stripe.com/docs/identity/verification-sessions#results).
     """
 
-    OBJECT_NAME = "identity.verification_report"
+    OBJECT_NAME: ClassVar[
+        Literal["identity.verification_report"]
+    ] = "identity.verification_report"
     if TYPE_CHECKING:
 
         class ListParams(RequestOptions):

--- a/stripe/api_resources/identity/verification_session.py
+++ b/stripe/api_resources/identity/verification_session.py
@@ -10,9 +10,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/identity/verification_session.py
+++ b/stripe/api_resources/identity/verification_session.py
@@ -12,6 +12,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -45,7 +46,9 @@ class VerificationSession(
     Related guide: [The Verification Sessions API](https://stripe.com/docs/identity/verification-sessions)
     """
 
-    OBJECT_NAME = "identity.verification_session"
+    OBJECT_NAME: ClassVar[
+        Literal["identity.verification_session"]
+    ] = "identity.verification_session"
     if TYPE_CHECKING:
 
         class CancelParams(RequestOptions):

--- a/stripe/api_resources/invoice.py
+++ b/stripe/api_resources/invoice.py
@@ -13,9 +13,8 @@ from stripe.api_resources.list_object import ListObject
 from stripe.api_resources.search_result_object import SearchResultObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, Union, cast
+from typing import ClassVar, Dict, List, Optional, Union, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/invoice.py
+++ b/stripe/api_resources/invoice.py
@@ -15,6 +15,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, Union, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -84,7 +85,7 @@ class Invoice(
     Related guide: [Send invoices to customers](https://stripe.com/docs/billing/invoices/sending)
     """
 
-    OBJECT_NAME = "invoice"
+    OBJECT_NAME: ClassVar[Literal["invoice"]] = "invoice"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/invoice_item.py
+++ b/stripe/api_resources/invoice_item.py
@@ -13,6 +13,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -52,7 +53,7 @@ class InvoiceItem(
     Related guides: [Integrate with the Invoicing API](https://stripe.com/docs/invoicing/integration), [Subscription Invoices](https://stripe.com/docs/billing/invoices/subscription#adding-upcoming-invoice-items).
     """
 
-    OBJECT_NAME = "invoiceitem"
+    OBJECT_NAME: ClassVar[Literal["invoiceitem"]] = "invoiceitem"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/invoice_item.py
+++ b/stripe/api_resources/invoice_item.py
@@ -11,9 +11,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/invoice_line_item.py
+++ b/stripe/api_resources/invoice_line_item.py
@@ -3,7 +3,7 @@
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional
-from typing_extensions import Literal, TYPE_CHECKING
+from typing_extensions import ClassVar, Literal, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.discount import Discount
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 
 class InvoiceLineItem(StripeObject):
-    OBJECT_NAME = "line_item"
+    OBJECT_NAME: ClassVar[Literal["line_item"]] = "line_item"
     amount: int
     amount_excluding_tax: Optional[int]
     currency: str

--- a/stripe/api_resources/invoice_line_item.py
+++ b/stripe/api_resources/invoice_line_item.py
@@ -2,8 +2,8 @@
 # File generated from our OpenAPI spec
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional
-from typing_extensions import ClassVar, Literal, TYPE_CHECKING
+from typing import ClassVar, Dict, List, Optional
+from typing_extensions import Literal, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.discount import Discount

--- a/stripe/api_resources/issuing/authorization.py
+++ b/stripe/api_resources/issuing/authorization.py
@@ -10,9 +10,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     Type,

--- a/stripe/api_resources/issuing/authorization.py
+++ b/stripe/api_resources/issuing/authorization.py
@@ -12,6 +12,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     Type,
@@ -41,7 +42,9 @@ class Authorization(
     Related guide: [Issued card authorizations](https://stripe.com/docs/issuing/purchases/authorizations)
     """
 
-    OBJECT_NAME = "issuing.authorization"
+    OBJECT_NAME: ClassVar[
+        Literal["issuing.authorization"]
+    ] = "issuing.authorization"
     if TYPE_CHECKING:
 
         class ApproveParams(RequestOptions):

--- a/stripe/api_resources/issuing/card.py
+++ b/stripe/api_resources/issuing/card.py
@@ -11,9 +11,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     Type,

--- a/stripe/api_resources/issuing/card.py
+++ b/stripe/api_resources/issuing/card.py
@@ -13,6 +13,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     Type,
@@ -35,7 +36,7 @@ class Card(
     You can [create physical or virtual cards](https://stripe.com/docs/issuing/cards) that are issued to cardholders.
     """
 
-    OBJECT_NAME = "issuing.card"
+    OBJECT_NAME: ClassVar[Literal["issuing.card"]] = "issuing.card"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/issuing/cardholder.py
+++ b/stripe/api_resources/issuing/cardholder.py
@@ -10,6 +10,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -30,7 +31,7 @@ class Cardholder(
     Related guide: [How to create a cardholder](https://stripe.com/docs/issuing/cards#create-cardholder)
     """
 
-    OBJECT_NAME = "issuing.cardholder"
+    OBJECT_NAME: ClassVar[Literal["issuing.cardholder"]] = "issuing.cardholder"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/issuing/cardholder.py
+++ b/stripe/api_resources/issuing/cardholder.py
@@ -8,9 +8,8 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/issuing/dispute.py
+++ b/stripe/api_resources/issuing/dispute.py
@@ -10,9 +10,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/issuing/dispute.py
+++ b/stripe/api_resources/issuing/dispute.py
@@ -12,6 +12,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -36,7 +37,7 @@ class Dispute(
     Related guide: [Issuing disputes](https://stripe.com/docs/issuing/purchases/disputes)
     """
 
-    OBJECT_NAME = "issuing.dispute"
+    OBJECT_NAME: ClassVar[Literal["issuing.dispute"]] = "issuing.dispute"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/issuing/token.py
+++ b/stripe/api_resources/issuing/token.py
@@ -8,9 +8,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional, cast
+from typing import ClassVar, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/issuing/token.py
+++ b/stripe/api_resources/issuing/token.py
@@ -10,6 +10,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -27,7 +28,7 @@ class Token(ListableAPIResource["Token"], UpdateableAPIResource["Token"]):
     An issuing token object is created when an issued card is added to a digital wallet. As a [card issuer](https://stripe.com/docs/issuing), you can [view and manage these tokens](https://stripe.com/docs/issuing/controls/token-management) through Stripe.
     """
 
-    OBJECT_NAME = "issuing.token"
+    OBJECT_NAME: ClassVar[Literal["issuing.token"]] = "issuing.token"
     if TYPE_CHECKING:
 
         class ListParams(RequestOptions):

--- a/stripe/api_resources/issuing/transaction.py
+++ b/stripe/api_resources/issuing/transaction.py
@@ -10,9 +10,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     Type,

--- a/stripe/api_resources/issuing/transaction.py
+++ b/stripe/api_resources/issuing/transaction.py
@@ -12,6 +12,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     Type,
@@ -42,7 +43,9 @@ class Transaction(
     Related guide: [Issued card transactions](https://stripe.com/docs/issuing/purchases/transactions)
     """
 
-    OBJECT_NAME = "issuing.transaction"
+    OBJECT_NAME: ClassVar[
+        Literal["issuing.transaction"]
+    ] = "issuing.transaction"
     if TYPE_CHECKING:
 
         class ListParams(RequestOptions):

--- a/stripe/api_resources/line_item.py
+++ b/stripe/api_resources/line_item.py
@@ -2,7 +2,7 @@
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
 from typing import List, Optional
-from typing_extensions import Literal, TYPE_CHECKING
+from typing_extensions import ClassVar, Literal, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.price import Price
@@ -13,7 +13,7 @@ class LineItem(StripeObject):
     A line item.
     """
 
-    OBJECT_NAME = "item"
+    OBJECT_NAME: ClassVar[Literal["item"]] = "item"
     amount_discount: int
     amount_subtotal: int
     amount_tax: int

--- a/stripe/api_resources/line_item.py
+++ b/stripe/api_resources/line_item.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
-from typing import List, Optional
-from typing_extensions import ClassVar, Literal, TYPE_CHECKING
+from typing import ClassVar, List, Optional
+from typing_extensions import Literal, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.price import Price

--- a/stripe/api_resources/login_link.py
+++ b/stripe/api_resources/login_link.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
-from typing_extensions import Literal
+from typing_extensions import ClassVar, Literal
 
 
 class LoginLink(StripeObject):
@@ -9,7 +9,7 @@ class LoginLink(StripeObject):
     Login Links are single-use login link for an Express account to access their Stripe dashboard.
     """
 
-    OBJECT_NAME = "login_link"
+    OBJECT_NAME: ClassVar[Literal["login_link"]] = "login_link"
     created: int
     object: Literal["login_link"]
     url: str

--- a/stripe/api_resources/login_link.py
+++ b/stripe/api_resources/login_link.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
-from typing_extensions import ClassVar, Literal
+from typing import ClassVar
+from typing_extensions import Literal
 
 
 class LoginLink(StripeObject):

--- a/stripe/api_resources/mandate.py
+++ b/stripe/api_resources/mandate.py
@@ -4,14 +4,8 @@ from stripe.api_resources.abstract import APIResource
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional
-from typing_extensions import (
-    ClassVar,
-    Literal,
-    NotRequired,
-    Unpack,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, List, Optional
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.payment_method import PaymentMethod

--- a/stripe/api_resources/mandate.py
+++ b/stripe/api_resources/mandate.py
@@ -5,7 +5,13 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    ClassVar,
+    Literal,
+    NotRequired,
+    Unpack,
+    TYPE_CHECKING,
+)
 
 if TYPE_CHECKING:
     from stripe.api_resources.payment_method import PaymentMethod
@@ -16,7 +22,7 @@ class Mandate(APIResource["Mandate"]):
     A Mandate is a record of the permission that your customer gives you to debit their payment method.
     """
 
-    OBJECT_NAME = "mandate"
+    OBJECT_NAME: ClassVar[Literal["mandate"]] = "mandate"
     if TYPE_CHECKING:
 
         class RetrieveParams(RequestOptions):

--- a/stripe/api_resources/payment_intent.py
+++ b/stripe/api_resources/payment_intent.py
@@ -12,9 +12,8 @@ from stripe.api_resources.list_object import ListObject
 from stripe.api_resources.search_result_object import SearchResultObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, Union, cast
+from typing import ClassVar, Dict, List, Optional, Union, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -411,6 +410,9 @@ class PaymentIntent(
                 "Literal['if_available', 'never']|None"
             ]
             request_incremental_authorization_support: NotRequired["bool|None"]
+            request_incremental_authorization: NotRequired[
+                "Literal['if_available', 'never']|None"
+            ]
 
         class ConfirmParamsPaymentMethodOptionsCard(TypedDict):
             capture_method: NotRequired["Literal['']|Literal['manual']|None"]
@@ -1211,6 +1213,9 @@ class PaymentIntent(
                 "Literal['if_available', 'never']|None"
             ]
             request_incremental_authorization_support: NotRequired["bool|None"]
+            request_incremental_authorization: NotRequired[
+                "Literal['if_available', 'never']|None"
+            ]
 
         class CreateParamsPaymentMethodOptionsCard(TypedDict):
             capture_method: NotRequired["Literal['']|Literal['manual']|None"]
@@ -2009,6 +2014,9 @@ class PaymentIntent(
                 "Literal['if_available', 'never']|None"
             ]
             request_incremental_authorization_support: NotRequired["bool|None"]
+            request_incremental_authorization: NotRequired[
+                "Literal['if_available', 'never']|None"
+            ]
 
         class ModifyParamsPaymentMethodOptionsCard(TypedDict):
             capture_method: NotRequired["Literal['']|Literal['manual']|None"]

--- a/stripe/api_resources/payment_intent.py
+++ b/stripe/api_resources/payment_intent.py
@@ -14,6 +14,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, Union, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -55,7 +56,7 @@ class PaymentIntent(
     Related guide: [Payment Intents API](https://stripe.com/docs/payments/payment-intents)
     """
 
-    OBJECT_NAME = "payment_intent"
+    OBJECT_NAME: ClassVar[Literal["payment_intent"]] = "payment_intent"
     if TYPE_CHECKING:
 
         class ApplyCustomerBalanceParams(RequestOptions):

--- a/stripe/api_resources/payment_link.py
+++ b/stripe/api_resources/payment_link.py
@@ -12,6 +12,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -39,7 +40,7 @@ class PaymentLink(
     Related guide: [Payment Links API](https://stripe.com/docs/payment-links)
     """
 
-    OBJECT_NAME = "payment_link"
+    OBJECT_NAME: ClassVar[Literal["payment_link"]] = "payment_link"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/payment_link.py
+++ b/stripe/api_resources/payment_link.py
@@ -10,9 +10,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/payment_method.py
+++ b/stripe/api_resources/payment_method.py
@@ -12,6 +12,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -37,7 +38,7 @@ class PaymentMethod(
     Related guides: [Payment Methods](https://stripe.com/docs/payments/payment-methods) and [More Payment Scenarios](https://stripe.com/docs/payments/more-payment-scenarios).
     """
 
-    OBJECT_NAME = "payment_method"
+    OBJECT_NAME: ClassVar[Literal["payment_method"]] = "payment_method"
     if TYPE_CHECKING:
 
         class AttachParams(RequestOptions):

--- a/stripe/api_resources/payment_method.py
+++ b/stripe/api_resources/payment_method.py
@@ -10,9 +10,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/payment_method_configuration.py
+++ b/stripe/api_resources/payment_method_configuration.py
@@ -8,9 +8,8 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional, cast
+from typing import ClassVar, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/payment_method_configuration.py
+++ b/stripe/api_resources/payment_method_configuration.py
@@ -10,6 +10,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -41,7 +42,9 @@ class PaymentMethodConfiguration(
     - [Multiple configurations for your Connect accounts](https://stripe.com/docs/connect/multiple-payment-method-configurations)
     """
 
-    OBJECT_NAME = "payment_method_configuration"
+    OBJECT_NAME: ClassVar[
+        Literal["payment_method_configuration"]
+    ] = "payment_method_configuration"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/payment_method_domain.py
+++ b/stripe/api_resources/payment_method_domain.py
@@ -9,14 +9,8 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional, cast
-from typing_extensions import (
-    ClassVar,
-    Literal,
-    NotRequired,
-    Unpack,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, List, Optional, cast
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 

--- a/stripe/api_resources/payment_method_domain.py
+++ b/stripe/api_resources/payment_method_domain.py
@@ -10,7 +10,13 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional, cast
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    ClassVar,
+    Literal,
+    NotRequired,
+    Unpack,
+    TYPE_CHECKING,
+)
 from urllib.parse import quote_plus
 
 
@@ -26,7 +32,9 @@ class PaymentMethodDomain(
     Related guides: [Payment method domains](https://stripe.com/docs/payments/payment-methods/pmd-registration).
     """
 
-    OBJECT_NAME = "payment_method_domain"
+    OBJECT_NAME: ClassVar[
+        Literal["payment_method_domain"]
+    ] = "payment_method_domain"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/payout.py
+++ b/stripe/api_resources/payout.py
@@ -9,9 +9,8 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
-from typing import Dict, List, Optional, Union, cast
+from typing import ClassVar, Dict, List, Optional, Union, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/payout.py
+++ b/stripe/api_resources/payout.py
@@ -11,6 +11,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from typing import Dict, List, Optional, Union, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -41,7 +42,7 @@ class Payout(
     Related guide: [Receiving payouts](https://stripe.com/docs/payouts)
     """
 
-    OBJECT_NAME = "payout"
+    OBJECT_NAME: ClassVar[Literal["payout"]] = "payout"
     if TYPE_CHECKING:
 
         class CancelParams(RequestOptions):

--- a/stripe/api_resources/person.py
+++ b/stripe/api_resources/person.py
@@ -3,8 +3,8 @@
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.account import Account
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional
-from typing_extensions import ClassVar, Literal
+from typing import ClassVar, Dict, List, Optional
+from typing_extensions import Literal
 from urllib.parse import quote_plus
 
 

--- a/stripe/api_resources/person.py
+++ b/stripe/api_resources/person.py
@@ -4,7 +4,7 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.account import Account
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional
-from typing_extensions import Literal
+from typing_extensions import ClassVar, Literal
 from urllib.parse import quote_plus
 
 
@@ -18,7 +18,7 @@ class Person(UpdateableAPIResource["Person"]):
     Related guide: [Handling identity verification with the API](https://stripe.com/docs/connect/handling-api-verification#person-information)
     """
 
-    OBJECT_NAME = "person"
+    OBJECT_NAME: ClassVar[Literal["person"]] = "person"
     account: Optional[str]
     additional_tos_acceptances: Optional[StripeObject]
     address: Optional[StripeObject]

--- a/stripe/api_resources/plan.py
+++ b/stripe/api_resources/plan.py
@@ -11,9 +11,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, Union, cast
+from typing import ClassVar, Dict, List, Optional, Union, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/plan.py
+++ b/stripe/api_resources/plan.py
@@ -13,6 +13,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, Union, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -42,7 +43,7 @@ class Plan(
     Related guides: [Set up a subscription](https://stripe.com/docs/billing/subscriptions/set-up-subscription) and more about [products and prices](https://stripe.com/docs/products-prices/overview).
     """
 
-    OBJECT_NAME = "plan"
+    OBJECT_NAME: ClassVar[Literal["plan"]] = "plan"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/platform_tax_fee.py
+++ b/stripe/api_resources/platform_tax_fee.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
-from typing_extensions import ClassVar, Literal
+from typing import ClassVar
+from typing_extensions import Literal
 
 
 class PlatformTaxFee(StripeObject):

--- a/stripe/api_resources/platform_tax_fee.py
+++ b/stripe/api_resources/platform_tax_fee.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
-from typing_extensions import Literal
+from typing_extensions import ClassVar, Literal
 
 
 class PlatformTaxFee(StripeObject):
-    OBJECT_NAME = "platform_tax_fee"
+    OBJECT_NAME: ClassVar[Literal["platform_tax_fee"]] = "platform_tax_fee"
     account: str
     id: str
     object: Literal["platform_tax_fee"]

--- a/stripe/api_resources/price.py
+++ b/stripe/api_resources/price.py
@@ -13,6 +13,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, Union, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -40,7 +41,7 @@ class Price(
     Related guides: [Set up a subscription](https://stripe.com/docs/billing/subscriptions/set-up-subscription), [create an invoice](https://stripe.com/docs/billing/invoices/create), and more about [products and prices](https://stripe.com/docs/products-prices/overview).
     """
 
-    OBJECT_NAME = "price"
+    OBJECT_NAME: ClassVar[Literal["price"]] = "price"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/price.py
+++ b/stripe/api_resources/price.py
@@ -11,9 +11,8 @@ from stripe.api_resources.list_object import ListObject
 from stripe.api_resources.search_result_object import SearchResultObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, Union, cast
+from typing import ClassVar, Dict, List, Optional, Union, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/product.py
+++ b/stripe/api_resources/product.py
@@ -15,6 +15,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, Union, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -46,7 +47,7 @@ class Product(
     and more about [Products and Prices](https://stripe.com/docs/products-prices/overview)
     """
 
-    OBJECT_NAME = "product"
+    OBJECT_NAME: ClassVar[Literal["product"]] = "product"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/product.py
+++ b/stripe/api_resources/product.py
@@ -13,9 +13,8 @@ from stripe.api_resources.list_object import ListObject
 from stripe.api_resources.search_result_object import SearchResultObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, Union, cast
+from typing import ClassVar, Dict, List, Optional, Union, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/promotion_code.py
+++ b/stripe/api_resources/promotion_code.py
@@ -9,9 +9,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/promotion_code.py
+++ b/stripe/api_resources/promotion_code.py
@@ -11,6 +11,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -34,7 +35,7 @@ class PromotionCode(
     create multiple codes for a single coupon.
     """
 
-    OBJECT_NAME = "promotion_code"
+    OBJECT_NAME: ClassVar[Literal["promotion_code"]] = "promotion_code"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/quote.py
+++ b/stripe/api_resources/quote.py
@@ -11,9 +11,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/quote.py
+++ b/stripe/api_resources/quote.py
@@ -13,6 +13,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -44,7 +45,7 @@ class Quote(
     Once accepted, it will automatically create an invoice, subscription or subscription schedule.
     """
 
-    OBJECT_NAME = "quote"
+    OBJECT_NAME: ClassVar[Literal["quote"]] = "quote"
     if TYPE_CHECKING:
 
         class AcceptParams(RequestOptions):

--- a/stripe/api_resources/radar/early_fraud_warning.py
+++ b/stripe/api_resources/radar/early_fraud_warning.py
@@ -4,14 +4,8 @@ from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
-from typing import List, Optional
-from typing_extensions import (
-    ClassVar,
-    Literal,
-    NotRequired,
-    Unpack,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, List, Optional
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.charge import Charge

--- a/stripe/api_resources/radar/early_fraud_warning.py
+++ b/stripe/api_resources/radar/early_fraud_warning.py
@@ -5,7 +5,13 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from typing import List, Optional
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    ClassVar,
+    Literal,
+    NotRequired,
+    Unpack,
+    TYPE_CHECKING,
+)
 
 if TYPE_CHECKING:
     from stripe.api_resources.charge import Charge
@@ -20,7 +26,9 @@ class EarlyFraudWarning(ListableAPIResource["EarlyFraudWarning"]):
     Related guide: [Early fraud warnings](https://stripe.com/docs/disputes/measuring#early-fraud-warnings)
     """
 
-    OBJECT_NAME = "radar.early_fraud_warning"
+    OBJECT_NAME: ClassVar[
+        Literal["radar.early_fraud_warning"]
+    ] = "radar.early_fraud_warning"
     if TYPE_CHECKING:
 
         class ListParams(RequestOptions):

--- a/stripe/api_resources/radar/value_list.py
+++ b/stripe/api_resources/radar/value_list.py
@@ -11,6 +11,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -35,7 +36,7 @@ class ValueList(
     Related guide: [Default Stripe lists](https://stripe.com/docs/radar/lists#managing-list-items)
     """
 
-    OBJECT_NAME = "radar.value_list"
+    OBJECT_NAME: ClassVar[Literal["radar.value_list"]] = "radar.value_list"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/radar/value_list.py
+++ b/stripe/api_resources/radar/value_list.py
@@ -9,9 +9,8 @@ from stripe.api_resources.abstract import (
 )
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/radar/value_list_item.py
+++ b/stripe/api_resources/radar/value_list_item.py
@@ -8,9 +8,8 @@ from stripe.api_resources.abstract import (
 )
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
-from typing import List, Optional, cast
+from typing import ClassVar, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/radar/value_list_item.py
+++ b/stripe/api_resources/radar/value_list_item.py
@@ -10,6 +10,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from typing import List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -30,7 +31,9 @@ class ValueListItem(
     Related guide: [Managing list items](https://stripe.com/docs/radar/lists#managing-list-items)
     """
 
-    OBJECT_NAME = "radar.value_list_item"
+    OBJECT_NAME: ClassVar[
+        Literal["radar.value_list_item"]
+    ] = "radar.value_list_item"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/refund.py
+++ b/stripe/api_resources/refund.py
@@ -11,15 +11,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
-from typing_extensions import (
-    ClassVar,
-    Literal,
-    NotRequired,
-    Type,
-    Unpack,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, Dict, List, Optional, cast
+from typing_extensions import Literal, NotRequired, Type, Unpack, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 if TYPE_CHECKING:

--- a/stripe/api_resources/refund.py
+++ b/stripe/api_resources/refund.py
@@ -12,7 +12,14 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
-from typing_extensions import Literal, NotRequired, Type, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    ClassVar,
+    Literal,
+    NotRequired,
+    Type,
+    Unpack,
+    TYPE_CHECKING,
+)
 from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
@@ -35,7 +42,7 @@ class Refund(
     Related guide: [Refunds](https://stripe.com/docs/refunds)
     """
 
-    OBJECT_NAME = "refund"
+    OBJECT_NAME: ClassVar[Literal["refund"]] = "refund"
     if TYPE_CHECKING:
 
         class CancelParams(RequestOptions):

--- a/stripe/api_resources/reporting/report_run.py
+++ b/stripe/api_resources/reporting/report_run.py
@@ -9,6 +9,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -35,7 +36,9 @@ class ReportRun(
     data), and will error when queried without a [live-mode API key](https://stripe.com/docs/keys#test-live-modes).
     """
 
-    OBJECT_NAME = "reporting.report_run"
+    OBJECT_NAME: ClassVar[
+        Literal["reporting.report_run"]
+    ] = "reporting.report_run"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/reporting/report_run.py
+++ b/stripe/api_resources/reporting/report_run.py
@@ -7,9 +7,8 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional, cast
+from typing import ClassVar, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/reporting/report_type.py
+++ b/stripe/api_resources/reporting/report_type.py
@@ -4,7 +4,13 @@ from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from typing import List, Optional
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    ClassVar,
+    Literal,
+    NotRequired,
+    Unpack,
+    TYPE_CHECKING,
+)
 
 
 class ReportType(ListableAPIResource["ReportType"]):
@@ -19,7 +25,9 @@ class ReportType(ListableAPIResource["ReportType"]):
     data), and will error when queried without a [live-mode API key](https://stripe.com/docs/keys#test-live-modes).
     """
 
-    OBJECT_NAME = "reporting.report_type"
+    OBJECT_NAME: ClassVar[
+        Literal["reporting.report_type"]
+    ] = "reporting.report_type"
     if TYPE_CHECKING:
 
         class ListParams(RequestOptions):

--- a/stripe/api_resources/reporting/report_type.py
+++ b/stripe/api_resources/reporting/report_type.py
@@ -3,14 +3,8 @@
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
-from typing import List, Optional
-from typing_extensions import (
-    ClassVar,
-    Literal,
-    NotRequired,
-    Unpack,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, List, Optional
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 
 
 class ReportType(ListableAPIResource["ReportType"]):

--- a/stripe/api_resources/reserve_transaction.py
+++ b/stripe/api_resources/reserve_transaction.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
-from typing import Optional
-from typing_extensions import ClassVar, Literal
+from typing import ClassVar, Optional
+from typing_extensions import Literal
 
 
 class ReserveTransaction(StripeObject):

--- a/stripe/api_resources/reserve_transaction.py
+++ b/stripe/api_resources/reserve_transaction.py
@@ -2,11 +2,13 @@
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
 from typing import Optional
-from typing_extensions import Literal
+from typing_extensions import ClassVar, Literal
 
 
 class ReserveTransaction(StripeObject):
-    OBJECT_NAME = "reserve_transaction"
+    OBJECT_NAME: ClassVar[
+        Literal["reserve_transaction"]
+    ] = "reserve_transaction"
     amount: int
     currency: str
     description: Optional[str]

--- a/stripe/api_resources/reversal.py
+++ b/stripe/api_resources/reversal.py
@@ -4,7 +4,7 @@ from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.transfer import Transfer
 from typing import Dict, Optional
-from typing_extensions import Literal, TYPE_CHECKING
+from typing_extensions import ClassVar, Literal, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
@@ -29,7 +29,7 @@ class Reversal(UpdateableAPIResource["Reversal"]):
     Related guide: [Reversing transfers](https://stripe.com/docs/connect/separate-charges-and-transfers#reversing-transfers)
     """
 
-    OBJECT_NAME = "transfer_reversal"
+    OBJECT_NAME: ClassVar[Literal["transfer_reversal"]] = "transfer_reversal"
     amount: int
     balance_transaction: Optional[ExpandableField["BalanceTransaction"]]
     created: int

--- a/stripe/api_resources/reversal.py
+++ b/stripe/api_resources/reversal.py
@@ -3,8 +3,8 @@
 from stripe.api_resources.abstract import UpdateableAPIResource
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.transfer import Transfer
-from typing import Dict, Optional
-from typing_extensions import ClassVar, Literal, TYPE_CHECKING
+from typing import ClassVar, Dict, Optional
+from typing_extensions import Literal, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 if TYPE_CHECKING:

--- a/stripe/api_resources/review.py
+++ b/stripe/api_resources/review.py
@@ -6,9 +6,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/review.py
+++ b/stripe/api_resources/review.py
@@ -8,6 +8,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -28,7 +29,7 @@ class Review(ListableAPIResource["Review"]):
     [here](https://stripe.com/docs/radar/reviews).
     """
 
-    OBJECT_NAME = "review"
+    OBJECT_NAME: ClassVar[Literal["review"]] = "review"
     if TYPE_CHECKING:
 
         class ApproveParams(RequestOptions):

--- a/stripe/api_resources/setup_attempt.py
+++ b/stripe/api_resources/setup_attempt.py
@@ -5,9 +5,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/setup_attempt.py
+++ b/stripe/api_resources/setup_attempt.py
@@ -7,6 +7,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -30,7 +31,7 @@ class SetupAttempt(ListableAPIResource["SetupAttempt"]):
     payment method using a SetupIntent.
     """
 
-    OBJECT_NAME = "setup_attempt"
+    OBJECT_NAME: ClassVar[Literal["setup_attempt"]] = "setup_attempt"
     if TYPE_CHECKING:
 
         class ListParams(RequestOptions):

--- a/stripe/api_resources/setup_intent.py
+++ b/stripe/api_resources/setup_intent.py
@@ -12,6 +12,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -58,7 +59,7 @@ class SetupIntent(
     Related guide: [Setup Intents API](https://stripe.com/docs/payments/setup-intents)
     """
 
-    OBJECT_NAME = "setup_intent"
+    OBJECT_NAME: ClassVar[Literal["setup_intent"]] = "setup_intent"
     if TYPE_CHECKING:
 
         class CancelParams(RequestOptions):

--- a/stripe/api_resources/setup_intent.py
+++ b/stripe/api_resources/setup_intent.py
@@ -10,9 +10,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/shipping_rate.py
+++ b/stripe/api_resources/shipping_rate.py
@@ -9,9 +9,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/shipping_rate.py
+++ b/stripe/api_resources/shipping_rate.py
@@ -11,6 +11,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -33,7 +34,7 @@ class ShippingRate(
     applied to a purchase. For more information, see [Charge for shipping](https://stripe.com/docs/payments/during-payment/charge-shipping).
     """
 
-    OBJECT_NAME = "shipping_rate"
+    OBJECT_NAME: ClassVar[Literal["shipping_rate"]] = "shipping_rate"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/sigma/scheduled_query_run.py
+++ b/stripe/api_resources/sigma/scheduled_query_run.py
@@ -5,7 +5,13 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    ClassVar,
+    Literal,
+    NotRequired,
+    Unpack,
+    TYPE_CHECKING,
+)
 
 if TYPE_CHECKING:
     from stripe.api_resources.file import File
@@ -19,7 +25,9 @@ class ScheduledQueryRun(ListableAPIResource["ScheduledQueryRun"]):
     retrieve the query results.
     """
 
-    OBJECT_NAME = "scheduled_query_run"
+    OBJECT_NAME: ClassVar[
+        Literal["scheduled_query_run"]
+    ] = "scheduled_query_run"
     if TYPE_CHECKING:
 
         class ListParams(RequestOptions):

--- a/stripe/api_resources/sigma/scheduled_query_run.py
+++ b/stripe/api_resources/sigma/scheduled_query_run.py
@@ -4,14 +4,8 @@ from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional
-from typing_extensions import (
-    ClassVar,
-    Literal,
-    NotRequired,
-    Unpack,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, List, Optional
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.file import File

--- a/stripe/api_resources/source.py
+++ b/stripe/api_resources/source.py
@@ -10,6 +10,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -33,7 +34,7 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
     Related guides: [Sources API](https://stripe.com/docs/sources) and [Sources & Customers](https://stripe.com/docs/sources/customers).
     """
 
-    OBJECT_NAME = "source"
+    OBJECT_NAME: ClassVar[Literal["source"]] = "source"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/source.py
+++ b/stripe/api_resources/source.py
@@ -8,9 +8,8 @@ from stripe.api_resources.abstract import (
 )
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/source_mandate_notification.py
+++ b/stripe/api_resources/source_mandate_notification.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
-from typing import Optional
-from typing_extensions import ClassVar, Literal, TYPE_CHECKING
+from typing import ClassVar, Optional
+from typing_extensions import Literal, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.source import Source

--- a/stripe/api_resources/source_mandate_notification.py
+++ b/stripe/api_resources/source_mandate_notification.py
@@ -2,7 +2,7 @@
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
 from typing import Optional
-from typing_extensions import Literal, TYPE_CHECKING
+from typing_extensions import ClassVar, Literal, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.source import Source
@@ -15,7 +15,9 @@ class SourceMandateNotification(StripeObject):
     deliver an email to the customer.
     """
 
-    OBJECT_NAME = "source_mandate_notification"
+    OBJECT_NAME: ClassVar[
+        Literal["source_mandate_notification"]
+    ] = "source_mandate_notification"
     acss_debit: Optional[StripeObject]
     amount: Optional[int]
     bacs_debit: Optional[StripeObject]

--- a/stripe/api_resources/source_transaction.py
+++ b/stripe/api_resources/source_transaction.py
@@ -2,7 +2,7 @@
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
 from typing import Optional
-from typing_extensions import Literal
+from typing_extensions import ClassVar, Literal
 
 
 class SourceTransaction(StripeObject):
@@ -13,7 +13,7 @@ class SourceTransaction(StripeObject):
     transactions.
     """
 
-    OBJECT_NAME = "source_transaction"
+    OBJECT_NAME: ClassVar[Literal["source_transaction"]] = "source_transaction"
     ach_credit_transfer: Optional[StripeObject]
     amount: int
     chf_credit_transfer: Optional[StripeObject]

--- a/stripe/api_resources/source_transaction.py
+++ b/stripe/api_resources/source_transaction.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
-from typing import Optional
-from typing_extensions import ClassVar, Literal
+from typing import ClassVar, Optional
+from typing_extensions import Literal
 
 
 class SourceTransaction(StripeObject):

--- a/stripe/api_resources/subscription.py
+++ b/stripe/api_resources/subscription.py
@@ -13,9 +13,8 @@ from stripe.api_resources.list_object import ListObject
 from stripe.api_resources.search_result_object import SearchResultObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, Union, cast
+from typing import ClassVar, Dict, List, Optional, Union, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/subscription.py
+++ b/stripe/api_resources/subscription.py
@@ -15,6 +15,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, Union, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -53,7 +54,7 @@ class Subscription(
     Related guide: [Creating subscriptions](https://stripe.com/docs/billing/subscriptions/creating)
     """
 
-    OBJECT_NAME = "subscription"
+    OBJECT_NAME: ClassVar[Literal["subscription"]] = "subscription"
     if TYPE_CHECKING:
 
         class CancelParams(RequestOptions):

--- a/stripe/api_resources/subscription_item.py
+++ b/stripe/api_resources/subscription_item.py
@@ -11,9 +11,8 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/subscription_item.py
+++ b/stripe/api_resources/subscription_item.py
@@ -13,6 +13,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -40,7 +41,7 @@ class SubscriptionItem(
     one plan, making it easy to represent complex billing relationships.
     """
 
-    OBJECT_NAME = "subscription_item"
+    OBJECT_NAME: ClassVar[Literal["subscription_item"]] = "subscription_item"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/subscription_schedule.py
+++ b/stripe/api_resources/subscription_schedule.py
@@ -10,9 +10,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/subscription_schedule.py
+++ b/stripe/api_resources/subscription_schedule.py
@@ -12,6 +12,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -38,7 +39,9 @@ class SubscriptionSchedule(
     Related guide: [Subscription schedules](https://stripe.com/docs/billing/subscriptions/subscription-schedules)
     """
 
-    OBJECT_NAME = "subscription_schedule"
+    OBJECT_NAME: ClassVar[
+        Literal["subscription_schedule"]
+    ] = "subscription_schedule"
     if TYPE_CHECKING:
 
         class CancelParams(RequestOptions):

--- a/stripe/api_resources/tax/calculation.py
+++ b/stripe/api_resources/tax/calculation.py
@@ -5,9 +5,8 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional, cast
+from typing import ClassVar, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/tax/calculation.py
+++ b/stripe/api_resources/tax/calculation.py
@@ -7,6 +7,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -27,7 +28,7 @@ class Calculation(CreateableAPIResource["Calculation"]):
     Related guide: [Calculate tax in your custom payment flow](https://stripe.com/docs/tax/custom)
     """
 
-    OBJECT_NAME = "tax.calculation"
+    OBJECT_NAME: ClassVar[Literal["tax.calculation"]] = "tax.calculation"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/tax/calculation_line_item.py
+++ b/stripe/api_resources/tax/calculation_line_item.py
@@ -2,11 +2,13 @@
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
 from typing import List, Optional
-from typing_extensions import Literal
+from typing_extensions import ClassVar, Literal
 
 
 class CalculationLineItem(StripeObject):
-    OBJECT_NAME = "tax.calculation_line_item"
+    OBJECT_NAME: ClassVar[
+        Literal["tax.calculation_line_item"]
+    ] = "tax.calculation_line_item"
     amount: int
     amount_tax: int
     id: str

--- a/stripe/api_resources/tax/calculation_line_item.py
+++ b/stripe/api_resources/tax/calculation_line_item.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
-from typing import List, Optional
-from typing_extensions import ClassVar, Literal
+from typing import ClassVar, List, Optional
+from typing_extensions import Literal
 
 
 class CalculationLineItem(StripeObject):

--- a/stripe/api_resources/tax/settings.py
+++ b/stripe/api_resources/tax/settings.py
@@ -6,9 +6,8 @@ from stripe.api_resources.abstract import (
 )
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional, cast
+from typing import ClassVar, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/tax/settings.py
+++ b/stripe/api_resources/tax/settings.py
@@ -8,6 +8,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -27,7 +28,7 @@ class Settings(
     Related guide: [Using the Settings API](https://stripe.com/docs/tax/settings-api)
     """
 
-    OBJECT_NAME = "tax.settings"
+    OBJECT_NAME: ClassVar[Literal["tax.settings"]] = "tax.settings"
     if TYPE_CHECKING:
 
         class ModifyParams(RequestOptions):

--- a/stripe/api_resources/tax/transaction.py
+++ b/stripe/api_resources/tax/transaction.py
@@ -5,9 +5,8 @@ from stripe.api_resources.abstract import APIResource
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional
+from typing import ClassVar, Dict, List, Optional
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/tax/transaction.py
+++ b/stripe/api_resources/tax/transaction.py
@@ -7,6 +7,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -27,7 +28,7 @@ class Transaction(APIResource["Transaction"]):
     Related guide: [Calculate tax in your custom payment flow](https://stripe.com/docs/tax/custom#tax-transaction)
     """
 
-    OBJECT_NAME = "tax.transaction"
+    OBJECT_NAME: ClassVar[Literal["tax.transaction"]] = "tax.transaction"
     if TYPE_CHECKING:
 
         class CreateFromCalculationParams(RequestOptions):

--- a/stripe/api_resources/tax/transaction_line_item.py
+++ b/stripe/api_resources/tax/transaction_line_item.py
@@ -2,11 +2,13 @@
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
 from typing import Dict, Optional
-from typing_extensions import Literal
+from typing_extensions import ClassVar, Literal
 
 
 class TransactionLineItem(StripeObject):
-    OBJECT_NAME = "tax.transaction_line_item"
+    OBJECT_NAME: ClassVar[
+        Literal["tax.transaction_line_item"]
+    ] = "tax.transaction_line_item"
     amount: int
     amount_tax: int
     id: str

--- a/stripe/api_resources/tax/transaction_line_item.py
+++ b/stripe/api_resources/tax/transaction_line_item.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
-from typing import Dict, Optional
-from typing_extensions import ClassVar, Literal
+from typing import ClassVar, Dict, Optional
+from typing_extensions import Literal
 
 
 class TransactionLineItem(StripeObject):

--- a/stripe/api_resources/tax_code.py
+++ b/stripe/api_resources/tax_code.py
@@ -4,7 +4,13 @@ from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from typing import List, Optional
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    ClassVar,
+    Literal,
+    NotRequired,
+    Unpack,
+    TYPE_CHECKING,
+)
 
 
 class TaxCode(ListableAPIResource["TaxCode"]):
@@ -12,7 +18,7 @@ class TaxCode(ListableAPIResource["TaxCode"]):
     [Tax codes](https://stripe.com/docs/tax/tax-categories) classify goods and services for tax purposes.
     """
 
-    OBJECT_NAME = "tax_code"
+    OBJECT_NAME: ClassVar[Literal["tax_code"]] = "tax_code"
     if TYPE_CHECKING:
 
         class ListParams(RequestOptions):

--- a/stripe/api_resources/tax_code.py
+++ b/stripe/api_resources/tax_code.py
@@ -3,14 +3,8 @@
 from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
-from typing import List, Optional
-from typing_extensions import (
-    ClassVar,
-    Literal,
-    NotRequired,
-    Unpack,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, List, Optional
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 
 
 class TaxCode(ListableAPIResource["TaxCode"]):

--- a/stripe/api_resources/tax_deducted_at_source.py
+++ b/stripe/api_resources/tax_deducted_at_source.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
-from typing_extensions import Literal
+from typing_extensions import ClassVar, Literal
 
 
 class TaxDeductedAtSource(StripeObject):
-    OBJECT_NAME = "tax_deducted_at_source"
+    OBJECT_NAME: ClassVar[
+        Literal["tax_deducted_at_source"]
+    ] = "tax_deducted_at_source"
     id: str
     object: Literal["tax_deducted_at_source"]
     period_end: int

--- a/stripe/api_resources/tax_deducted_at_source.py
+++ b/stripe/api_resources/tax_deducted_at_source.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
-from typing_extensions import ClassVar, Literal
+from typing import ClassVar
+from typing_extensions import Literal
 
 
 class TaxDeductedAtSource(StripeObject):

--- a/stripe/api_resources/tax_id.py
+++ b/stripe/api_resources/tax_id.py
@@ -5,7 +5,7 @@ from stripe.api_resources.customer import Customer
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
 from typing import Optional
-from typing_extensions import Literal
+from typing_extensions import ClassVar, Literal
 from urllib.parse import quote_plus
 
 
@@ -17,7 +17,7 @@ class TaxId(APIResource["TaxId"]):
     Related guides: [Customer tax identification numbers](https://stripe.com/docs/billing/taxes/tax-ids), [Account tax IDs](https://stripe.com/docs/invoicing/connect#account-tax-ids)
     """
 
-    OBJECT_NAME = "tax_id"
+    OBJECT_NAME: ClassVar[Literal["tax_id"]] = "tax_id"
     country: Optional[str]
     created: int
     customer: Optional[ExpandableField["Customer"]]

--- a/stripe/api_resources/tax_id.py
+++ b/stripe/api_resources/tax_id.py
@@ -4,8 +4,8 @@ from stripe.api_resources.abstract import APIResource
 from stripe.api_resources.customer import Customer
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.stripe_object import StripeObject
-from typing import Optional
-from typing_extensions import ClassVar, Literal
+from typing import ClassVar, Optional
+from typing_extensions import Literal
 from urllib.parse import quote_plus
 
 

--- a/stripe/api_resources/tax_rate.py
+++ b/stripe/api_resources/tax_rate.py
@@ -7,9 +7,8 @@ from stripe.api_resources.abstract import (
 )
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/tax_rate.py
+++ b/stripe/api_resources/tax_rate.py
@@ -9,6 +9,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -29,7 +30,7 @@ class TaxRate(
     Related guide: [Tax rates](https://stripe.com/docs/billing/taxes/tax-rates)
     """
 
-    OBJECT_NAME = "tax_rate"
+    OBJECT_NAME: ClassVar[Literal["tax_rate"]] = "tax_rate"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/terminal/configuration.py
+++ b/stripe/api_resources/terminal/configuration.py
@@ -12,6 +12,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -31,7 +32,9 @@ class Configuration(
     A Configurations object represents how features should be configured for terminal readers.
     """
 
-    OBJECT_NAME = "terminal.configuration"
+    OBJECT_NAME: ClassVar[
+        Literal["terminal.configuration"]
+    ] = "terminal.configuration"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/terminal/configuration.py
+++ b/stripe/api_resources/terminal/configuration.py
@@ -10,9 +10,8 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional, cast
+from typing import ClassVar, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/terminal/connection_token.py
+++ b/stripe/api_resources/terminal/connection_token.py
@@ -3,7 +3,13 @@
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.request_options import RequestOptions
 from typing import List, Optional, cast
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    ClassVar,
+    Literal,
+    NotRequired,
+    Unpack,
+    TYPE_CHECKING,
+)
 
 
 class ConnectionToken(CreateableAPIResource["ConnectionToken"]):
@@ -13,7 +19,9 @@ class ConnectionToken(CreateableAPIResource["ConnectionToken"]):
     Related guide: [Fleet management](https://stripe.com/docs/terminal/fleet/locations)
     """
 
-    OBJECT_NAME = "terminal.connection_token"
+    OBJECT_NAME: ClassVar[
+        Literal["terminal.connection_token"]
+    ] = "terminal.connection_token"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/terminal/connection_token.py
+++ b/stripe/api_resources/terminal/connection_token.py
@@ -2,14 +2,8 @@
 # File generated from our OpenAPI spec
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.request_options import RequestOptions
-from typing import List, Optional, cast
-from typing_extensions import (
-    ClassVar,
-    Literal,
-    NotRequired,
-    Unpack,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, List, Optional, cast
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 
 
 class ConnectionToken(CreateableAPIResource["ConnectionToken"]):

--- a/stripe/api_resources/terminal/location.py
+++ b/stripe/api_resources/terminal/location.py
@@ -12,6 +12,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -33,7 +34,7 @@ class Location(
     Related guide: [Fleet management](https://stripe.com/docs/terminal/fleet/locations)
     """
 
-    OBJECT_NAME = "terminal.location"
+    OBJECT_NAME: ClassVar[Literal["terminal.location"]] = "terminal.location"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/terminal/location.py
+++ b/stripe/api_resources/terminal/location.py
@@ -10,9 +10,8 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/terminal/reader.py
+++ b/stripe/api_resources/terminal/reader.py
@@ -14,6 +14,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     Type,
@@ -39,7 +40,7 @@ class Reader(
     Related guide: [Connecting to a reader](https://stripe.com/docs/terminal/payments/connect-reader)
     """
 
-    OBJECT_NAME = "terminal.reader"
+    OBJECT_NAME: ClassVar[Literal["terminal.reader"]] = "terminal.reader"
     if TYPE_CHECKING:
 
         class CancelActionParams(RequestOptions):

--- a/stripe/api_resources/terminal/reader.py
+++ b/stripe/api_resources/terminal/reader.py
@@ -12,9 +12,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     Type,

--- a/stripe/api_resources/test_helpers/test_clock.py
+++ b/stripe/api_resources/test_helpers/test_clock.py
@@ -9,7 +9,13 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from typing import List, Optional, cast
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    ClassVar,
+    Literal,
+    NotRequired,
+    Unpack,
+    TYPE_CHECKING,
+)
 from urllib.parse import quote_plus
 
 
@@ -24,7 +30,9 @@ class TestClock(
     you can either validate the current state of your scenario (and test your assumptions), change the current state of your scenario (and test more complex scenarios), or keep advancing forward in time.
     """
 
-    OBJECT_NAME = "test_helpers.test_clock"
+    OBJECT_NAME: ClassVar[
+        Literal["test_helpers.test_clock"]
+    ] = "test_helpers.test_clock"
     if TYPE_CHECKING:
 
         class AdvanceParams(RequestOptions):

--- a/stripe/api_resources/test_helpers/test_clock.py
+++ b/stripe/api_resources/test_helpers/test_clock.py
@@ -8,14 +8,8 @@ from stripe.api_resources.abstract import (
 )
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
-from typing import List, Optional, cast
-from typing_extensions import (
-    ClassVar,
-    Literal,
-    NotRequired,
-    Unpack,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, List, Optional, cast
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 

--- a/stripe/api_resources/token.py
+++ b/stripe/api_resources/token.py
@@ -2,9 +2,8 @@
 # File generated from our OpenAPI spec
 from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.request_options import RequestOptions
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/token.py
+++ b/stripe/api_resources/token.py
@@ -4,6 +4,7 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.request_options import RequestOptions
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -40,7 +41,7 @@ class Token(CreateableAPIResource["Token"]):
     performs best with integrations that use client-side tokenization.
     """
 
-    OBJECT_NAME = "token"
+    OBJECT_NAME: ClassVar[Literal["token"]] = "token"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/topup.py
+++ b/stripe/api_resources/topup.py
@@ -11,6 +11,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -37,7 +38,7 @@ class Topup(
     Related guide: [Topping up your platform account](https://stripe.com/docs/connect/top-ups)
     """
 
-    OBJECT_NAME = "topup"
+    OBJECT_NAME: ClassVar[Literal["topup"]] = "topup"
     if TYPE_CHECKING:
 
         class CancelParams(RequestOptions):

--- a/stripe/api_resources/topup.py
+++ b/stripe/api_resources/topup.py
@@ -9,9 +9,8 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/transfer.py
+++ b/stripe/api_resources/transfer.py
@@ -10,9 +10,8 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/transfer.py
+++ b/stripe/api_resources/transfer.py
@@ -12,6 +12,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -46,7 +47,7 @@ class Transfer(
     Related guide: [Creating separate charges and transfers](https://stripe.com/docs/connect/separate-charges-and-transfers)
     """
 
-    OBJECT_NAME = "transfer"
+    OBJECT_NAME: ClassVar[Literal["transfer"]] = "transfer"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/treasury/credit_reversal.py
+++ b/stripe/api_resources/treasury/credit_reversal.py
@@ -9,7 +9,13 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    ClassVar,
+    Literal,
+    NotRequired,
+    Unpack,
+    TYPE_CHECKING,
+)
 
 if TYPE_CHECKING:
     from stripe.api_resources.treasury.transaction import Transaction
@@ -23,7 +29,9 @@ class CreditReversal(
     You can reverse some [ReceivedCredits](https://stripe.com/docs/api#received_credits) depending on their network and source flow. Reversing a ReceivedCredit leads to the creation of a new object known as a CreditReversal.
     """
 
-    OBJECT_NAME = "treasury.credit_reversal"
+    OBJECT_NAME: ClassVar[
+        Literal["treasury.credit_reversal"]
+    ] = "treasury.credit_reversal"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/treasury/credit_reversal.py
+++ b/stripe/api_resources/treasury/credit_reversal.py
@@ -8,14 +8,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
-from typing_extensions import (
-    ClassVar,
-    Literal,
-    NotRequired,
-    Unpack,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, Dict, List, Optional, cast
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.treasury.transaction import Transaction

--- a/stripe/api_resources/treasury/debit_reversal.py
+++ b/stripe/api_resources/treasury/debit_reversal.py
@@ -9,7 +9,13 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    ClassVar,
+    Literal,
+    NotRequired,
+    Unpack,
+    TYPE_CHECKING,
+)
 
 if TYPE_CHECKING:
     from stripe.api_resources.treasury.transaction import Transaction
@@ -23,7 +29,9 @@ class DebitReversal(
     You can reverse some [ReceivedDebits](https://stripe.com/docs/api#received_debits) depending on their network and source flow. Reversing a ReceivedDebit leads to the creation of a new object known as a DebitReversal.
     """
 
-    OBJECT_NAME = "treasury.debit_reversal"
+    OBJECT_NAME: ClassVar[
+        Literal["treasury.debit_reversal"]
+    ] = "treasury.debit_reversal"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/treasury/debit_reversal.py
+++ b/stripe/api_resources/treasury/debit_reversal.py
@@ -8,14 +8,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
-from typing_extensions import (
-    ClassVar,
-    Literal,
-    NotRequired,
-    Unpack,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, Dict, List, Optional, cast
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe.api_resources.treasury.transaction import Transaction

--- a/stripe/api_resources/treasury/financial_account.py
+++ b/stripe/api_resources/treasury/financial_account.py
@@ -11,6 +11,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -35,7 +36,9 @@ class FinancialAccount(
     FinancialAccounts serve as the source and destination of Treasury's money movement APIs.
     """
 
-    OBJECT_NAME = "treasury.financial_account"
+    OBJECT_NAME: ClassVar[
+        Literal["treasury.financial_account"]
+    ] = "treasury.financial_account"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):

--- a/stripe/api_resources/treasury/financial_account.py
+++ b/stripe/api_resources/treasury/financial_account.py
@@ -9,9 +9,8 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/treasury/financial_account_features.py
+++ b/stripe/api_resources/treasury/financial_account_features.py
@@ -2,7 +2,7 @@
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
 from typing import Optional
-from typing_extensions import Literal
+from typing_extensions import ClassVar, Literal
 
 
 class FinancialAccountFeatures(StripeObject):
@@ -11,7 +11,9 @@ class FinancialAccountFeatures(StripeObject):
     Stripe or the platform can control Features via the requested field.
     """
 
-    OBJECT_NAME = "treasury.financial_account_features"
+    OBJECT_NAME: ClassVar[
+        Literal["treasury.financial_account_features"]
+    ] = "treasury.financial_account_features"
     card_issuing: Optional[StripeObject]
     deposit_insurance: Optional[StripeObject]
     financial_addresses: Optional[StripeObject]

--- a/stripe/api_resources/treasury/financial_account_features.py
+++ b/stripe/api_resources/treasury/financial_account_features.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
-from typing import Optional
-from typing_extensions import ClassVar, Literal
+from typing import ClassVar, Optional
+from typing_extensions import Literal
 
 
 class FinancialAccountFeatures(StripeObject):

--- a/stripe/api_resources/treasury/inbound_transfer.py
+++ b/stripe/api_resources/treasury/inbound_transfer.py
@@ -10,9 +10,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     Type,

--- a/stripe/api_resources/treasury/inbound_transfer.py
+++ b/stripe/api_resources/treasury/inbound_transfer.py
@@ -12,6 +12,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     Type,
@@ -32,7 +33,9 @@ class InboundTransfer(
     Use [InboundTransfers](https://stripe.com/docs/treasury/moving-money/financial-accounts/into/inbound-transfers) to add funds to your [FinancialAccount](https://stripe.com/docs/api#financial_accounts) via a PaymentMethod that is owned by you. The funds will be transferred via an ACH debit.
     """
 
-    OBJECT_NAME = "treasury.inbound_transfer"
+    OBJECT_NAME: ClassVar[
+        Literal["treasury.inbound_transfer"]
+    ] = "treasury.inbound_transfer"
     if TYPE_CHECKING:
 
         class CancelParams(RequestOptions):

--- a/stripe/api_resources/treasury/outbound_payment.py
+++ b/stripe/api_resources/treasury/outbound_payment.py
@@ -10,9 +10,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     Type,

--- a/stripe/api_resources/treasury/outbound_payment.py
+++ b/stripe/api_resources/treasury/outbound_payment.py
@@ -12,6 +12,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     Type,
@@ -34,7 +35,9 @@ class OutboundPayment(
     Simulate OutboundPayment state changes with the `/v1/test_helpers/treasury/outbound_payments` endpoints. These methods can only be called on test mode objects.
     """
 
-    OBJECT_NAME = "treasury.outbound_payment"
+    OBJECT_NAME: ClassVar[
+        Literal["treasury.outbound_payment"]
+    ] = "treasury.outbound_payment"
     if TYPE_CHECKING:
 
         class CancelParams(RequestOptions):

--- a/stripe/api_resources/treasury/outbound_transfer.py
+++ b/stripe/api_resources/treasury/outbound_transfer.py
@@ -10,9 +10,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     Type,

--- a/stripe/api_resources/treasury/outbound_transfer.py
+++ b/stripe/api_resources/treasury/outbound_transfer.py
@@ -12,6 +12,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import Dict, List, Optional, cast
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     Type,
@@ -34,7 +35,9 @@ class OutboundTransfer(
     Simulate OutboundTransfer state changes with the `/v1/test_helpers/treasury/outbound_transfers` endpoints. These methods can only be called on test mode objects.
     """
 
-    OBJECT_NAME = "treasury.outbound_transfer"
+    OBJECT_NAME: ClassVar[
+        Literal["treasury.outbound_transfer"]
+    ] = "treasury.outbound_transfer"
     if TYPE_CHECKING:
 
         class CancelParams(RequestOptions):

--- a/stripe/api_resources/treasury/received_credit.py
+++ b/stripe/api_resources/treasury/received_credit.py
@@ -8,9 +8,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     Type,

--- a/stripe/api_resources/treasury/received_credit.py
+++ b/stripe/api_resources/treasury/received_credit.py
@@ -10,6 +10,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     Type,
@@ -27,7 +28,9 @@ class ReceivedCredit(ListableAPIResource["ReceivedCredit"]):
     ReceivedCredits represent funds sent to a [FinancialAccount](https://stripe.com/docs/api#financial_accounts) (for example, via ACH or wire). These money movements are not initiated from the FinancialAccount.
     """
 
-    OBJECT_NAME = "treasury.received_credit"
+    OBJECT_NAME: ClassVar[
+        Literal["treasury.received_credit"]
+    ] = "treasury.received_credit"
     if TYPE_CHECKING:
 
         class ListParams(RequestOptions):

--- a/stripe/api_resources/treasury/received_debit.py
+++ b/stripe/api_resources/treasury/received_debit.py
@@ -8,9 +8,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     Type,

--- a/stripe/api_resources/treasury/received_debit.py
+++ b/stripe/api_resources/treasury/received_debit.py
@@ -10,6 +10,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     Type,
@@ -27,7 +28,9 @@ class ReceivedDebit(ListableAPIResource["ReceivedDebit"]):
     ReceivedDebits represent funds pulled from a [FinancialAccount](https://stripe.com/docs/api#financial_accounts). These are not initiated from the FinancialAccount.
     """
 
-    OBJECT_NAME = "treasury.received_debit"
+    OBJECT_NAME: ClassVar[
+        Literal["treasury.received_debit"]
+    ] = "treasury.received_debit"
     if TYPE_CHECKING:
 
         class ListParams(RequestOptions):

--- a/stripe/api_resources/treasury/transaction.py
+++ b/stripe/api_resources/treasury/transaction.py
@@ -4,9 +4,8 @@ from stripe.api_resources.abstract import ListableAPIResource
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/treasury/transaction.py
+++ b/stripe/api_resources/treasury/transaction.py
@@ -6,6 +6,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -24,7 +25,9 @@ class Transaction(ListableAPIResource["Transaction"]):
     Transactions represent changes to a [FinancialAccount's](https://stripe.com/docs/api#financial_accounts) balance.
     """
 
-    OBJECT_NAME = "treasury.transaction"
+    OBJECT_NAME: ClassVar[
+        Literal["treasury.transaction"]
+    ] = "treasury.transaction"
     if TYPE_CHECKING:
 
         class ListParams(RequestOptions):

--- a/stripe/api_resources/treasury/transaction_entry.py
+++ b/stripe/api_resources/treasury/transaction_entry.py
@@ -7,6 +7,7 @@ from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from typing import List, Optional
 from typing_extensions import (
+    ClassVar,
     Literal,
     NotRequired,
     TypedDict,
@@ -23,7 +24,9 @@ class TransactionEntry(ListableAPIResource["TransactionEntry"]):
     TransactionEntries represent individual units of money movements within a single [Transaction](https://stripe.com/docs/api#transactions).
     """
 
-    OBJECT_NAME = "treasury.transaction_entry"
+    OBJECT_NAME: ClassVar[
+        Literal["treasury.transaction_entry"]
+    ] = "treasury.transaction_entry"
     if TYPE_CHECKING:
 
         class ListParams(RequestOptions):

--- a/stripe/api_resources/treasury/transaction_entry.py
+++ b/stripe/api_resources/treasury/transaction_entry.py
@@ -5,9 +5,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from typing_extensions import (
-    ClassVar,
     Literal,
     NotRequired,
     TypedDict,

--- a/stripe/api_resources/usage_record.py
+++ b/stripe/api_resources/usage_record.py
@@ -2,7 +2,8 @@
 # File generated from our OpenAPI spec
 from stripe import api_requestor, util
 from stripe.api_resources.abstract import APIResource
-from typing_extensions import ClassVar, Literal
+from typing import ClassVar
+from typing_extensions import Literal
 
 
 class UsageRecord(APIResource["UsageRecord"]):

--- a/stripe/api_resources/usage_record.py
+++ b/stripe/api_resources/usage_record.py
@@ -2,7 +2,7 @@
 # File generated from our OpenAPI spec
 from stripe import api_requestor, util
 from stripe.api_resources.abstract import APIResource
-from typing_extensions import Literal
+from typing_extensions import ClassVar, Literal
 
 
 class UsageRecord(APIResource["UsageRecord"]):
@@ -13,7 +13,7 @@ class UsageRecord(APIResource["UsageRecord"]):
     Related guide: [Metered billing](https://stripe.com/docs/billing/subscriptions/metered-billing)
     """
 
-    OBJECT_NAME = "usage_record"
+    OBJECT_NAME: ClassVar[Literal["usage_record"]] = "usage_record"
     id: str
     livemode: bool
     object: Literal["usage_record"]

--- a/stripe/api_resources/usage_record_summary.py
+++ b/stripe/api_resources/usage_record_summary.py
@@ -2,11 +2,13 @@
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
 from typing import Optional
-from typing_extensions import Literal
+from typing_extensions import ClassVar, Literal
 
 
 class UsageRecordSummary(StripeObject):
-    OBJECT_NAME = "usage_record_summary"
+    OBJECT_NAME: ClassVar[
+        Literal["usage_record_summary"]
+    ] = "usage_record_summary"
     id: str
     invoice: Optional[str]
     livemode: bool

--- a/stripe/api_resources/usage_record_summary.py
+++ b/stripe/api_resources/usage_record_summary.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 from stripe.stripe_object import StripeObject
-from typing import Optional
-from typing_extensions import ClassVar, Literal
+from typing import ClassVar, Optional
+from typing_extensions import Literal
 
 
 class UsageRecordSummary(StripeObject):

--- a/stripe/api_resources/webhook_endpoint.py
+++ b/stripe/api_resources/webhook_endpoint.py
@@ -9,14 +9,8 @@ from stripe.api_resources.abstract import (
 )
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
-from typing import Dict, List, Optional, cast
-from typing_extensions import (
-    ClassVar,
-    Literal,
-    NotRequired,
-    Unpack,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, Dict, List, Optional, cast
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 

--- a/stripe/api_resources/webhook_endpoint.py
+++ b/stripe/api_resources/webhook_endpoint.py
@@ -10,7 +10,13 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from typing import Dict, List, Optional, cast
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    ClassVar,
+    Literal,
+    NotRequired,
+    Unpack,
+    TYPE_CHECKING,
+)
 from urllib.parse import quote_plus
 
 
@@ -30,7 +36,7 @@ class WebhookEndpoint(
     Related guide: [Setting up webhooks](https://stripe.com/docs/webhooks/configure)
     """
 
-    OBJECT_NAME = "webhook_endpoint"
+    OBJECT_NAME: ClassVar[Literal["webhook_endpoint"]] = "webhook_endpoint"
     if TYPE_CHECKING:
 
         class CreateParams(RequestOptions):


### PR DESCRIPTION
Fixes

```
stripe.api_resources.account.Account.OBJECT_NAME
stripe/api_resources/account.py:51:5 - error: Ambiguous base class override
    Type declared in base class is "str"
    Type inferred in child class is "Literal['account']"
```

Makes the pyright --verifytypes report go from

```
Symbols exported by "stripe": ...
  With ambiguous type: 95
```
to
```
Symbols exported by "stripe": ...
  With ambiguous type: 0
```

And Type completeness score: 96.1% -> 96.5%