### PR TITLE
Add @util.deprecated decorator

### DIFF
--- a/flake8_stripe/flake8_stripe.py
+++ b/flake8_stripe/flake8_stripe.py
@@ -50,6 +50,7 @@ class TypingImportsChecker:
         "Iterator",
         "Mapping",
         "Set",
+        "Callable",
     ]
 
     def __init__(self, tree: ast.AST):

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,13 @@ setup(
     license="MIT",
     keywords="stripe api payments",
     packages=find_packages(exclude=["tests", "tests.*"]),
-    package_data={"stripe": ["data/ca-certificates.crt"]},
+    package_data={"stripe": ["data/ca-certificates.crt", "py.typed"]},
     zip_safe=False,
     install_requires=[
         'typing_extensions <= 4.2.0, > 3.7.2; python_version < "3.7"',
-        'typing_extensions >= 4.0.0; python_version >= "3.7"',
+        # The best typing support comes from 4.5.0+ but we can support down to
+        # 4.0.0 without throwing exceptions.
+        'typing_extensions >= 4.5.0; python_version >= "3.7"',
         'requests >= 2.20; python_version >= "3.0"',
     ],
     python_requires=">=3.6",

--- a/setup.py
+++ b/setup.py
@@ -28,12 +28,12 @@ setup(
     license="MIT",
     keywords="stripe api payments",
     packages=find_packages(exclude=["tests", "tests.*"]),
-    package_data={"stripe": ["data/ca-certificates.crt", "py.typed"]},
+    package_data={"stripe": ["data/ca-certificates.crt"]},
     zip_safe=False,
     install_requires=[
         'typing_extensions <= 4.2.0, > 3.7.2; python_version < "3.7"',
         # The best typing support comes from 4.5.0+ but we can support down to
-        # 4.0.0 without throwing exceptions.
+        # 3.7.2 without throwing exceptions.
         'typing_extensions >= 4.5.0; python_version >= "3.7"',
         'requests >= 2.20; python_version >= "3.0"',
     ],

--- a/stripe/api_resources/abstract/updateable_api_resource.py
+++ b/stripe/api_resources/abstract/updateable_api_resource.py
@@ -13,12 +13,10 @@ class UpdateableAPIResource(APIResource[T]):
         url = "%s/%s" % (cls.class_url(), quote_plus(sid))
         return cast(T, cls._static_request("post", url, params=params))
 
+    @util.deprecated(
+        "The `save` method is deprecated and will be removed in a future major version of the library. Use the class method `modify` on the resource instead."
+    )
     def save(self, idempotency_key=None):
-        """
-        The `save` method is deprecated and will be removed in a future major version of the library.
-
-        Use the class method `modify` on the resource instead.
-        """
         updated_params = self.serialize(None)
         if updated_params:
             self._request_and_refresh(


### PR DESCRIPTION
## Background
The current approach for deprecating methods in stripe-python is "put a note in the docstring". See [this conversation from last year (to the day)](https://github.com/stripe/stripe-python/pull/887/commits/bdab77dcf008cde0eac060b5b28e903d3c62588c#r1003792936).

This has some drawbacks
  - Deprecations do not emit warnings so they cannot be "captured" (e.g. [by pytest](https://docs.pytest.org/en/7.4.x/how-to/capture-warnings.html#how-to-capture-warnings)).
  - Are not captured by type checkers, either.
  - No special IDE support. IDEs won't do the cute little "crossing out" of the deprecated method, or display a notice.

There is [PEP 702](https://peps.python.org/pep-0702/), which isn't accepted yet, but is clearly [en route to acceptance](https://discuss.python.org/t/pep-702-marking-deprecations-using-the-type-system/23036) where Python will gain a standard `@deprecated` decorator, either in `typing` or in `warnings`. For now, a precursor is available `typing_extensions.deprecated`. This precursor
  - Emits a warning, so e.g. `pytest` will capture it by default.
  - Is specially detected by `pyright`, so VSCode with Pylance will cross it out, and running pyright in CI (with the reportDeprecated rule) will report. [No Pycharm yet](https://youtrack.jetbrains.com/issue/PY-61651/Deprecation-highlighting-with-PEP-702-deprecated-decorator).

Unfortunately, `@deprecated` was introduced in typing_extensions 4.5.0 which isn't compatible with python 3.6. 

## Summary
This PR introduces @util.deprecated. If  `typing_extensions.deprecated` is available, this is simply an alias to it. If not, it falls back to the implementation of `typing_extensions.deprecated` that I have pasted into the library. 

At runtime, this will behave exactly the same as `typing_extensions.deprecated`, i.e. it will emit a DeprecationWarning warning. At type checking time it will specially recognized by Pyright and recieve special IDE support iff `typing_extensions.deprecated` is available.

This PR changes `save` to use `@util.deprecated`.
<img width="736" alt="image" src="https://github.com/stripe/stripe-python/assets/52928443/52bb542a-13ff-4b62-8dc1-c78b89f0ee8e">


## Alternatives

1. We could continue with "mention in the docstring". I don't personally feel this is loud enough, you don't often review the docstrings of library code you aren't actively changing. Much of the purpose of deprecation is to prevent new usage but it's also  important to provide advance notice to existing users that they should change their implementations.

2. We could just `warnings.warn(..., DeprecationWarning)` inside the implementation of each deprecated function. This actually does get statically detected by Pycharm, but not by pyright. My view is that this isn't as future-proof as `typing_extensions.deprecated`. If PEP 702 is ratified, it's more likely that Pycharm, Mypy and the rest will add support for the PEP 702 than it is for IDEs beyond pycharm to start snooping inside implementations for `warnings.warn(...)`

3. There's [this PyPi package](https://pypi.org/project/Deprecated/) but as far as I can tell, it gives you no IDE deprecation detection, and would involve adding a dependency to `stripe-python` which I prefer to avoid if there's an alternative.

### Aside
One concern [last year](https://github.com/stripe/stripe-python/pull/887/commits/bdab77dcf008cde0eac060b5b28e903d3c62588c#r1003792936) was that warnings would pollute stderr at runtime. I am not concerned by this because the [default warning filter](https://docs.python.org/3/library/warnings.html#default-warning-filter) is to squelch deprecation warnings outside of `__main__`. That is, if your entire app is one big `main.py` file and you call a deprecated stripe method in there, you will see a warning in stderr, but if (as I expect the vast majority do) you have broken up your app into modules and do not invoke stripe directly from the entry point, you will see no warning.
