### PR TITLE
Types: represent big decimals as `str` & typecheck test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,10 @@ exclude = '''
 '''
 [tool.pyright]
 executionEnvironments=[
-  {"root" = "stripe"}
+  {"root" = "stripe"},
+  {"root" = "tests"}
 ]
-include=["stripe"]
+include=["stripe", "tests/test_generated_examples.py"]
 exclude=["build", "**/__pycache__"]
 reportMissingTypeArgument=true
 reportUnnecessaryCast=true

--- a/stripe/api_resources/checkout/session.py
+++ b/stripe/api_resources/checkout/session.py
@@ -812,7 +812,7 @@ class Session(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsLineItemPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]

--- a/stripe/api_resources/credit_note.py
+++ b/stripe/api_resources/credit_note.py
@@ -76,7 +76,7 @@ class CreditNote(
             tax_rates: NotRequired["Literal['']|List[str]|None"]
             type: Literal["custom_line_item", "invoice_line_item"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class ListParams(RequestOptions):
             customer: NotRequired["str|None"]
@@ -121,7 +121,7 @@ class CreditNote(
             tax_rates: NotRequired["Literal['']|List[str]|None"]
             type: Literal["custom_line_item", "invoice_line_item"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class PreviewLinesParams(RequestOptions):
             amount: NotRequired["int|None"]
@@ -156,7 +156,7 @@ class CreditNote(
             tax_rates: NotRequired["Literal['']|List[str]|None"]
             type: Literal["custom_line_item", "invoice_line_item"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class RetrieveParams(RequestOptions):
             expand: NotRequired["List[str]|None"]

--- a/stripe/api_resources/credit_note_line_item.py
+++ b/stripe/api_resources/credit_note_line_item.py
@@ -41,8 +41,8 @@ class CreditNoteLineItem(ListableAPIResource["CreditNoteLineItem"]):
     tax_rates: List["TaxRate"]
     type: Literal["custom_line_item", "invoice_line_item"]
     unit_amount: Optional[int]
-    unit_amount_decimal: Optional[float]
-    unit_amount_excluding_tax: Optional[float]
+    unit_amount_decimal: Optional[str]
+    unit_amount_excluding_tax: Optional[str]
 
     @classmethod
     def list(

--- a/stripe/api_resources/invoice.py
+++ b/stripe/api_resources/invoice.py
@@ -737,7 +737,7 @@ class Invoice(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class UpcomingParamsSubscriptionItemPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]
@@ -768,7 +768,7 @@ class Invoice(
             tax_code: NotRequired["Literal['']|str|None"]
             tax_rates: NotRequired["Literal['']|List[str]|None"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class UpcomingParamsInvoiceItemPriceData(TypedDict):
             currency: str
@@ -777,7 +777,7 @@ class Invoice(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class UpcomingParamsInvoiceItemPeriod(TypedDict):
             end: int
@@ -971,7 +971,7 @@ class Invoice(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class UpcomingLinesParamsSubscriptionItemPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]
@@ -1004,7 +1004,7 @@ class Invoice(
             tax_code: NotRequired["Literal['']|str|None"]
             tax_rates: NotRequired["Literal['']|List[str]|None"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class UpcomingLinesParamsInvoiceItemPriceData(TypedDict):
             currency: str
@@ -1013,7 +1013,7 @@ class Invoice(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class UpcomingLinesParamsInvoiceItemPeriod(TypedDict):
             end: int

--- a/stripe/api_resources/invoice_item.py
+++ b/stripe/api_resources/invoice_item.py
@@ -78,7 +78,7 @@ class InvoiceItem(
             tax_code: NotRequired["Literal['']|str|None"]
             tax_rates: NotRequired["List[str]|None"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsPriceData(TypedDict):
             currency: str
@@ -87,7 +87,7 @@ class InvoiceItem(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsPeriod(TypedDict):
             end: int
@@ -135,7 +135,7 @@ class InvoiceItem(
             tax_code: NotRequired["Literal['']|str|None"]
             tax_rates: NotRequired["Literal['']|List[str]|None"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class ModifyParamsPriceData(TypedDict):
             currency: str
@@ -144,7 +144,7 @@ class InvoiceItem(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class ModifyParamsPeriod(TypedDict):
             end: int
@@ -179,7 +179,7 @@ class InvoiceItem(
     tax_rates: Optional[List["TaxRate"]]
     test_clock: Optional[ExpandableField["TestClock"]]
     unit_amount: Optional[int]
-    unit_amount_decimal: Optional[float]
+    unit_amount_decimal: Optional[str]
     deleted: Optional[Literal[True]]
 
     @classmethod

--- a/stripe/api_resources/invoice_line_item.py
+++ b/stripe/api_resources/invoice_line_item.py
@@ -40,4 +40,4 @@ class InvoiceLineItem(StripeObject):
     tax_amounts: Optional[List[StripeObject]]
     tax_rates: Optional[List["TaxRate"]]
     type: Literal["invoiceitem", "subscription"]
-    unit_amount_excluding_tax: Optional[float]
+    unit_amount_excluding_tax: Optional[str]

--- a/stripe/api_resources/issuing/authorization.py
+++ b/stripe/api_resources/issuing/authorization.py
@@ -105,7 +105,7 @@ class Authorization(
 
         class CaptureParamsPurchaseDetailsReceipt(TypedDict):
             description: NotRequired["str|None"]
-            quantity: NotRequired["float|None"]
+            quantity: NotRequired["str|None"]
             total: NotRequired["int|None"]
             unit_cost: NotRequired["int|None"]
 
@@ -118,8 +118,8 @@ class Authorization(
                 "Literal['diesel', 'other', 'unleaded_plus', 'unleaded_regular', 'unleaded_super']|None"
             ]
             unit: NotRequired["Literal['liter', 'us_gallon']|None"]
-            unit_cost_decimal: NotRequired["float|None"]
-            volume_decimal: NotRequired["float|None"]
+            unit_cost_decimal: NotRequired["str|None"]
+            volume_decimal: NotRequired["str|None"]
 
         class CaptureParamsPurchaseDetailsFlight(TypedDict):
             departure_at: NotRequired["int|None"]

--- a/stripe/api_resources/issuing/transaction.py
+++ b/stripe/api_resources/issuing/transaction.py
@@ -99,7 +99,7 @@ class Transaction(
 
         class CreateForceCaptureParamsPurchaseDetailsReceipt(TypedDict):
             description: NotRequired["str|None"]
-            quantity: NotRequired["float|None"]
+            quantity: NotRequired["str|None"]
             total: NotRequired["int|None"]
             unit_cost: NotRequired["int|None"]
 
@@ -112,8 +112,8 @@ class Transaction(
                 "Literal['diesel', 'other', 'unleaded_plus', 'unleaded_regular', 'unleaded_super']|None"
             ]
             unit: NotRequired["Literal['liter', 'us_gallon']|None"]
-            unit_cost_decimal: NotRequired["float|None"]
-            volume_decimal: NotRequired["float|None"]
+            unit_cost_decimal: NotRequired["str|None"]
+            volume_decimal: NotRequired["str|None"]
 
         class CreateForceCaptureParamsPurchaseDetailsFlight(TypedDict):
             departure_at: NotRequired["int|None"]
@@ -173,7 +173,7 @@ class Transaction(
 
         class CreateUnlinkedRefundParamsPurchaseDetailsReceipt(TypedDict):
             description: NotRequired["str|None"]
-            quantity: NotRequired["float|None"]
+            quantity: NotRequired["str|None"]
             total: NotRequired["int|None"]
             unit_cost: NotRequired["int|None"]
 
@@ -186,8 +186,8 @@ class Transaction(
                 "Literal['diesel', 'other', 'unleaded_plus', 'unleaded_regular', 'unleaded_super']|None"
             ]
             unit: NotRequired["Literal['liter', 'us_gallon']|None"]
-            unit_cost_decimal: NotRequired["float|None"]
-            volume_decimal: NotRequired["float|None"]
+            unit_cost_decimal: NotRequired["str|None"]
+            volume_decimal: NotRequired["str|None"]
 
         class CreateUnlinkedRefundParamsPurchaseDetailsFlight(TypedDict):
             departure_at: NotRequired["int|None"]

--- a/stripe/api_resources/plan.py
+++ b/stripe/api_resources/plan.py
@@ -51,7 +51,7 @@ class Plan(
                 "Literal['last_during_period', 'last_ever', 'max', 'sum']|None"
             ]
             amount: NotRequired["int|None"]
-            amount_decimal: NotRequired["float|None"]
+            amount_decimal: NotRequired["str|None"]
             billing_scheme: NotRequired["Literal['per_unit', 'tiered']|None"]
             currency: str
             expand: NotRequired["List[str]|None"]
@@ -75,9 +75,9 @@ class Plan(
 
         class CreateParamsTier(TypedDict):
             flat_amount: NotRequired["int|None"]
-            flat_amount_decimal: NotRequired["float|None"]
+            flat_amount_decimal: NotRequired["str|None"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
             up_to: Union[Literal["inf"], int]
 
         class CreateParamsProduct(TypedDict):
@@ -123,7 +123,7 @@ class Plan(
         Literal["last_during_period", "last_ever", "max", "sum"]
     ]
     amount: Optional[int]
-    amount_decimal: Optional[float]
+    amount_decimal: Optional[str]
     billing_scheme: Literal["per_unit", "tiered"]
     created: int
     currency: str

--- a/stripe/api_resources/price.py
+++ b/stripe/api_resources/price.py
@@ -70,7 +70,7 @@ class Price(
                 "Price.CreateParamsTransformQuantity|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsTransformQuantity(TypedDict):
             divide_by: int
@@ -78,9 +78,9 @@ class Price(
 
         class CreateParamsTier(TypedDict):
             flat_amount: NotRequired["int|None"]
-            flat_amount_decimal: NotRequired["float|None"]
+            flat_amount_decimal: NotRequired["str|None"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
             up_to: Union[Literal["inf"], int]
 
         class CreateParamsRecurring(TypedDict):
@@ -118,13 +118,13 @@ class Price(
                 "List[Price.CreateParamsCurrencyOptionsTier]|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsCurrencyOptionsTier(TypedDict):
             flat_amount: NotRequired["int|None"]
-            flat_amount_decimal: NotRequired["float|None"]
+            flat_amount_decimal: NotRequired["str|None"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
             up_to: Union[Literal["inf"], int]
 
         class CreateParamsCurrencyOptionsCustomUnitAmount(TypedDict):
@@ -183,13 +183,13 @@ class Price(
                 "List[Price.ModifyParamsCurrencyOptionsTier]|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class ModifyParamsCurrencyOptionsTier(TypedDict):
             flat_amount: NotRequired["int|None"]
-            flat_amount_decimal: NotRequired["float|None"]
+            flat_amount_decimal: NotRequired["str|None"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
             up_to: Union[Literal["inf"], int]
 
         class ModifyParamsCurrencyOptionsCustomUnitAmount(TypedDict):
@@ -227,7 +227,7 @@ class Price(
     transform_quantity: Optional[StripeObject]
     type: Literal["one_time", "recurring"]
     unit_amount: Optional[int]
-    unit_amount_decimal: Optional[float]
+    unit_amount_decimal: Optional[str]
     deleted: Optional[Literal[True]]
 
     @classmethod

--- a/stripe/api_resources/product.py
+++ b/stripe/api_resources/product.py
@@ -92,7 +92,7 @@ class Product(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsDefaultPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]
@@ -109,13 +109,13 @@ class Product(
                 "List[Product.CreateParamsDefaultPriceDataCurrencyOptionsTier]|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsDefaultPriceDataCurrencyOptionsTier(TypedDict):
             flat_amount: NotRequired["int|None"]
-            flat_amount_decimal: NotRequired["float|None"]
+            flat_amount_decimal: NotRequired["str|None"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
             up_to: Union[Literal["inf"], int]
 
         class CreateParamsDefaultPriceDataCurrencyOptionsCustomUnitAmount(

--- a/stripe/api_resources/quote.py
+++ b/stripe/api_resources/quote.py
@@ -113,7 +113,7 @@ class Quote(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsLineItemPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]
@@ -219,7 +219,7 @@ class Quote(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class ModifyParamsLineItemPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]

--- a/stripe/api_resources/subscription.py
+++ b/stripe/api_resources/subscription.py
@@ -278,7 +278,7 @@ class Subscription(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsItemPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]
@@ -309,7 +309,7 @@ class Subscription(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class DeleteDiscountParams(RequestOptions):
             pass
@@ -581,7 +581,7 @@ class Subscription(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class ModifyParamsItemPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]
@@ -618,7 +618,7 @@ class Subscription(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class ResumeParams(RequestOptions):
             billing_cycle_anchor: NotRequired[

--- a/stripe/api_resources/subscription_item.py
+++ b/stripe/api_resources/subscription_item.py
@@ -75,7 +75,7 @@ class SubscriptionItem(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]
@@ -128,7 +128,7 @@ class SubscriptionItem(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class ModifyParamsPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]

--- a/stripe/api_resources/subscription_schedule.py
+++ b/stripe/api_resources/subscription_schedule.py
@@ -128,7 +128,7 @@ class SubscriptionSchedule(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsPhaseItemPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]
@@ -162,7 +162,7 @@ class SubscriptionSchedule(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsDefaultSettings(TypedDict):
             application_fee_percent: NotRequired["float|None"]
@@ -327,7 +327,7 @@ class SubscriptionSchedule(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class ModifyParamsPhaseItemPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]
@@ -361,7 +361,7 @@ class SubscriptionSchedule(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class ModifyParamsDefaultSettings(TypedDict):
             application_fee_percent: NotRequired["float|None"]

--- a/tests/test_generated_examples.py
+++ b/tests/test_generated_examples.py
@@ -3767,14 +3767,14 @@ class TestGeneratedExamples(object):
                 "fuel": {
                     "type": "diesel",
                     "unit": "liter",
-                    "unit_cost_decimal": 3.5,
-                    "volume_decimal": 10,
+                    "unit_cost_decimal": "3.5",
+                    "volume_decimal": "10",
                 },
                 "lodging": {"check_in_at": 1633651200, "nights": 2},
                 "receipt": [
                     {
                         "description": "Room charge",
-                        "quantity": 1,
+                        "quantity": "1",
                         "total": 200,
                         "unit_cost": 200,
                     },
@@ -3852,14 +3852,14 @@ class TestGeneratedExamples(object):
                 "fuel": {
                     "type": "diesel",
                     "unit": "liter",
-                    "unit_cost_decimal": 3.5,
-                    "volume_decimal": 10,
+                    "unit_cost_decimal": "3.5",
+                    "volume_decimal": "10",
                 },
                 "lodging": {"check_in_at": 1533651200, "nights": 2},
                 "receipt": [
                     {
                         "description": "Room charge",
-                        "quantity": 1,
+                        "quantity": "1",
                         "total": 200,
                         "unit_cost": 200,
                     },
@@ -3907,14 +3907,14 @@ class TestGeneratedExamples(object):
                 "fuel": {
                     "type": "diesel",
                     "unit": "liter",
-                    "unit_cost_decimal": 3.5,
-                    "volume_decimal": 10,
+                    "unit_cost_decimal": "3.5",
+                    "volume_decimal": "10",
                 },
                 "lodging": {"check_in_at": 1533651200, "nights": 2},
                 "receipt": [
                     {
                         "description": "Room charge",
-                        "quantity": 1,
+                        "quantity": "1",
                         "total": 200,
                         "unit_cost": 200,
                     },

--- a/tests/test_generated_examples.py
+++ b/tests/test_generated_examples.py
@@ -3767,14 +3767,14 @@ class TestGeneratedExamples(object):
                 "fuel": {
                     "type": "diesel",
                     "unit": "liter",
-                    "unit_cost_decimal": "3.5",
-                    "volume_decimal": "10",
+                    "unit_cost_decimal": 3.5,
+                    "volume_decimal": 10,
                 },
                 "lodging": {"check_in_at": 1633651200, "nights": 2},
                 "receipt": [
                     {
                         "description": "Room charge",
-                        "quantity": "1",
+                        "quantity": 1,
                         "total": 200,
                         "unit_cost": 200,
                     },
@@ -3852,14 +3852,14 @@ class TestGeneratedExamples(object):
                 "fuel": {
                     "type": "diesel",
                     "unit": "liter",
-                    "unit_cost_decimal": "3.5",
-                    "volume_decimal": "10",
+                    "unit_cost_decimal": 3.5,
+                    "volume_decimal": 10,
                 },
                 "lodging": {"check_in_at": 1533651200, "nights": 2},
                 "receipt": [
                     {
                         "description": "Room charge",
-                        "quantity": "1",
+                        "quantity": 1,
                         "total": 200,
                         "unit_cost": 200,
                     },
@@ -3907,14 +3907,14 @@ class TestGeneratedExamples(object):
                 "fuel": {
                     "type": "diesel",
                     "unit": "liter",
-                    "unit_cost_decimal": "3.5",
-                    "volume_decimal": "10",
+                    "unit_cost_decimal": 3.5,
+                    "volume_decimal": 10,
                 },
                 "lodging": {"check_in_at": 1533651200, "nights": 2},
                 "receipt": [
                     {
                         "description": "Room charge",
-                        "quantity": "1",
+                        "quantity": 1,
                         "total": 200,
                         "unit_cost": 200,
                     },


### PR DESCRIPTION
Starts running `pyright` on `test/generated_examples_test.py`, and fixes the type error that occurred (big decimal types should be represented as str, not float).

We could change this type to `str|Decimal` but as we don't deserializes responses into `Decimal`, having `str` here is more symmetric but we are open to feedback.