### PR TITLE
Beta: export raw request, deserialize, and preview in a better way

### DIFF
--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -47,6 +47,8 @@ from stripe.webhook import Webhook, WebhookSignature  # noqa
 
 from stripe.raw_request import _raw_request  # noqa
 
+# The type checker won't re-export imported symbols unless they are redundant,
+# so we need to re-export them manually.
 raw_request = _raw_request
 
 from stripe.raw_request import _deserialize  # noqa

--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -45,11 +45,16 @@ from stripe.oauth import OAuth  # noqa
 # Webhooks
 from stripe.webhook import Webhook, WebhookSignature  # noqa
 
-from stripe.raw_request import _raw_request as raw_request  # noqa
+from stripe.raw_request import _raw_request  # noqa
 
-from stripe.raw_request import _deserialize as deserialize  # noqa
+raw_request = _raw_request
 
-from stripe.preview import preview  # noqa
+from stripe.raw_request import _deserialize  # noqa
+
+deserialize = _deserialize
+
+
+from stripe.preview import preview as preview  # noqa
 
 from . import stripe_response  # noqa
 from . import stripe_object  # noqa


### PR DESCRIPTION
These symbols were not considered to be exported by the type checker

https://github.com/microsoft/pyright/blob/cecb3e1e0cfd6dd504655ba678332f3399e218dc/docs/typed-libraries.md#library-interface

Imported symbols are not considered exported unless they are redundant (or use that odd `from . import ...` syntax). So you want to export an imported symbol under a different name, you have to explicitly define the new name outside of the import statement.