### PR TITLE
Fix class method variant types

### DIFF
--- a/stripe/api_resources/account.py
+++ b/stripe/api_resources/account.py
@@ -12,13 +12,12 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, Union, cast
+from typing import ClassVar, Dict, List, Optional, Union, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus

--- a/stripe/api_resources/account.py
+++ b/stripe/api_resources/account.py
@@ -11,12 +11,14 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, Union, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -1056,8 +1058,21 @@ class Account(
             cls._static_request("delete", url, params=params),
         )
 
-    @util.class_method_variant("_cls_delete")
+    @overload
+    @classmethod
+    def delete(
+        cls, sid: str, **params: Unpack["Account.DeleteParams"]
+    ) -> "Account":
+        ...
+
+    @overload
     def delete(self, **params: Unpack["Account.DeleteParams"]) -> "Account":
+        ...
+
+    @class_method_variant("_cls_delete")
+    def delete(  # type: ignore
+        self, **params: Unpack["Account.DeleteParams"]
+    ) -> "Account":
         return self._request_and_refresh(
             "delete",
             self.instance_url(),
@@ -1112,8 +1127,28 @@ class Account(
             ),
         )
 
-    @util.class_method_variant("_cls_persons")
+    @overload
+    @classmethod
     def persons(
+        cls,
+        account: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Account.PersonsParams"]
+    ) -> ListObject["Person"]:
+        ...
+
+    @overload
+    def persons(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Account.PersonsParams"]
+    ) -> ListObject["Person"]:
+        ...
+
+    @class_method_variant(_cls_persons)
+    def persons(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Account.PersonsParams"]
@@ -1153,8 +1188,28 @@ class Account(
             ),
         )
 
-    @util.class_method_variant("_cls_reject")
+    @overload
+    @classmethod
     def reject(
+        cls,
+        account: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Account.RejectParams"]
+    ) -> "Account":
+        ...
+
+    @overload
+    def reject(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Account.RejectParams"]
+    ) -> "Account":
+        ...
+
+    @class_method_variant(_cls_reject)
+    def reject(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Account.RejectParams"]

--- a/stripe/api_resources/account.py
+++ b/stripe/api_resources/account.py
@@ -1146,7 +1146,7 @@ class Account(
     ) -> ListObject["Person"]:
         ...
 
-    @class_method_variant(_cls_persons)
+    @class_method_variant("_cls_persons")
     def persons(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -1207,7 +1207,7 @@ class Account(
     ) -> "Account":
         ...
 
-    @class_method_variant(_cls_reject)
+    @class_method_variant("_cls_reject")
     def reject(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/account.py
+++ b/stripe/api_resources/account.py
@@ -1069,7 +1069,7 @@ class Account(
         ...
 
     @class_method_variant("_cls_delete")
-    def delete(  # type: ignore
+    def delete(  # pyright: ignore[reportGeneralTypeIssues]
         self, **params: Unpack["Account.DeleteParams"]
     ) -> "Account":
         return self._request_and_refresh(
@@ -1147,7 +1147,7 @@ class Account(
         ...
 
     @class_method_variant("_cls_persons")
-    def persons(  # type: ignore
+    def persons(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Account.PersonsParams"]
@@ -1208,7 +1208,7 @@ class Account(
         ...
 
     @class_method_variant("_cls_reject")
-    def reject(  # type: ignore
+    def reject(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Account.RejectParams"]

--- a/stripe/api_resources/apple_pay_domain.py
+++ b/stripe/api_resources/apple_pay_domain.py
@@ -91,7 +91,7 @@ class ApplePayDomain(
         ...
 
     @class_method_variant("_cls_delete")
-    def delete(  # type: ignore
+    def delete(  # pyright: ignore[reportGeneralTypeIssues]
         self, **params: Unpack["ApplePayDomain.DeleteParams"]
     ) -> "ApplePayDomain":
         return self._request_and_refresh(

--- a/stripe/api_resources/apple_pay_domain.py
+++ b/stripe/api_resources/apple_pay_domain.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     DeletableAPIResource,
@@ -8,8 +7,15 @@ from stripe.api_resources.abstract import (
 )
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
+from stripe.util import class_method_variant
 from typing import ClassVar, List, Optional, cast
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    Literal,
+    NotRequired,
+    Unpack,
+    overload,
+    TYPE_CHECKING,
+)
 from urllib.parse import quote_plus
 
 
@@ -77,8 +83,21 @@ class ApplePayDomain(
             cls._static_request("delete", url, params=params),
         )
 
-    @util.class_method_variant("_cls_delete")
+    @overload
+    @classmethod
     def delete(
+        cls, sid: str, **params: Unpack["ApplePayDomain.DeleteParams"]
+    ) -> "ApplePayDomain":
+        ...
+
+    @overload
+    def delete(
+        self, **params: Unpack["ApplePayDomain.DeleteParams"]
+    ) -> "ApplePayDomain":
+        ...
+
+    @class_method_variant("_cls_delete")
+    def delete(  # type: ignore
         self, **params: Unpack["ApplePayDomain.DeleteParams"]
     ) -> "ApplePayDomain":
         return self._request_and_refresh(

--- a/stripe/api_resources/apple_pay_domain.py
+++ b/stripe/api_resources/apple_pay_domain.py
@@ -8,14 +8,8 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.util import class_method_variant
-from typing import ClassVar, List, Optional, cast
-from typing_extensions import (
-    Literal,
-    NotRequired,
-    Unpack,
-    overload,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, List, Optional, cast, overload
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 

--- a/stripe/api_resources/application_fee.py
+++ b/stripe/api_resources/application_fee.py
@@ -9,13 +9,12 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 

--- a/stripe/api_resources/application_fee.py
+++ b/stripe/api_resources/application_fee.py
@@ -157,7 +157,7 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
         ...
 
     @class_method_variant("_cls_refund")
-    def refund(  # type: ignore
+    def refund(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["ApplicationFee.RefundParams"]

--- a/stripe/api_resources/application_fee.py
+++ b/stripe/api_resources/application_fee.py
@@ -8,12 +8,14 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 
@@ -135,8 +137,28 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
             ),
         )
 
-    @util.class_method_variant("_cls_refund")
+    @overload
+    @classmethod
     def refund(
+        cls,
+        id: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["ApplicationFee.RefundParams"]
+    ) -> "ApplicationFeeRefund":
+        ...
+
+    @overload
+    def refund(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["ApplicationFee.RefundParams"]
+    ) -> "ApplicationFeeRefund":
+        ...
+
+    @class_method_variant(_cls_refund)
+    def refund(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["ApplicationFee.RefundParams"]

--- a/stripe/api_resources/application_fee.py
+++ b/stripe/api_resources/application_fee.py
@@ -156,7 +156,7 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
     ) -> "ApplicationFeeRefund":
         ...
 
-    @class_method_variant(_cls_refund)
+    @class_method_variant("_cls_refund")
     def refund(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/bank_account.py
+++ b/stripe/api_resources/bank_account.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import error, util
+from stripe import error
 from stripe.api_resources.abstract import (
     DeletableAPIResource,
     UpdateableAPIResource,
@@ -11,8 +11,9 @@ from stripe.api_resources.customer import Customer
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, Union, cast
-from typing_extensions import Literal, Unpack, TYPE_CHECKING
+from typing_extensions import Literal, Unpack, overload, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
@@ -71,8 +72,21 @@ class BankAccount(
             cls._static_request("delete", url, params=params),
         )
 
-    @util.class_method_variant("_cls_delete")
+    @overload
+    @classmethod
     def delete(
+        cls, sid: str, **params: Unpack["BankAccount.DeleteParams"]
+    ) -> Union["BankAccount", "Card"]:
+        ...
+
+    @overload
+    def delete(
+        self, **params: Unpack["BankAccount.DeleteParams"]
+    ) -> Union["BankAccount", "Card"]:
+        ...
+
+    @class_method_variant("_cls_delete")
+    def delete(  # type: ignore
         self, **params: Unpack["BankAccount.DeleteParams"]
     ) -> Union["BankAccount", "Card"]:
         return self._request_and_refresh(

--- a/stripe/api_resources/bank_account.py
+++ b/stripe/api_resources/bank_account.py
@@ -86,7 +86,7 @@ class BankAccount(
         ...
 
     @class_method_variant("_cls_delete")
-    def delete(  # type: ignore
+    def delete(  # pyright: ignore[reportGeneralTypeIssues]
         self, **params: Unpack["BankAccount.DeleteParams"]
     ) -> Union["BankAccount", "Card"]:
         return self._request_and_refresh(

--- a/stripe/api_resources/bank_account.py
+++ b/stripe/api_resources/bank_account.py
@@ -12,8 +12,8 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, Union, cast
-from typing_extensions import Literal, Unpack, overload, TYPE_CHECKING
+from typing import ClassVar, Dict, List, Optional, Union, cast, overload
+from typing_extensions import Literal, Unpack, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 if TYPE_CHECKING:

--- a/stripe/api_resources/card.py
+++ b/stripe/api_resources/card.py
@@ -90,7 +90,7 @@ class Card(DeletableAPIResource["Card"], UpdateableAPIResource["Card"]):
         ...
 
     @class_method_variant("_cls_delete")
-    def delete(  # type: ignore
+    def delete(  # pyright: ignore[reportGeneralTypeIssues]
         self, **params: Unpack["Card.DeleteParams"]
     ) -> Union["BankAccount", "Card"]:
         return self._request_and_refresh(

--- a/stripe/api_resources/card.py
+++ b/stripe/api_resources/card.py
@@ -10,8 +10,8 @@ from stripe.api_resources.customer import Customer
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.request_options import RequestOptions
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, Union, cast
-from typing_extensions import Literal, Unpack, overload, TYPE_CHECKING
+from typing import ClassVar, Dict, List, Optional, Union, cast, overload
+from typing_extensions import Literal, Unpack, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 if TYPE_CHECKING:

--- a/stripe/api_resources/card.py
+++ b/stripe/api_resources/card.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import error, util
+from stripe import error
 from stripe.api_resources.abstract import (
     DeletableAPIResource,
     UpdateableAPIResource,
@@ -9,8 +9,9 @@ from stripe.api_resources.account import Account
 from stripe.api_resources.customer import Customer
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.request_options import RequestOptions
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, Union, cast
-from typing_extensions import Literal, Unpack, TYPE_CHECKING
+from typing_extensions import Literal, Unpack, overload, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
@@ -75,8 +76,21 @@ class Card(DeletableAPIResource["Card"], UpdateableAPIResource["Card"]):
             cls._static_request("delete", url, params=params),
         )
 
-    @util.class_method_variant("_cls_delete")
+    @overload
+    @classmethod
     def delete(
+        cls, sid: str, **params: Unpack["Card.DeleteParams"]
+    ) -> Union["BankAccount", "Card"]:
+        ...
+
+    @overload
+    def delete(
+        self, **params: Unpack["Card.DeleteParams"]
+    ) -> Union["BankAccount", "Card"]:
+        ...
+
+    @class_method_variant("_cls_delete")
+    def delete(  # type: ignore
         self, **params: Unpack["Card.DeleteParams"]
     ) -> Union["BankAccount", "Card"]:
         return self._request_and_refresh(

--- a/stripe/api_resources/charge.py
+++ b/stripe/api_resources/charge.py
@@ -12,12 +12,14 @@ from stripe.api_resources.list_object import ListObject
 from stripe.api_resources.search_result_object import SearchResultObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, Iterator, List, Optional, Union, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -242,8 +244,28 @@ class Charge(
             ),
         )
 
-    @util.class_method_variant("_cls_capture")
+    @overload
+    @classmethod
     def capture(
+        cls,
+        charge: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Charge.CaptureParams"]
+    ) -> "Charge":
+        ...
+
+    @overload
+    def capture(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Charge.CaptureParams"]
+    ) -> "Charge":
+        ...
+
+    @class_method_variant(_cls_capture)
+    def capture(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Charge.CaptureParams"]

--- a/stripe/api_resources/charge.py
+++ b/stripe/api_resources/charge.py
@@ -272,7 +272,7 @@ class Charge(
     ) -> "Charge":
         ...
 
-    @class_method_variant(_cls_capture)
+    @class_method_variant("_cls_capture")
     def capture(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/charge.py
+++ b/stripe/api_resources/charge.py
@@ -13,13 +13,21 @@ from stripe.api_resources.search_result_object import SearchResultObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, Iterator, List, Optional, Union, cast
+from typing import (
+    ClassVar,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Union,
+    cast,
+    overload,
+)
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus

--- a/stripe/api_resources/charge.py
+++ b/stripe/api_resources/charge.py
@@ -273,7 +273,7 @@ class Charge(
         ...
 
     @class_method_variant("_cls_capture")
-    def capture(  # type: ignore
+    def capture(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Charge.CaptureParams"]

--- a/stripe/api_resources/checkout/session.py
+++ b/stripe/api_resources/checkout/session.py
@@ -10,13 +10,12 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 
@@ -814,7 +813,7 @@ class Session(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsLineItemPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]

--- a/stripe/api_resources/checkout/session.py
+++ b/stripe/api_resources/checkout/session.py
@@ -1127,7 +1127,7 @@ class Session(
     ) -> "Session":
         ...
 
-    @class_method_variant(_cls_expire)
+    @class_method_variant("_cls_expire")
     def expire(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -1213,7 +1213,7 @@ class Session(
     ) -> ListObject["LineItem"]:
         ...
 
-    @class_method_variant(_cls_list_line_items)
+    @class_method_variant("_cls_list_line_items")
     def list_line_items(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/checkout/session.py
+++ b/stripe/api_resources/checkout/session.py
@@ -1128,7 +1128,7 @@ class Session(
         ...
 
     @class_method_variant("_cls_expire")
-    def expire(  # type: ignore
+    def expire(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Session.ExpireParams"]
@@ -1214,7 +1214,7 @@ class Session(
         ...
 
     @class_method_variant("_cls_list_line_items")
-    def list_line_items(  # type: ignore
+    def list_line_items(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Session.ListLineItemsParams"]

--- a/stripe/api_resources/checkout/session.py
+++ b/stripe/api_resources/checkout/session.py
@@ -9,12 +9,14 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 
@@ -1106,8 +1108,28 @@ class Session(
             ),
         )
 
-    @util.class_method_variant("_cls_expire")
+    @overload
+    @classmethod
     def expire(
+        cls,
+        session: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Session.ExpireParams"]
+    ) -> "Session":
+        ...
+
+    @overload
+    def expire(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Session.ExpireParams"]
+    ) -> "Session":
+        ...
+
+    @class_method_variant(_cls_expire)
+    def expire(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Session.ExpireParams"]
@@ -1172,8 +1194,28 @@ class Session(
             ),
         )
 
-    @util.class_method_variant("_cls_list_line_items")
+    @overload
+    @classmethod
     def list_line_items(
+        cls,
+        session: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Session.ListLineItemsParams"]
+    ) -> ListObject["LineItem"]:
+        ...
+
+    @overload
+    def list_line_items(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Session.ListLineItemsParams"]
+    ) -> ListObject["LineItem"]:
+        ...
+
+    @class_method_variant(_cls_list_line_items)
+    def list_line_items(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Session.ListLineItemsParams"]

--- a/stripe/api_resources/coupon.py
+++ b/stripe/api_resources/coupon.py
@@ -10,13 +10,12 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus

--- a/stripe/api_resources/coupon.py
+++ b/stripe/api_resources/coupon.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     DeletableAPIResource,
@@ -10,12 +9,14 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -142,8 +143,21 @@ class Coupon(
             cls._static_request("delete", url, params=params),
         )
 
-    @util.class_method_variant("_cls_delete")
+    @overload
+    @classmethod
+    def delete(
+        cls, sid: str, **params: Unpack["Coupon.DeleteParams"]
+    ) -> "Coupon":
+        ...
+
+    @overload
     def delete(self, **params: Unpack["Coupon.DeleteParams"]) -> "Coupon":
+        ...
+
+    @class_method_variant("_cls_delete")
+    def delete(  # type: ignore
+        self, **params: Unpack["Coupon.DeleteParams"]
+    ) -> "Coupon":
         return self._request_and_refresh(
             "delete",
             self.instance_url(),

--- a/stripe/api_resources/coupon.py
+++ b/stripe/api_resources/coupon.py
@@ -154,7 +154,7 @@ class Coupon(
         ...
 
     @class_method_variant("_cls_delete")
-    def delete(  # type: ignore
+    def delete(  # pyright: ignore[reportGeneralTypeIssues]
         self, **params: Unpack["Coupon.DeleteParams"]
     ) -> "Coupon":
         return self._request_and_refresh(

--- a/stripe/api_resources/credit_note.py
+++ b/stripe/api_resources/credit_note.py
@@ -11,12 +11,14 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -333,8 +335,28 @@ class CreditNote(
             ),
         )
 
-    @util.class_method_variant("_cls_void_credit_note")
+    @overload
+    @classmethod
     def void_credit_note(
+        cls,
+        id: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["CreditNote.VoidCreditNoteParams"]
+    ) -> "CreditNote":
+        ...
+
+    @overload
+    def void_credit_note(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["CreditNote.VoidCreditNoteParams"]
+    ) -> "CreditNote":
+        ...
+
+    @class_method_variant(_cls_void_credit_note)
+    def void_credit_note(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["CreditNote.VoidCreditNoteParams"]

--- a/stripe/api_resources/credit_note.py
+++ b/stripe/api_resources/credit_note.py
@@ -354,7 +354,7 @@ class CreditNote(
     ) -> "CreditNote":
         ...
 
-    @class_method_variant(_cls_void_credit_note)
+    @class_method_variant("_cls_void_credit_note")
     def void_credit_note(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/credit_note.py
+++ b/stripe/api_resources/credit_note.py
@@ -12,13 +12,12 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -78,7 +77,7 @@ class CreditNote(
             tax_rates: NotRequired["Literal['']|List[str]|None"]
             type: Literal["custom_line_item", "invoice_line_item"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class ListParams(RequestOptions):
             customer: NotRequired["str|None"]
@@ -123,7 +122,7 @@ class CreditNote(
             tax_rates: NotRequired["Literal['']|List[str]|None"]
             type: Literal["custom_line_item", "invoice_line_item"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class PreviewLinesParams(RequestOptions):
             amount: NotRequired["int|None"]
@@ -158,7 +157,7 @@ class CreditNote(
             tax_rates: NotRequired["Literal['']|List[str]|None"]
             type: Literal["custom_line_item", "invoice_line_item"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class RetrieveParams(RequestOptions):
             expand: NotRequired["List[str]|None"]

--- a/stripe/api_resources/credit_note.py
+++ b/stripe/api_resources/credit_note.py
@@ -355,7 +355,7 @@ class CreditNote(
         ...
 
     @class_method_variant("_cls_void_credit_note")
-    def void_credit_note(  # type: ignore
+    def void_credit_note(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["CreditNote.VoidCreditNoteParams"]

--- a/stripe/api_resources/credit_note_line_item.py
+++ b/stripe/api_resources/credit_note_line_item.py
@@ -41,8 +41,8 @@ class CreditNoteLineItem(ListableAPIResource["CreditNoteLineItem"]):
     tax_rates: List["TaxRate"]
     type: Literal["custom_line_item", "invoice_line_item"]
     unit_amount: Optional[int]
-    unit_amount_decimal: Optional[float]
-    unit_amount_excluding_tax: Optional[float]
+    unit_amount_decimal: Optional[str]
+    unit_amount_excluding_tax: Optional[str]
 
     @classmethod
     def list(

--- a/stripe/api_resources/customer.py
+++ b/stripe/api_resources/customer.py
@@ -15,6 +15,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.api_resources.search_result_object import SearchResultObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, Iterator, List, Optional, Union, cast
 from typing_extensions import (
     Literal,
@@ -22,6 +23,7 @@ from typing_extensions import (
     Type,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -643,8 +645,28 @@ class Customer(
             ),
         )
 
-    @util.class_method_variant("_cls_create_funding_instructions")
+    @overload
+    @classmethod
     def create_funding_instructions(
+        cls,
+        customer: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Customer.CreateFundingInstructionsParams"]
+    ) -> "FundingInstructions":
+        ...
+
+    @overload
+    def create_funding_instructions(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Customer.CreateFundingInstructionsParams"]
+    ) -> "FundingInstructions":
+        ...
+
+    @class_method_variant(_cls_create_funding_instructions)
+    def create_funding_instructions(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Customer.CreateFundingInstructionsParams"]
@@ -671,8 +693,21 @@ class Customer(
             cls._static_request("delete", url, params=params),
         )
 
-    @util.class_method_variant("_cls_delete")
+    @overload
+    @classmethod
+    def delete(
+        cls, sid: str, **params: Unpack["Customer.DeleteParams"]
+    ) -> "Customer":
+        ...
+
+    @overload
     def delete(self, **params: Unpack["Customer.DeleteParams"]) -> "Customer":
+        ...
+
+    @class_method_variant("_cls_delete")
+    def delete(  # type: ignore
+        self, **params: Unpack["Customer.DeleteParams"]
+    ) -> "Customer":
         return self._request_and_refresh(
             "delete",
             self.instance_url(),
@@ -702,8 +737,28 @@ class Customer(
             ),
         )
 
-    @util.class_method_variant("_cls_delete_discount")
+    @overload
+    @classmethod
     def delete_discount(
+        cls,
+        customer: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Customer.DeleteDiscountParams"]
+    ) -> "Discount":
+        ...
+
+    @overload
+    def delete_discount(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Customer.DeleteDiscountParams"]
+    ) -> "Discount":
+        ...
+
+    @class_method_variant(_cls_delete_discount)
+    def delete_discount(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Customer.DeleteDiscountParams"]
@@ -768,8 +823,28 @@ class Customer(
             ),
         )
 
-    @util.class_method_variant("_cls_list_payment_methods")
+    @overload
+    @classmethod
     def list_payment_methods(
+        cls,
+        customer: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Customer.ListPaymentMethodsParams"]
+    ) -> ListObject["PaymentMethod"]:
+        ...
+
+    @overload
+    def list_payment_methods(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Customer.ListPaymentMethodsParams"]
+    ) -> ListObject["PaymentMethod"]:
+        ...
+
+    @class_method_variant(_cls_list_payment_methods)
+    def list_payment_methods(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Customer.ListPaymentMethodsParams"]
@@ -829,8 +904,30 @@ class Customer(
             ),
         )
 
-    @util.class_method_variant("_cls_retrieve_payment_method")
+    @overload
+    @classmethod
     def retrieve_payment_method(
+        cls,
+        customer: str,
+        payment_method: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Customer.RetrievePaymentMethodParams"]
+    ) -> "PaymentMethod":
+        ...
+
+    @overload
+    def retrieve_payment_method(
+        self,
+        payment_method: str,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Customer.RetrievePaymentMethodParams"]
+    ) -> "PaymentMethod":
+        ...
+
+    @class_method_variant(_cls_retrieve_payment_method)
+    def retrieve_payment_method(  # type: ignore
         self,
         payment_method: str,
         idempotency_key: Optional[str] = None,
@@ -1294,8 +1391,28 @@ class Customer(
                 ),
             )
 
-        @util.class_method_variant("_cls_fund_cash_balance")
+        @overload
+        @classmethod
         def fund_cash_balance(
+            cls,
+            customer: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Customer.FundCashBalanceParams"]
+        ) -> "CustomerCashBalanceTransaction":
+            ...
+
+        @overload
+        def fund_cash_balance(
+            self,
+            idempotency_key: Optional[str] = None,
+            **params: Unpack["Customer.FundCashBalanceParams"]
+        ) -> "CustomerCashBalanceTransaction":
+            ...
+
+        @class_method_variant(_cls_fund_cash_balance)
+        def fund_cash_balance(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Customer.FundCashBalanceParams"]

--- a/stripe/api_resources/customer.py
+++ b/stripe/api_resources/customer.py
@@ -674,7 +674,7 @@ class Customer(
         ...
 
     @class_method_variant("_cls_create_funding_instructions")
-    def create_funding_instructions(  # type: ignore
+    def create_funding_instructions(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Customer.CreateFundingInstructionsParams"]
@@ -713,7 +713,7 @@ class Customer(
         ...
 
     @class_method_variant("_cls_delete")
-    def delete(  # type: ignore
+    def delete(  # pyright: ignore[reportGeneralTypeIssues]
         self, **params: Unpack["Customer.DeleteParams"]
     ) -> "Customer":
         return self._request_and_refresh(
@@ -766,7 +766,7 @@ class Customer(
         ...
 
     @class_method_variant("_cls_delete_discount")
-    def delete_discount(  # type: ignore
+    def delete_discount(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Customer.DeleteDiscountParams"]
@@ -852,7 +852,7 @@ class Customer(
         ...
 
     @class_method_variant("_cls_list_payment_methods")
-    def list_payment_methods(  # type: ignore
+    def list_payment_methods(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Customer.ListPaymentMethodsParams"]
@@ -935,7 +935,7 @@ class Customer(
         ...
 
     @class_method_variant("_cls_retrieve_payment_method")
-    def retrieve_payment_method(  # type: ignore
+    def retrieve_payment_method(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         payment_method: str,
         idempotency_key: Optional[str] = None,
@@ -1420,7 +1420,7 @@ class Customer(
             ...
 
         @class_method_variant("_cls_fund_cash_balance")
-        def fund_cash_balance(  # type: ignore
+        def fund_cash_balance(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Customer.FundCashBalanceParams"]

--- a/stripe/api_resources/customer.py
+++ b/stripe/api_resources/customer.py
@@ -673,7 +673,7 @@ class Customer(
     ) -> "FundingInstructions":
         ...
 
-    @class_method_variant(_cls_create_funding_instructions)
+    @class_method_variant("_cls_create_funding_instructions")
     def create_funding_instructions(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -765,7 +765,7 @@ class Customer(
     ) -> "Discount":
         ...
 
-    @class_method_variant(_cls_delete_discount)
+    @class_method_variant("_cls_delete_discount")
     def delete_discount(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -851,7 +851,7 @@ class Customer(
     ) -> ListObject["PaymentMethod"]:
         ...
 
-    @class_method_variant(_cls_list_payment_methods)
+    @class_method_variant("_cls_list_payment_methods")
     def list_payment_methods(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -934,7 +934,7 @@ class Customer(
     ) -> "PaymentMethod":
         ...
 
-    @class_method_variant(_cls_retrieve_payment_method)
+    @class_method_variant("_cls_retrieve_payment_method")
     def retrieve_payment_method(  # type: ignore
         self,
         payment_method: str,
@@ -1419,7 +1419,7 @@ class Customer(
         ) -> "CustomerCashBalanceTransaction":
             ...
 
-        @class_method_variant(_cls_fund_cash_balance)
+        @class_method_variant("_cls_fund_cash_balance")
         def fund_cash_balance(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/customer.py
+++ b/stripe/api_resources/customer.py
@@ -16,14 +16,22 @@ from stripe.api_resources.search_result_object import SearchResultObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, Iterator, List, Optional, Union, cast
+from typing import (
+    ClassVar,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Union,
+    cast,
+    overload,
+)
 from typing_extensions import (
     Literal,
     NotRequired,
     Type,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus

--- a/stripe/api_resources/dispute.py
+++ b/stripe/api_resources/dispute.py
@@ -165,7 +165,7 @@ class Dispute(
     ) -> "Dispute":
         ...
 
-    @class_method_variant(_cls_close)
+    @class_method_variant("_cls_close")
     def close(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/dispute.py
+++ b/stripe/api_resources/dispute.py
@@ -9,12 +9,14 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -144,8 +146,28 @@ class Dispute(
             ),
         )
 
-    @util.class_method_variant("_cls_close")
+    @overload
+    @classmethod
     def close(
+        cls,
+        dispute: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Dispute.CloseParams"]
+    ) -> "Dispute":
+        ...
+
+    @overload
+    def close(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Dispute.CloseParams"]
+    ) -> "Dispute":
+        ...
+
+    @class_method_variant(_cls_close)
+    def close(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Dispute.CloseParams"]

--- a/stripe/api_resources/dispute.py
+++ b/stripe/api_resources/dispute.py
@@ -10,13 +10,12 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus

--- a/stripe/api_resources/dispute.py
+++ b/stripe/api_resources/dispute.py
@@ -166,7 +166,7 @@ class Dispute(
         ...
 
     @class_method_variant("_cls_close")
-    def close(  # type: ignore
+    def close(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Dispute.CloseParams"]

--- a/stripe/api_resources/ephemeral_key.py
+++ b/stripe/api_resources/ephemeral_key.py
@@ -47,7 +47,7 @@ class EphemeralKey(DeletableAPIResource["EphemeralKey"]):
         ...
 
     @class_method_variant("_cls_delete")
-    def delete(  # type: ignore
+    def delete(  # pyright: ignore[reportGeneralTypeIssues]
         self, **params: Unpack["EphemeralKey.DeleteParams"]
     ) -> "EphemeralKey":
         return self._request_and_refresh(

--- a/stripe/api_resources/ephemeral_key.py
+++ b/stripe/api_resources/ephemeral_key.py
@@ -4,14 +4,8 @@ from stripe import api_requestor, util
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.request_options import RequestOptions
 from stripe.util import class_method_variant
-from typing import ClassVar, List, Optional, cast
-from typing_extensions import (
-    Literal,
-    NotRequired,
-    Unpack,
-    overload,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, List, Optional, cast, overload
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 

--- a/stripe/api_resources/ephemeral_key.py
+++ b/stripe/api_resources/ephemeral_key.py
@@ -3,8 +3,15 @@
 from stripe import api_requestor, util
 from stripe.api_resources.abstract import DeletableAPIResource
 from stripe.request_options import RequestOptions
+from stripe.util import class_method_variant
 from typing import ClassVar, List, Optional, cast
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    Literal,
+    NotRequired,
+    Unpack,
+    overload,
+    TYPE_CHECKING,
+)
 from urllib.parse import quote_plus
 
 
@@ -32,8 +39,21 @@ class EphemeralKey(DeletableAPIResource["EphemeralKey"]):
             cls._static_request("delete", url, params=params),
         )
 
-    @util.class_method_variant("_cls_delete")
+    @overload
+    @classmethod
     def delete(
+        cls, sid: str, **params: Unpack["EphemeralKey.DeleteParams"]
+    ) -> "EphemeralKey":
+        ...
+
+    @overload
+    def delete(
+        self, **params: Unpack["EphemeralKey.DeleteParams"]
+    ) -> "EphemeralKey":
+        ...
+
+    @class_method_variant("_cls_delete")
+    def delete(  # type: ignore
         self, **params: Unpack["EphemeralKey.DeleteParams"]
     ) -> "EphemeralKey":
         return self._request_and_refresh(

--- a/stripe/api_resources/financial_connections/account.py
+++ b/stripe/api_resources/financial_connections/account.py
@@ -136,7 +136,7 @@ class Account(ListableAPIResource["Account"]):
     ) -> "Account":
         ...
 
-    @class_method_variant(_cls_disconnect)
+    @class_method_variant("_cls_disconnect")
     def disconnect(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -222,7 +222,7 @@ class Account(ListableAPIResource["Account"]):
     ) -> ListObject["AccountOwner"]:
         ...
 
-    @class_method_variant(_cls_list_owners)
+    @class_method_variant("_cls_list_owners")
     def list_owners(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -283,7 +283,7 @@ class Account(ListableAPIResource["Account"]):
     ) -> "Account":
         ...
 
-    @class_method_variant(_cls_refresh_account)
+    @class_method_variant("_cls_refresh_account")
     def refresh_account(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/financial_connections/account.py
+++ b/stripe/api_resources/financial_connections/account.py
@@ -137,7 +137,7 @@ class Account(ListableAPIResource["Account"]):
         ...
 
     @class_method_variant("_cls_disconnect")
-    def disconnect(  # type: ignore
+    def disconnect(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Account.DisconnectParams"]
@@ -223,7 +223,7 @@ class Account(ListableAPIResource["Account"]):
         ...
 
     @class_method_variant("_cls_list_owners")
-    def list_owners(  # type: ignore
+    def list_owners(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Account.ListOwnersParams"]
@@ -284,7 +284,7 @@ class Account(ListableAPIResource["Account"]):
         ...
 
     @class_method_variant("_cls_refresh_account")
-    def refresh_account(  # type: ignore
+    def refresh_account(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Account.RefreshAccountParams"]

--- a/stripe/api_resources/financial_connections/account.py
+++ b/stripe/api_resources/financial_connections/account.py
@@ -7,13 +7,12 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, List, Optional, cast
+from typing import ClassVar, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 

--- a/stripe/api_resources/financial_connections/account.py
+++ b/stripe/api_resources/financial_connections/account.py
@@ -6,12 +6,14 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 
@@ -115,8 +117,28 @@ class Account(ListableAPIResource["Account"]):
             ),
         )
 
-    @util.class_method_variant("_cls_disconnect")
+    @overload
+    @classmethod
     def disconnect(
+        cls,
+        account: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Account.DisconnectParams"]
+    ) -> "Account":
+        ...
+
+    @overload
+    def disconnect(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Account.DisconnectParams"]
+    ) -> "Account":
+        ...
+
+    @class_method_variant(_cls_disconnect)
+    def disconnect(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Account.DisconnectParams"]
@@ -181,8 +203,28 @@ class Account(ListableAPIResource["Account"]):
             ),
         )
 
-    @util.class_method_variant("_cls_list_owners")
+    @overload
+    @classmethod
     def list_owners(
+        cls,
+        account: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Account.ListOwnersParams"]
+    ) -> ListObject["AccountOwner"]:
+        ...
+
+    @overload
+    def list_owners(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Account.ListOwnersParams"]
+    ) -> ListObject["AccountOwner"]:
+        ...
+
+    @class_method_variant(_cls_list_owners)
+    def list_owners(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Account.ListOwnersParams"]
@@ -222,8 +264,28 @@ class Account(ListableAPIResource["Account"]):
             ),
         )
 
-    @util.class_method_variant("_cls_refresh_account")
+    @overload
+    @classmethod
     def refresh_account(
+        cls,
+        account: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Account.RefreshAccountParams"]
+    ) -> "Account":
+        ...
+
+    @overload
+    def refresh_account(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Account.RefreshAccountParams"]
+    ) -> "Account":
+        ...
+
+    @class_method_variant(_cls_refresh_account)
+    def refresh_account(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Account.RefreshAccountParams"]

--- a/stripe/api_resources/identity/verification_session.py
+++ b/stripe/api_resources/identity/verification_session.py
@@ -11,13 +11,12 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus

--- a/stripe/api_resources/identity/verification_session.py
+++ b/stripe/api_resources/identity/verification_session.py
@@ -180,7 +180,7 @@ class VerificationSession(
         ...
 
     @class_method_variant("_cls_cancel")
-    def cancel(  # type: ignore
+    def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["VerificationSession.CancelParams"]
@@ -298,7 +298,7 @@ class VerificationSession(
         ...
 
     @class_method_variant("_cls_redact")
-    def redact(  # type: ignore
+    def redact(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["VerificationSession.RedactParams"]

--- a/stripe/api_resources/identity/verification_session.py
+++ b/stripe/api_resources/identity/verification_session.py
@@ -179,7 +179,7 @@ class VerificationSession(
     ) -> "VerificationSession":
         ...
 
-    @class_method_variant(_cls_cancel)
+    @class_method_variant("_cls_cancel")
     def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -297,7 +297,7 @@ class VerificationSession(
     ) -> "VerificationSession":
         ...
 
-    @class_method_variant(_cls_redact)
+    @class_method_variant("_cls_redact")
     def redact(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/identity/verification_session.py
+++ b/stripe/api_resources/identity/verification_session.py
@@ -10,12 +10,14 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -158,8 +160,28 @@ class VerificationSession(
             ),
         )
 
-    @util.class_method_variant("_cls_cancel")
+    @overload
+    @classmethod
     def cancel(
+        cls,
+        session: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["VerificationSession.CancelParams"]
+    ) -> "VerificationSession":
+        ...
+
+    @overload
+    def cancel(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["VerificationSession.CancelParams"]
+    ) -> "VerificationSession":
+        ...
+
+    @class_method_variant(_cls_cancel)
+    def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["VerificationSession.CancelParams"]
@@ -256,8 +278,28 @@ class VerificationSession(
             ),
         )
 
-    @util.class_method_variant("_cls_redact")
+    @overload
+    @classmethod
     def redact(
+        cls,
+        session: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["VerificationSession.RedactParams"]
+    ) -> "VerificationSession":
+        ...
+
+    @overload
+    def redact(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["VerificationSession.RedactParams"]
+    ) -> "VerificationSession":
+        ...
+
+    @class_method_variant(_cls_redact)
+    def redact(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["VerificationSession.RedactParams"]

--- a/stripe/api_resources/invoice.py
+++ b/stripe/api_resources/invoice.py
@@ -1303,7 +1303,7 @@ class Invoice(
         ...
 
     @class_method_variant("_cls_delete")
-    def delete(  # type: ignore
+    def delete(  # pyright: ignore[reportGeneralTypeIssues]
         self, **params: Unpack["Invoice.DeleteParams"]
     ) -> "Invoice":
         return self._request_and_refresh(
@@ -1356,7 +1356,7 @@ class Invoice(
         ...
 
     @class_method_variant("_cls_finalize_invoice")
-    def finalize_invoice(  # type: ignore
+    def finalize_invoice(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Invoice.FinalizeInvoiceParams"]
@@ -1442,7 +1442,7 @@ class Invoice(
         ...
 
     @class_method_variant("_cls_mark_uncollectible")
-    def mark_uncollectible(  # type: ignore
+    def mark_uncollectible(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Invoice.MarkUncollectibleParams"]
@@ -1513,7 +1513,7 @@ class Invoice(
         ...
 
     @class_method_variant("_cls_pay")
-    def pay(  # type: ignore
+    def pay(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Invoice.PayParams"]
@@ -1582,7 +1582,7 @@ class Invoice(
         ...
 
     @class_method_variant("_cls_send_invoice")
-    def send_invoice(  # type: ignore
+    def send_invoice(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Invoice.SendInvoiceParams"]
@@ -1683,7 +1683,7 @@ class Invoice(
         ...
 
     @class_method_variant("_cls_void_invoice")
-    def void_invoice(  # type: ignore
+    def void_invoice(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Invoice.VoidInvoiceParams"]

--- a/stripe/api_resources/invoice.py
+++ b/stripe/api_resources/invoice.py
@@ -14,13 +14,21 @@ from stripe.api_resources.search_result_object import SearchResultObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, Iterator, List, Optional, Union, cast
+from typing import (
+    ClassVar,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Union,
+    cast,
+    overload,
+)
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -739,7 +747,7 @@ class Invoice(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class UpcomingParamsSubscriptionItemPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]
@@ -770,7 +778,7 @@ class Invoice(
             tax_code: NotRequired["Literal['']|str|None"]
             tax_rates: NotRequired["Literal['']|List[str]|None"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class UpcomingParamsInvoiceItemPriceData(TypedDict):
             currency: str
@@ -779,7 +787,7 @@ class Invoice(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class UpcomingParamsInvoiceItemPeriod(TypedDict):
             end: int
@@ -973,7 +981,7 @@ class Invoice(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class UpcomingLinesParamsSubscriptionItemPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]
@@ -1006,7 +1014,7 @@ class Invoice(
             tax_code: NotRequired["Literal['']|str|None"]
             tax_rates: NotRequired["Literal['']|List[str]|None"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class UpcomingLinesParamsInvoiceItemPriceData(TypedDict):
             currency: str
@@ -1015,7 +1023,7 @@ class Invoice(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class UpcomingLinesParamsInvoiceItemPeriod(TypedDict):
             end: int

--- a/stripe/api_resources/invoice.py
+++ b/stripe/api_resources/invoice.py
@@ -1355,7 +1355,7 @@ class Invoice(
     ) -> "Invoice":
         ...
 
-    @class_method_variant(_cls_finalize_invoice)
+    @class_method_variant("_cls_finalize_invoice")
     def finalize_invoice(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -1441,7 +1441,7 @@ class Invoice(
     ) -> "Invoice":
         ...
 
-    @class_method_variant(_cls_mark_uncollectible)
+    @class_method_variant("_cls_mark_uncollectible")
     def mark_uncollectible(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -1512,7 +1512,7 @@ class Invoice(
     ) -> "Invoice":
         ...
 
-    @class_method_variant(_cls_pay)
+    @class_method_variant("_cls_pay")
     def pay(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -1581,7 +1581,7 @@ class Invoice(
     ) -> "Invoice":
         ...
 
-    @class_method_variant(_cls_send_invoice)
+    @class_method_variant("_cls_send_invoice")
     def send_invoice(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -1682,7 +1682,7 @@ class Invoice(
     ) -> "Invoice":
         ...
 
-    @class_method_variant(_cls_void_invoice)
+    @class_method_variant("_cls_void_invoice")
     def void_invoice(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/invoice.py
+++ b/stripe/api_resources/invoice.py
@@ -13,12 +13,14 @@ from stripe.api_resources.list_object import ListObject
 from stripe.api_resources.search_result_object import SearchResultObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, Iterator, List, Optional, Union, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -1281,8 +1283,21 @@ class Invoice(
             cls._static_request("delete", url, params=params),
         )
 
-    @util.class_method_variant("_cls_delete")
+    @overload
+    @classmethod
+    def delete(
+        cls, sid: str, **params: Unpack["Invoice.DeleteParams"]
+    ) -> "Invoice":
+        ...
+
+    @overload
     def delete(self, **params: Unpack["Invoice.DeleteParams"]) -> "Invoice":
+        ...
+
+    @class_method_variant("_cls_delete")
+    def delete(  # type: ignore
+        self, **params: Unpack["Invoice.DeleteParams"]
+    ) -> "Invoice":
         return self._request_and_refresh(
             "delete",
             self.instance_url(),
@@ -1312,8 +1327,28 @@ class Invoice(
             ),
         )
 
-    @util.class_method_variant("_cls_finalize_invoice")
+    @overload
+    @classmethod
     def finalize_invoice(
+        cls,
+        invoice: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Invoice.FinalizeInvoiceParams"]
+    ) -> "Invoice":
+        ...
+
+    @overload
+    def finalize_invoice(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Invoice.FinalizeInvoiceParams"]
+    ) -> "Invoice":
+        ...
+
+    @class_method_variant(_cls_finalize_invoice)
+    def finalize_invoice(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Invoice.FinalizeInvoiceParams"]
@@ -1378,8 +1413,28 @@ class Invoice(
             ),
         )
 
-    @util.class_method_variant("_cls_mark_uncollectible")
+    @overload
+    @classmethod
     def mark_uncollectible(
+        cls,
+        invoice: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Invoice.MarkUncollectibleParams"]
+    ) -> "Invoice":
+        ...
+
+    @overload
+    def mark_uncollectible(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Invoice.MarkUncollectibleParams"]
+    ) -> "Invoice":
+        ...
+
+    @class_method_variant(_cls_mark_uncollectible)
+    def mark_uncollectible(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Invoice.MarkUncollectibleParams"]
@@ -1429,8 +1484,28 @@ class Invoice(
             ),
         )
 
-    @util.class_method_variant("_cls_pay")
+    @overload
+    @classmethod
     def pay(
+        cls,
+        invoice: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Invoice.PayParams"]
+    ) -> "Invoice":
+        ...
+
+    @overload
+    def pay(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Invoice.PayParams"]
+    ) -> "Invoice":
+        ...
+
+    @class_method_variant(_cls_pay)
+    def pay(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Invoice.PayParams"]
@@ -1478,8 +1553,28 @@ class Invoice(
             ),
         )
 
-    @util.class_method_variant("_cls_send_invoice")
+    @overload
+    @classmethod
     def send_invoice(
+        cls,
+        invoice: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Invoice.SendInvoiceParams"]
+    ) -> "Invoice":
+        ...
+
+    @overload
+    def send_invoice(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Invoice.SendInvoiceParams"]
+    ) -> "Invoice":
+        ...
+
+    @class_method_variant(_cls_send_invoice)
+    def send_invoice(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Invoice.SendInvoiceParams"]
@@ -1559,8 +1654,28 @@ class Invoice(
             ),
         )
 
-    @util.class_method_variant("_cls_void_invoice")
+    @overload
+    @classmethod
     def void_invoice(
+        cls,
+        invoice: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Invoice.VoidInvoiceParams"]
+    ) -> "Invoice":
+        ...
+
+    @overload
+    def void_invoice(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Invoice.VoidInvoiceParams"]
+    ) -> "Invoice":
+        ...
+
+    @class_method_variant(_cls_void_invoice)
+    def void_invoice(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Invoice.VoidInvoiceParams"]

--- a/stripe/api_resources/invoice_item.py
+++ b/stripe/api_resources/invoice_item.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     DeletableAPIResource,
@@ -11,12 +10,14 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -214,8 +215,21 @@ class InvoiceItem(
             cls._static_request("delete", url, params=params),
         )
 
-    @util.class_method_variant("_cls_delete")
+    @overload
+    @classmethod
     def delete(
+        cls, sid: str, **params: Unpack["InvoiceItem.DeleteParams"]
+    ) -> "InvoiceItem":
+        ...
+
+    @overload
+    def delete(
+        self, **params: Unpack["InvoiceItem.DeleteParams"]
+    ) -> "InvoiceItem":
+        ...
+
+    @class_method_variant("_cls_delete")
+    def delete(  # type: ignore
         self, **params: Unpack["InvoiceItem.DeleteParams"]
     ) -> "InvoiceItem":
         return self._request_and_refresh(

--- a/stripe/api_resources/invoice_item.py
+++ b/stripe/api_resources/invoice_item.py
@@ -228,7 +228,7 @@ class InvoiceItem(
         ...
 
     @class_method_variant("_cls_delete")
-    def delete(  # type: ignore
+    def delete(  # pyright: ignore[reportGeneralTypeIssues]
         self, **params: Unpack["InvoiceItem.DeleteParams"]
     ) -> "InvoiceItem":
         return self._request_and_refresh(

--- a/stripe/api_resources/invoice_item.py
+++ b/stripe/api_resources/invoice_item.py
@@ -11,13 +11,12 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -79,7 +78,7 @@ class InvoiceItem(
             tax_code: NotRequired["Literal['']|str|None"]
             tax_rates: NotRequired["List[str]|None"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsPriceData(TypedDict):
             currency: str
@@ -88,7 +87,7 @@ class InvoiceItem(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsPeriod(TypedDict):
             end: int
@@ -136,7 +135,7 @@ class InvoiceItem(
             tax_code: NotRequired["Literal['']|str|None"]
             tax_rates: NotRequired["Literal['']|List[str]|None"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class ModifyParamsPriceData(TypedDict):
             currency: str
@@ -145,7 +144,7 @@ class InvoiceItem(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class ModifyParamsPeriod(TypedDict):
             end: int
@@ -180,7 +179,7 @@ class InvoiceItem(
     tax_rates: Optional[List["TaxRate"]]
     test_clock: Optional[ExpandableField["TestClock"]]
     unit_amount: Optional[int]
-    unit_amount_decimal: Optional[float]
+    unit_amount_decimal: Optional[str]
     deleted: Optional[Literal[True]]
 
     @classmethod

--- a/stripe/api_resources/invoice_line_item.py
+++ b/stripe/api_resources/invoice_line_item.py
@@ -40,4 +40,4 @@ class InvoiceLineItem(StripeObject):
     tax_amounts: Optional[List[StripeObject]]
     tax_rates: Optional[List["TaxRate"]]
     type: Literal["invoiceitem", "subscription"]
-    unit_amount_excluding_tax: Optional[float]
+    unit_amount_excluding_tax: Optional[str]

--- a/stripe/api_resources/issuing/authorization.py
+++ b/stripe/api_resources/issuing/authorization.py
@@ -280,7 +280,7 @@ class Authorization(
     ) -> "Authorization":
         ...
 
-    @class_method_variant(_cls_approve)
+    @class_method_variant("_cls_approve")
     def approve(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -341,7 +341,7 @@ class Authorization(
     ) -> "Authorization":
         ...
 
-    @class_method_variant(_cls_decline)
+    @class_method_variant("_cls_decline")
     def decline(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -448,7 +448,7 @@ class Authorization(
         ) -> "Authorization":
             ...
 
-        @class_method_variant(_cls_capture)
+        @class_method_variant("_cls_capture")
         def capture(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
@@ -529,7 +529,7 @@ class Authorization(
         ) -> "Authorization":
             ...
 
-        @class_method_variant(_cls_expire)
+        @class_method_variant("_cls_expire")
         def expire(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
@@ -590,7 +590,7 @@ class Authorization(
         ) -> "Authorization":
             ...
 
-        @class_method_variant(_cls_increment)
+        @class_method_variant("_cls_increment")
         def increment(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
@@ -651,7 +651,7 @@ class Authorization(
         ) -> "Authorization":
             ...
 
-        @class_method_variant(_cls_reverse)
+        @class_method_variant("_cls_reverse")
         def reverse(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/issuing/authorization.py
+++ b/stripe/api_resources/issuing/authorization.py
@@ -281,7 +281,7 @@ class Authorization(
         ...
 
     @class_method_variant("_cls_approve")
-    def approve(  # type: ignore
+    def approve(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Authorization.ApproveParams"]
@@ -342,7 +342,7 @@ class Authorization(
         ...
 
     @class_method_variant("_cls_decline")
-    def decline(  # type: ignore
+    def decline(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Authorization.DeclineParams"]
@@ -449,7 +449,7 @@ class Authorization(
             ...
 
         @class_method_variant("_cls_capture")
-        def capture(  # type: ignore
+        def capture(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Authorization.CaptureParams"]
@@ -530,7 +530,7 @@ class Authorization(
             ...
 
         @class_method_variant("_cls_expire")
-        def expire(  # type: ignore
+        def expire(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Authorization.ExpireParams"]
@@ -591,7 +591,7 @@ class Authorization(
             ...
 
         @class_method_variant("_cls_increment")
-        def increment(  # type: ignore
+        def increment(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Authorization.IncrementParams"]
@@ -652,7 +652,7 @@ class Authorization(
             ...
 
         @class_method_variant("_cls_reverse")
-        def reverse(  # type: ignore
+        def reverse(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Authorization.ReverseParams"]

--- a/stripe/api_resources/issuing/authorization.py
+++ b/stripe/api_resources/issuing/authorization.py
@@ -11,14 +11,13 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     Type,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -107,7 +106,7 @@ class Authorization(
 
         class CaptureParamsPurchaseDetailsReceipt(TypedDict):
             description: NotRequired["str|None"]
-            quantity: NotRequired["float|None"]
+            quantity: NotRequired["str|None"]
             total: NotRequired["int|None"]
             unit_cost: NotRequired["int|None"]
 
@@ -120,8 +119,8 @@ class Authorization(
                 "Literal['diesel', 'other', 'unleaded_plus', 'unleaded_regular', 'unleaded_super']|None"
             ]
             unit: NotRequired["Literal['liter', 'us_gallon']|None"]
-            unit_cost_decimal: NotRequired["float|None"]
-            volume_decimal: NotRequired["float|None"]
+            unit_cost_decimal: NotRequired["str|None"]
+            volume_decimal: NotRequired["str|None"]
 
         class CaptureParamsPurchaseDetailsFlight(TypedDict):
             departure_at: NotRequired["int|None"]

--- a/stripe/api_resources/issuing/authorization.py
+++ b/stripe/api_resources/issuing/authorization.py
@@ -10,6 +10,7 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
@@ -17,6 +18,7 @@ from typing_extensions import (
     Type,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -259,8 +261,28 @@ class Authorization(
             ),
         )
 
-    @util.class_method_variant("_cls_approve")
+    @overload
+    @classmethod
     def approve(
+        cls,
+        authorization: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Authorization.ApproveParams"]
+    ) -> "Authorization":
+        ...
+
+    @overload
+    def approve(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Authorization.ApproveParams"]
+    ) -> "Authorization":
+        ...
+
+    @class_method_variant(_cls_approve)
+    def approve(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Authorization.ApproveParams"]
@@ -300,8 +322,28 @@ class Authorization(
             ),
         )
 
-    @util.class_method_variant("_cls_decline")
+    @overload
+    @classmethod
     def decline(
+        cls,
+        authorization: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Authorization.DeclineParams"]
+    ) -> "Authorization":
+        ...
+
+    @overload
+    def decline(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Authorization.DeclineParams"]
+    ) -> "Authorization":
+        ...
+
+    @class_method_variant(_cls_decline)
+    def decline(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Authorization.DeclineParams"]
@@ -387,8 +429,28 @@ class Authorization(
                 ),
             )
 
-        @util.class_method_variant("_cls_capture")
+        @overload
+        @classmethod
         def capture(
+            cls,
+            authorization: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Authorization.CaptureParams"]
+        ) -> "Authorization":
+            ...
+
+        @overload
+        def capture(
+            self,
+            idempotency_key: Optional[str] = None,
+            **params: Unpack["Authorization.CaptureParams"]
+        ) -> "Authorization":
+            ...
+
+        @class_method_variant(_cls_capture)
+        def capture(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Authorization.CaptureParams"]
@@ -448,8 +510,28 @@ class Authorization(
                 ),
             )
 
-        @util.class_method_variant("_cls_expire")
+        @overload
+        @classmethod
         def expire(
+            cls,
+            authorization: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Authorization.ExpireParams"]
+        ) -> "Authorization":
+            ...
+
+        @overload
+        def expire(
+            self,
+            idempotency_key: Optional[str] = None,
+            **params: Unpack["Authorization.ExpireParams"]
+        ) -> "Authorization":
+            ...
+
+        @class_method_variant(_cls_expire)
+        def expire(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Authorization.ExpireParams"]
@@ -489,8 +571,28 @@ class Authorization(
                 ),
             )
 
-        @util.class_method_variant("_cls_increment")
+        @overload
+        @classmethod
         def increment(
+            cls,
+            authorization: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Authorization.IncrementParams"]
+        ) -> "Authorization":
+            ...
+
+        @overload
+        def increment(
+            self,
+            idempotency_key: Optional[str] = None,
+            **params: Unpack["Authorization.IncrementParams"]
+        ) -> "Authorization":
+            ...
+
+        @class_method_variant(_cls_increment)
+        def increment(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Authorization.IncrementParams"]
@@ -530,8 +632,28 @@ class Authorization(
                 ),
             )
 
-        @util.class_method_variant("_cls_reverse")
+        @overload
+        @classmethod
         def reverse(
+            cls,
+            authorization: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Authorization.ReverseParams"]
+        ) -> "Authorization":
+            ...
+
+        @overload
+        def reverse(
+            self,
+            idempotency_key: Optional[str] = None,
+            **params: Unpack["Authorization.ReverseParams"]
+        ) -> "Authorization":
+            ...
+
+        @class_method_variant(_cls_reverse)
+        def reverse(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Authorization.ReverseParams"]

--- a/stripe/api_resources/issuing/card.py
+++ b/stripe/api_resources/issuing/card.py
@@ -314,7 +314,7 @@ class Card(
         ) -> "Card":
             ...
 
-        @class_method_variant(_cls_deliver_card)
+        @class_method_variant("_cls_deliver_card")
         def deliver_card(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
@@ -375,7 +375,7 @@ class Card(
         ) -> "Card":
             ...
 
-        @class_method_variant(_cls_fail_card)
+        @class_method_variant("_cls_fail_card")
         def fail_card(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
@@ -436,7 +436,7 @@ class Card(
         ) -> "Card":
             ...
 
-        @class_method_variant(_cls_return_card)
+        @class_method_variant("_cls_return_card")
         def return_card(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
@@ -497,7 +497,7 @@ class Card(
         ) -> "Card":
             ...
 
-        @class_method_variant(_cls_ship_card)
+        @class_method_variant("_cls_ship_card")
         def ship_card(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/issuing/card.py
+++ b/stripe/api_resources/issuing/card.py
@@ -12,14 +12,13 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     Type,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus

--- a/stripe/api_resources/issuing/card.py
+++ b/stripe/api_resources/issuing/card.py
@@ -11,6 +11,7 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
@@ -18,6 +19,7 @@ from typing_extensions import (
     Type,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -293,8 +295,28 @@ class Card(
                 ),
             )
 
-        @util.class_method_variant("_cls_deliver_card")
+        @overload
+        @classmethod
         def deliver_card(
+            cls,
+            card: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Card.DeliverCardParams"]
+        ) -> "Card":
+            ...
+
+        @overload
+        def deliver_card(
+            self,
+            idempotency_key: Optional[str] = None,
+            **params: Unpack["Card.DeliverCardParams"]
+        ) -> "Card":
+            ...
+
+        @class_method_variant(_cls_deliver_card)
+        def deliver_card(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Card.DeliverCardParams"]
@@ -334,8 +356,28 @@ class Card(
                 ),
             )
 
-        @util.class_method_variant("_cls_fail_card")
+        @overload
+        @classmethod
         def fail_card(
+            cls,
+            card: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Card.FailCardParams"]
+        ) -> "Card":
+            ...
+
+        @overload
+        def fail_card(
+            self,
+            idempotency_key: Optional[str] = None,
+            **params: Unpack["Card.FailCardParams"]
+        ) -> "Card":
+            ...
+
+        @class_method_variant(_cls_fail_card)
+        def fail_card(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Card.FailCardParams"]
@@ -375,8 +417,28 @@ class Card(
                 ),
             )
 
-        @util.class_method_variant("_cls_return_card")
+        @overload
+        @classmethod
         def return_card(
+            cls,
+            card: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Card.ReturnCardParams"]
+        ) -> "Card":
+            ...
+
+        @overload
+        def return_card(
+            self,
+            idempotency_key: Optional[str] = None,
+            **params: Unpack["Card.ReturnCardParams"]
+        ) -> "Card":
+            ...
+
+        @class_method_variant(_cls_return_card)
+        def return_card(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Card.ReturnCardParams"]
@@ -416,8 +478,28 @@ class Card(
                 ),
             )
 
-        @util.class_method_variant("_cls_ship_card")
+        @overload
+        @classmethod
         def ship_card(
+            cls,
+            card: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Card.ShipCardParams"]
+        ) -> "Card":
+            ...
+
+        @overload
+        def ship_card(
+            self,
+            idempotency_key: Optional[str] = None,
+            **params: Unpack["Card.ShipCardParams"]
+        ) -> "Card":
+            ...
+
+        @class_method_variant(_cls_ship_card)
+        def ship_card(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Card.ShipCardParams"]

--- a/stripe/api_resources/issuing/card.py
+++ b/stripe/api_resources/issuing/card.py
@@ -315,7 +315,7 @@ class Card(
             ...
 
         @class_method_variant("_cls_deliver_card")
-        def deliver_card(  # type: ignore
+        def deliver_card(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Card.DeliverCardParams"]
@@ -376,7 +376,7 @@ class Card(
             ...
 
         @class_method_variant("_cls_fail_card")
-        def fail_card(  # type: ignore
+        def fail_card(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Card.FailCardParams"]
@@ -437,7 +437,7 @@ class Card(
             ...
 
         @class_method_variant("_cls_return_card")
-        def return_card(  # type: ignore
+        def return_card(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Card.ReturnCardParams"]
@@ -498,7 +498,7 @@ class Card(
             ...
 
         @class_method_variant("_cls_ship_card")
-        def ship_card(  # type: ignore
+        def ship_card(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Card.ShipCardParams"]

--- a/stripe/api_resources/issuing/dispute.py
+++ b/stripe/api_resources/issuing/dispute.py
@@ -11,13 +11,12 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus

--- a/stripe/api_resources/issuing/dispute.py
+++ b/stripe/api_resources/issuing/dispute.py
@@ -379,7 +379,7 @@ class Dispute(
         ...
 
     @class_method_variant("_cls_submit")
-    def submit(  # type: ignore
+    def submit(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Dispute.SubmitParams"]

--- a/stripe/api_resources/issuing/dispute.py
+++ b/stripe/api_resources/issuing/dispute.py
@@ -10,12 +10,14 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -357,8 +359,28 @@ class Dispute(
             ),
         )
 
-    @util.class_method_variant("_cls_submit")
+    @overload
+    @classmethod
     def submit(
+        cls,
+        dispute: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Dispute.SubmitParams"]
+    ) -> "Dispute":
+        ...
+
+    @overload
+    def submit(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Dispute.SubmitParams"]
+    ) -> "Dispute":
+        ...
+
+    @class_method_variant(_cls_submit)
+    def submit(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Dispute.SubmitParams"]

--- a/stripe/api_resources/issuing/dispute.py
+++ b/stripe/api_resources/issuing/dispute.py
@@ -378,7 +378,7 @@ class Dispute(
     ) -> "Dispute":
         ...
 
-    @class_method_variant(_cls_submit)
+    @class_method_variant("_cls_submit")
     def submit(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/issuing/transaction.py
+++ b/stripe/api_resources/issuing/transaction.py
@@ -11,14 +11,13 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     Type,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -101,7 +100,7 @@ class Transaction(
 
         class CreateForceCaptureParamsPurchaseDetailsReceipt(TypedDict):
             description: NotRequired["str|None"]
-            quantity: NotRequired["float|None"]
+            quantity: NotRequired["str|None"]
             total: NotRequired["int|None"]
             unit_cost: NotRequired["int|None"]
 
@@ -114,8 +113,8 @@ class Transaction(
                 "Literal['diesel', 'other', 'unleaded_plus', 'unleaded_regular', 'unleaded_super']|None"
             ]
             unit: NotRequired["Literal['liter', 'us_gallon']|None"]
-            unit_cost_decimal: NotRequired["float|None"]
-            volume_decimal: NotRequired["float|None"]
+            unit_cost_decimal: NotRequired["str|None"]
+            volume_decimal: NotRequired["str|None"]
 
         class CreateForceCaptureParamsPurchaseDetailsFlight(TypedDict):
             departure_at: NotRequired["int|None"]
@@ -175,7 +174,7 @@ class Transaction(
 
         class CreateUnlinkedRefundParamsPurchaseDetailsReceipt(TypedDict):
             description: NotRequired["str|None"]
-            quantity: NotRequired["float|None"]
+            quantity: NotRequired["str|None"]
             total: NotRequired["int|None"]
             unit_cost: NotRequired["int|None"]
 
@@ -188,8 +187,8 @@ class Transaction(
                 "Literal['diesel', 'other', 'unleaded_plus', 'unleaded_regular', 'unleaded_super']|None"
             ]
             unit: NotRequired["Literal['liter', 'us_gallon']|None"]
-            unit_cost_decimal: NotRequired["float|None"]
-            volume_decimal: NotRequired["float|None"]
+            unit_cost_decimal: NotRequired["str|None"]
+            volume_decimal: NotRequired["str|None"]
 
         class CreateUnlinkedRefundParamsPurchaseDetailsFlight(TypedDict):
             departure_at: NotRequired["int|None"]

--- a/stripe/api_resources/issuing/transaction.py
+++ b/stripe/api_resources/issuing/transaction.py
@@ -10,6 +10,7 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
@@ -17,6 +18,7 @@ from typing_extensions import (
     Type,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -355,8 +357,28 @@ class Transaction(
                 ),
             )
 
-        @util.class_method_variant("_cls_refund")
+        @overload
+        @classmethod
         def refund(
+            cls,
+            transaction: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Transaction.RefundParams"]
+        ) -> "Transaction":
+            ...
+
+        @overload
+        def refund(
+            self,
+            idempotency_key: Optional[str] = None,
+            **params: Unpack["Transaction.RefundParams"]
+        ) -> "Transaction":
+            ...
+
+        @class_method_variant(_cls_refund)
+        def refund(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Transaction.RefundParams"]

--- a/stripe/api_resources/issuing/transaction.py
+++ b/stripe/api_resources/issuing/transaction.py
@@ -377,7 +377,7 @@ class Transaction(
             ...
 
         @class_method_variant("_cls_refund")
-        def refund(  # type: ignore
+        def refund(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Transaction.RefundParams"]

--- a/stripe/api_resources/issuing/transaction.py
+++ b/stripe/api_resources/issuing/transaction.py
@@ -376,7 +376,7 @@ class Transaction(
         ) -> "Transaction":
             ...
 
-        @class_method_variant(_cls_refund)
+        @class_method_variant("_cls_refund")
         def refund(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/payment_intent.py
+++ b/stripe/api_resources/payment_intent.py
@@ -2568,7 +2568,7 @@ class PaymentIntent(
         ...
 
     @class_method_variant("_cls_apply_customer_balance")
-    def apply_customer_balance(  # type: ignore
+    def apply_customer_balance(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["PaymentIntent.ApplyCustomerBalanceParams"]
@@ -2629,7 +2629,7 @@ class PaymentIntent(
         ...
 
     @class_method_variant("_cls_cancel")
-    def cancel(  # type: ignore
+    def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["PaymentIntent.CancelParams"]
@@ -2690,7 +2690,7 @@ class PaymentIntent(
         ...
 
     @class_method_variant("_cls_capture")
-    def capture(  # type: ignore
+    def capture(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["PaymentIntent.CaptureParams"]
@@ -2751,7 +2751,7 @@ class PaymentIntent(
         ...
 
     @class_method_variant("_cls_confirm")
-    def confirm(  # type: ignore
+    def confirm(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["PaymentIntent.ConfirmParams"]
@@ -2834,7 +2834,7 @@ class PaymentIntent(
         ...
 
     @class_method_variant("_cls_increment_authorization")
-    def increment_authorization(  # type: ignore
+    def increment_authorization(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["PaymentIntent.IncrementAuthorizationParams"]
@@ -2938,7 +2938,7 @@ class PaymentIntent(
         ...
 
     @class_method_variant("_cls_verify_microdeposits")
-    def verify_microdeposits(  # type: ignore
+    def verify_microdeposits(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["PaymentIntent.VerifyMicrodepositsParams"]

--- a/stripe/api_resources/payment_intent.py
+++ b/stripe/api_resources/payment_intent.py
@@ -2567,7 +2567,7 @@ class PaymentIntent(
     ) -> "PaymentIntent":
         ...
 
-    @class_method_variant(_cls_apply_customer_balance)
+    @class_method_variant("_cls_apply_customer_balance")
     def apply_customer_balance(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -2628,7 +2628,7 @@ class PaymentIntent(
     ) -> "PaymentIntent":
         ...
 
-    @class_method_variant(_cls_cancel)
+    @class_method_variant("_cls_cancel")
     def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -2689,7 +2689,7 @@ class PaymentIntent(
     ) -> "PaymentIntent":
         ...
 
-    @class_method_variant(_cls_capture)
+    @class_method_variant("_cls_capture")
     def capture(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -2750,7 +2750,7 @@ class PaymentIntent(
     ) -> "PaymentIntent":
         ...
 
-    @class_method_variant(_cls_confirm)
+    @class_method_variant("_cls_confirm")
     def confirm(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -2833,7 +2833,7 @@ class PaymentIntent(
     ) -> "PaymentIntent":
         ...
 
-    @class_method_variant(_cls_increment_authorization)
+    @class_method_variant("_cls_increment_authorization")
     def increment_authorization(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -2937,7 +2937,7 @@ class PaymentIntent(
     ) -> "PaymentIntent":
         ...
 
-    @class_method_variant(_cls_verify_microdeposits)
+    @class_method_variant("_cls_verify_microdeposits")
     def verify_microdeposits(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/payment_intent.py
+++ b/stripe/api_resources/payment_intent.py
@@ -13,13 +13,21 @@ from stripe.api_resources.search_result_object import SearchResultObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, Iterator, List, Optional, Union, cast
+from typing import (
+    ClassVar,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Union,
+    cast,
+    overload,
+)
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus

--- a/stripe/api_resources/payment_intent.py
+++ b/stripe/api_resources/payment_intent.py
@@ -12,12 +12,14 @@ from stripe.api_resources.list_object import ListObject
 from stripe.api_resources.search_result_object import SearchResultObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, Iterator, List, Optional, Union, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -2537,8 +2539,28 @@ class PaymentIntent(
             ),
         )
 
-    @util.class_method_variant("_cls_apply_customer_balance")
+    @overload
+    @classmethod
     def apply_customer_balance(
+        cls,
+        intent: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["PaymentIntent.ApplyCustomerBalanceParams"]
+    ) -> "PaymentIntent":
+        ...
+
+    @overload
+    def apply_customer_balance(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["PaymentIntent.ApplyCustomerBalanceParams"]
+    ) -> "PaymentIntent":
+        ...
+
+    @class_method_variant(_cls_apply_customer_balance)
+    def apply_customer_balance(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["PaymentIntent.ApplyCustomerBalanceParams"]
@@ -2578,8 +2600,28 @@ class PaymentIntent(
             ),
         )
 
-    @util.class_method_variant("_cls_cancel")
+    @overload
+    @classmethod
     def cancel(
+        cls,
+        intent: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["PaymentIntent.CancelParams"]
+    ) -> "PaymentIntent":
+        ...
+
+    @overload
+    def cancel(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["PaymentIntent.CancelParams"]
+    ) -> "PaymentIntent":
+        ...
+
+    @class_method_variant(_cls_cancel)
+    def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["PaymentIntent.CancelParams"]
@@ -2619,8 +2661,28 @@ class PaymentIntent(
             ),
         )
 
-    @util.class_method_variant("_cls_capture")
+    @overload
+    @classmethod
     def capture(
+        cls,
+        intent: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["PaymentIntent.CaptureParams"]
+    ) -> "PaymentIntent":
+        ...
+
+    @overload
+    def capture(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["PaymentIntent.CaptureParams"]
+    ) -> "PaymentIntent":
+        ...
+
+    @class_method_variant(_cls_capture)
+    def capture(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["PaymentIntent.CaptureParams"]
@@ -2660,8 +2722,28 @@ class PaymentIntent(
             ),
         )
 
-    @util.class_method_variant("_cls_confirm")
+    @overload
+    @classmethod
     def confirm(
+        cls,
+        intent: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["PaymentIntent.ConfirmParams"]
+    ) -> "PaymentIntent":
+        ...
+
+    @overload
+    def confirm(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["PaymentIntent.ConfirmParams"]
+    ) -> "PaymentIntent":
+        ...
+
+    @class_method_variant(_cls_confirm)
+    def confirm(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["PaymentIntent.ConfirmParams"]
@@ -2723,8 +2805,28 @@ class PaymentIntent(
             ),
         )
 
-    @util.class_method_variant("_cls_increment_authorization")
+    @overload
+    @classmethod
     def increment_authorization(
+        cls,
+        intent: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["PaymentIntent.IncrementAuthorizationParams"]
+    ) -> "PaymentIntent":
+        ...
+
+    @overload
+    def increment_authorization(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["PaymentIntent.IncrementAuthorizationParams"]
+    ) -> "PaymentIntent":
+        ...
+
+    @class_method_variant(_cls_increment_authorization)
+    def increment_authorization(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["PaymentIntent.IncrementAuthorizationParams"]
@@ -2807,8 +2909,28 @@ class PaymentIntent(
             ),
         )
 
-    @util.class_method_variant("_cls_verify_microdeposits")
+    @overload
+    @classmethod
     def verify_microdeposits(
+        cls,
+        intent: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["PaymentIntent.VerifyMicrodepositsParams"]
+    ) -> "PaymentIntent":
+        ...
+
+    @overload
+    def verify_microdeposits(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["PaymentIntent.VerifyMicrodepositsParams"]
+    ) -> "PaymentIntent":
+        ...
+
+    @class_method_variant(_cls_verify_microdeposits)
+    def verify_microdeposits(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["PaymentIntent.VerifyMicrodepositsParams"]

--- a/stripe/api_resources/payment_link.py
+++ b/stripe/api_resources/payment_link.py
@@ -10,12 +10,14 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -1047,8 +1049,28 @@ class PaymentLink(
             ),
         )
 
-    @util.class_method_variant("_cls_list_line_items")
+    @overload
+    @classmethod
     def list_line_items(
+        cls,
+        payment_link: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["PaymentLink.ListLineItemsParams"]
+    ) -> ListObject["LineItem"]:
+        ...
+
+    @overload
+    def list_line_items(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["PaymentLink.ListLineItemsParams"]
+    ) -> ListObject["LineItem"]:
+        ...
+
+    @class_method_variant(_cls_list_line_items)
+    def list_line_items(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["PaymentLink.ListLineItemsParams"]

--- a/stripe/api_resources/payment_link.py
+++ b/stripe/api_resources/payment_link.py
@@ -11,13 +11,12 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus

--- a/stripe/api_resources/payment_link.py
+++ b/stripe/api_resources/payment_link.py
@@ -1069,7 +1069,7 @@ class PaymentLink(
         ...
 
     @class_method_variant("_cls_list_line_items")
-    def list_line_items(  # type: ignore
+    def list_line_items(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["PaymentLink.ListLineItemsParams"]

--- a/stripe/api_resources/payment_link.py
+++ b/stripe/api_resources/payment_link.py
@@ -1068,7 +1068,7 @@ class PaymentLink(
     ) -> ListObject["LineItem"]:
         ...
 
-    @class_method_variant(_cls_list_line_items)
+    @class_method_variant("_cls_list_line_items")
     def list_line_items(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/payment_method.py
+++ b/stripe/api_resources/payment_method.py
@@ -450,7 +450,7 @@ class PaymentMethod(
     ) -> "PaymentMethod":
         ...
 
-    @class_method_variant(_cls_attach)
+    @class_method_variant("_cls_attach")
     def attach(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -533,7 +533,7 @@ class PaymentMethod(
     ) -> "PaymentMethod":
         ...
 
-    @class_method_variant(_cls_detach)
+    @class_method_variant("_cls_detach")
     def detach(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/payment_method.py
+++ b/stripe/api_resources/payment_method.py
@@ -11,13 +11,12 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus

--- a/stripe/api_resources/payment_method.py
+++ b/stripe/api_resources/payment_method.py
@@ -10,12 +10,14 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -429,8 +431,28 @@ class PaymentMethod(
             ),
         )
 
-    @util.class_method_variant("_cls_attach")
+    @overload
+    @classmethod
     def attach(
+        cls,
+        payment_method: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["PaymentMethod.AttachParams"]
+    ) -> "PaymentMethod":
+        ...
+
+    @overload
+    def attach(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["PaymentMethod.AttachParams"]
+    ) -> "PaymentMethod":
+        ...
+
+    @class_method_variant(_cls_attach)
+    def attach(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["PaymentMethod.AttachParams"]
@@ -492,8 +514,28 @@ class PaymentMethod(
             ),
         )
 
-    @util.class_method_variant("_cls_detach")
+    @overload
+    @classmethod
     def detach(
+        cls,
+        payment_method: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["PaymentMethod.DetachParams"]
+    ) -> "PaymentMethod":
+        ...
+
+    @overload
+    def detach(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["PaymentMethod.DetachParams"]
+    ) -> "PaymentMethod":
+        ...
+
+    @class_method_variant(_cls_detach)
+    def detach(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["PaymentMethod.DetachParams"]

--- a/stripe/api_resources/payment_method.py
+++ b/stripe/api_resources/payment_method.py
@@ -451,7 +451,7 @@ class PaymentMethod(
         ...
 
     @class_method_variant("_cls_attach")
-    def attach(  # type: ignore
+    def attach(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["PaymentMethod.AttachParams"]
@@ -534,7 +534,7 @@ class PaymentMethod(
         ...
 
     @class_method_variant("_cls_detach")
-    def detach(  # type: ignore
+    def detach(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["PaymentMethod.DetachParams"]

--- a/stripe/api_resources/payment_method_domain.py
+++ b/stripe/api_resources/payment_method_domain.py
@@ -177,7 +177,7 @@ class PaymentMethodDomain(
         ...
 
     @class_method_variant("_cls_validate")
-    def validate(  # type: ignore
+    def validate(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["PaymentMethodDomain.ValidateParams"]

--- a/stripe/api_resources/payment_method_domain.py
+++ b/stripe/api_resources/payment_method_domain.py
@@ -10,14 +10,8 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, List, Optional, cast
-from typing_extensions import (
-    Literal,
-    NotRequired,
-    Unpack,
-    overload,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, List, Optional, cast, overload
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 

--- a/stripe/api_resources/payment_method_domain.py
+++ b/stripe/api_resources/payment_method_domain.py
@@ -9,8 +9,15 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, List, Optional, cast
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    Literal,
+    NotRequired,
+    Unpack,
+    overload,
+    TYPE_CHECKING,
+)
 from urllib.parse import quote_plus
 
 
@@ -155,8 +162,28 @@ class PaymentMethodDomain(
             ),
         )
 
-    @util.class_method_variant("_cls_validate")
+    @overload
+    @classmethod
     def validate(
+        cls,
+        payment_method_domain: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["PaymentMethodDomain.ValidateParams"]
+    ) -> "PaymentMethodDomain":
+        ...
+
+    @overload
+    def validate(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["PaymentMethodDomain.ValidateParams"]
+    ) -> "PaymentMethodDomain":
+        ...
+
+    @class_method_variant(_cls_validate)
+    def validate(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["PaymentMethodDomain.ValidateParams"]

--- a/stripe/api_resources/payment_method_domain.py
+++ b/stripe/api_resources/payment_method_domain.py
@@ -176,7 +176,7 @@ class PaymentMethodDomain(
     ) -> "PaymentMethodDomain":
         ...
 
-    @class_method_variant(_cls_validate)
+    @class_method_variant("_cls_validate")
     def validate(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/payout.py
+++ b/stripe/api_resources/payout.py
@@ -9,12 +9,14 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, Union, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -144,8 +146,28 @@ class Payout(
             ),
         )
 
-    @util.class_method_variant("_cls_cancel")
+    @overload
+    @classmethod
     def cancel(
+        cls,
+        payout: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Payout.CancelParams"]
+    ) -> "Payout":
+        ...
+
+    @overload
+    def cancel(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Payout.CancelParams"]
+    ) -> "Payout":
+        ...
+
+    @class_method_variant(_cls_cancel)
+    def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Payout.CancelParams"]
@@ -250,8 +272,28 @@ class Payout(
             ),
         )
 
-    @util.class_method_variant("_cls_reverse")
+    @overload
+    @classmethod
     def reverse(
+        cls,
+        payout: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Payout.ReverseParams"]
+    ) -> "Payout":
+        ...
+
+    @overload
+    def reverse(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Payout.ReverseParams"]
+    ) -> "Payout":
+        ...
+
+    @class_method_variant(_cls_reverse)
+    def reverse(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Payout.ReverseParams"]

--- a/stripe/api_resources/payout.py
+++ b/stripe/api_resources/payout.py
@@ -166,7 +166,7 @@ class Payout(
         ...
 
     @class_method_variant("_cls_cancel")
-    def cancel(  # type: ignore
+    def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Payout.CancelParams"]
@@ -292,7 +292,7 @@ class Payout(
         ...
 
     @class_method_variant("_cls_reverse")
-    def reverse(  # type: ignore
+    def reverse(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Payout.ReverseParams"]

--- a/stripe/api_resources/payout.py
+++ b/stripe/api_resources/payout.py
@@ -165,7 +165,7 @@ class Payout(
     ) -> "Payout":
         ...
 
-    @class_method_variant(_cls_cancel)
+    @class_method_variant("_cls_cancel")
     def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -291,7 +291,7 @@ class Payout(
     ) -> "Payout":
         ...
 
-    @class_method_variant(_cls_reverse)
+    @class_method_variant("_cls_reverse")
     def reverse(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/payout.py
+++ b/stripe/api_resources/payout.py
@@ -10,13 +10,12 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, Union, cast
+from typing import ClassVar, Dict, List, Optional, Union, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus

--- a/stripe/api_resources/plan.py
+++ b/stripe/api_resources/plan.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     DeletableAPIResource,
@@ -11,12 +10,14 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, Union, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -174,8 +175,19 @@ class Plan(
             cls._static_request("delete", url, params=params),
         )
 
-    @util.class_method_variant("_cls_delete")
+    @overload
+    @classmethod
+    def delete(cls, sid: str, **params: Unpack["Plan.DeleteParams"]) -> "Plan":
+        ...
+
+    @overload
     def delete(self, **params: Unpack["Plan.DeleteParams"]) -> "Plan":
+        ...
+
+    @class_method_variant("_cls_delete")
+    def delete(  # type: ignore
+        self, **params: Unpack["Plan.DeleteParams"]
+    ) -> "Plan":
         return self._request_and_refresh(
             "delete",
             self.instance_url(),

--- a/stripe/api_resources/plan.py
+++ b/stripe/api_resources/plan.py
@@ -184,7 +184,7 @@ class Plan(
         ...
 
     @class_method_variant("_cls_delete")
-    def delete(  # type: ignore
+    def delete(  # pyright: ignore[reportGeneralTypeIssues]
         self, **params: Unpack["Plan.DeleteParams"]
     ) -> "Plan":
         return self._request_and_refresh(

--- a/stripe/api_resources/plan.py
+++ b/stripe/api_resources/plan.py
@@ -11,13 +11,12 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, Union, cast
+from typing import ClassVar, Dict, List, Optional, Union, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -52,7 +51,7 @@ class Plan(
                 "Literal['last_during_period', 'last_ever', 'max', 'sum']|None"
             ]
             amount: NotRequired["int|None"]
-            amount_decimal: NotRequired["float|None"]
+            amount_decimal: NotRequired["str|None"]
             billing_scheme: NotRequired["Literal['per_unit', 'tiered']|None"]
             currency: str
             expand: NotRequired["List[str]|None"]
@@ -76,9 +75,9 @@ class Plan(
 
         class CreateParamsTier(TypedDict):
             flat_amount: NotRequired["int|None"]
-            flat_amount_decimal: NotRequired["float|None"]
+            flat_amount_decimal: NotRequired["str|None"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
             up_to: Union[Literal["inf"], int]
 
         class CreateParamsProduct(TypedDict):
@@ -124,7 +123,7 @@ class Plan(
         Literal["last_during_period", "last_ever", "max", "sum"]
     ]
     amount: Optional[int]
-    amount_decimal: Optional[float]
+    amount_decimal: Optional[str]
     billing_scheme: Literal["per_unit", "tiered"]
     created: int
     currency: str

--- a/stripe/api_resources/price.py
+++ b/stripe/api_resources/price.py
@@ -70,7 +70,7 @@ class Price(
                 "Price.CreateParamsTransformQuantity|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsTransformQuantity(TypedDict):
             divide_by: int
@@ -78,9 +78,9 @@ class Price(
 
         class CreateParamsTier(TypedDict):
             flat_amount: NotRequired["int|None"]
-            flat_amount_decimal: NotRequired["float|None"]
+            flat_amount_decimal: NotRequired["str|None"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
             up_to: Union[Literal["inf"], int]
 
         class CreateParamsRecurring(TypedDict):
@@ -118,13 +118,13 @@ class Price(
                 "List[Price.CreateParamsCurrencyOptionsTier]|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsCurrencyOptionsTier(TypedDict):
             flat_amount: NotRequired["int|None"]
-            flat_amount_decimal: NotRequired["float|None"]
+            flat_amount_decimal: NotRequired["str|None"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
             up_to: Union[Literal["inf"], int]
 
         class CreateParamsCurrencyOptionsCustomUnitAmount(TypedDict):
@@ -183,13 +183,13 @@ class Price(
                 "List[Price.ModifyParamsCurrencyOptionsTier]|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class ModifyParamsCurrencyOptionsTier(TypedDict):
             flat_amount: NotRequired["int|None"]
-            flat_amount_decimal: NotRequired["float|None"]
+            flat_amount_decimal: NotRequired["str|None"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
             up_to: Union[Literal["inf"], int]
 
         class ModifyParamsCurrencyOptionsCustomUnitAmount(TypedDict):
@@ -227,7 +227,7 @@ class Price(
     transform_quantity: Optional[StripeObject]
     type: Literal["one_time", "recurring"]
     unit_amount: Optional[int]
-    unit_amount_decimal: Optional[float]
+    unit_amount_decimal: Optional[str]
     deleted: Optional[Literal[True]]
 
     @classmethod

--- a/stripe/api_resources/product.py
+++ b/stripe/api_resources/product.py
@@ -13,13 +13,21 @@ from stripe.api_resources.search_result_object import SearchResultObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, Iterator, List, Optional, Union, cast
+from typing import (
+    ClassVar,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Union,
+    cast,
+    overload,
+)
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -93,7 +101,7 @@ class Product(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsDefaultPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]
@@ -110,13 +118,13 @@ class Product(
                 "List[Product.CreateParamsDefaultPriceDataCurrencyOptionsTier]|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsDefaultPriceDataCurrencyOptionsTier(TypedDict):
             flat_amount: NotRequired["int|None"]
-            flat_amount_decimal: NotRequired["float|None"]
+            flat_amount_decimal: NotRequired["str|None"]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
             up_to: Union[Literal["inf"], int]
 
         class CreateParamsDefaultPriceDataCurrencyOptionsCustomUnitAmount(

--- a/stripe/api_resources/product.py
+++ b/stripe/api_resources/product.py
@@ -259,7 +259,7 @@ class Product(
         ...
 
     @class_method_variant("_cls_delete")
-    def delete(  # type: ignore
+    def delete(  # pyright: ignore[reportGeneralTypeIssues]
         self, **params: Unpack["Product.DeleteParams"]
     ) -> "Product":
         return self._request_and_refresh(

--- a/stripe/api_resources/product.py
+++ b/stripe/api_resources/product.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     DeletableAPIResource,
@@ -13,12 +12,14 @@ from stripe.api_resources.list_object import ListObject
 from stripe.api_resources.search_result_object import SearchResultObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, Iterator, List, Optional, Union, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -238,8 +239,21 @@ class Product(
             cls._static_request("delete", url, params=params),
         )
 
-    @util.class_method_variant("_cls_delete")
+    @overload
+    @classmethod
+    def delete(
+        cls, sid: str, **params: Unpack["Product.DeleteParams"]
+    ) -> "Product":
+        ...
+
+    @overload
     def delete(self, **params: Unpack["Product.DeleteParams"]) -> "Product":
+        ...
+
+    @class_method_variant("_cls_delete")
+    def delete(  # type: ignore
+        self, **params: Unpack["Product.DeleteParams"]
+    ) -> "Product":
         return self._request_and_refresh(
             "delete",
             self.instance_url(),

--- a/stripe/api_resources/quote.py
+++ b/stripe/api_resources/quote.py
@@ -318,7 +318,7 @@ class Quote(
     ) -> "Quote":
         ...
 
-    @class_method_variant(_cls_accept)
+    @class_method_variant("_cls_accept")
     def accept(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -379,7 +379,7 @@ class Quote(
     ) -> "Quote":
         ...
 
-    @class_method_variant(_cls_cancel)
+    @class_method_variant("_cls_cancel")
     def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -462,7 +462,7 @@ class Quote(
     ) -> "Quote":
         ...
 
-    @class_method_variant(_cls_finalize_quote)
+    @class_method_variant("_cls_finalize_quote")
     def finalize_quote(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -548,7 +548,7 @@ class Quote(
     ) -> ListObject["LineItem"]:
         ...
 
-    @class_method_variant(_cls_list_computed_upfront_line_items)
+    @class_method_variant("_cls_list_computed_upfront_line_items")
     def list_computed_upfront_line_items(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -609,7 +609,7 @@ class Quote(
     ) -> ListObject["LineItem"]:
         ...
 
-    @class_method_variant(_cls_list_line_items)
+    @class_method_variant("_cls_list_line_items")
     def list_line_items(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/quote.py
+++ b/stripe/api_resources/quote.py
@@ -11,12 +11,14 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -297,8 +299,28 @@ class Quote(
             ),
         )
 
-    @util.class_method_variant("_cls_accept")
+    @overload
+    @classmethod
     def accept(
+        cls,
+        quote: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Quote.AcceptParams"]
+    ) -> "Quote":
+        ...
+
+    @overload
+    def accept(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Quote.AcceptParams"]
+    ) -> "Quote":
+        ...
+
+    @class_method_variant(_cls_accept)
+    def accept(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Quote.AcceptParams"]
@@ -338,8 +360,28 @@ class Quote(
             ),
         )
 
-    @util.class_method_variant("_cls_cancel")
+    @overload
+    @classmethod
     def cancel(
+        cls,
+        quote: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Quote.CancelParams"]
+    ) -> "Quote":
+        ...
+
+    @overload
+    def cancel(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Quote.CancelParams"]
+    ) -> "Quote":
+        ...
+
+    @class_method_variant(_cls_cancel)
+    def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Quote.CancelParams"]
@@ -401,8 +443,28 @@ class Quote(
             ),
         )
 
-    @util.class_method_variant("_cls_finalize_quote")
+    @overload
+    @classmethod
     def finalize_quote(
+        cls,
+        quote: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Quote.FinalizeQuoteParams"]
+    ) -> "Quote":
+        ...
+
+    @overload
+    def finalize_quote(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Quote.FinalizeQuoteParams"]
+    ) -> "Quote":
+        ...
+
+    @class_method_variant(_cls_finalize_quote)
+    def finalize_quote(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Quote.FinalizeQuoteParams"]
@@ -467,8 +529,28 @@ class Quote(
             ),
         )
 
-    @util.class_method_variant("_cls_list_computed_upfront_line_items")
+    @overload
+    @classmethod
     def list_computed_upfront_line_items(
+        cls,
+        quote: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Quote.ListComputedUpfrontLineItemsParams"]
+    ) -> ListObject["LineItem"]:
+        ...
+
+    @overload
+    def list_computed_upfront_line_items(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Quote.ListComputedUpfrontLineItemsParams"]
+    ) -> ListObject["LineItem"]:
+        ...
+
+    @class_method_variant(_cls_list_computed_upfront_line_items)
+    def list_computed_upfront_line_items(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Quote.ListComputedUpfrontLineItemsParams"]
@@ -508,8 +590,28 @@ class Quote(
             ),
         )
 
-    @util.class_method_variant("_cls_list_line_items")
+    @overload
+    @classmethod
     def list_line_items(
+        cls,
+        quote: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Quote.ListLineItemsParams"]
+    ) -> ListObject["LineItem"]:
+        ...
+
+    @overload
+    def list_line_items(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Quote.ListLineItemsParams"]
+    ) -> ListObject["LineItem"]:
+        ...
+
+    @class_method_variant(_cls_list_line_items)
+    def list_line_items(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Quote.ListLineItemsParams"]
@@ -569,8 +671,32 @@ class Quote(
         response, _ = requestor.request_stream("get", url, params, headers)
         return response
 
-    @util.class_method_variant("_cls_pdf")
+    @overload
+    @classmethod
     def pdf(
+        cls,
+        sid,
+        api_key=None,
+        idempotency_key=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        ...
+
+    @overload
+    def pdf(
+        self,
+        api_key=None,
+        api_version=None,
+        stripe_version=None,
+        stripe_account=None,
+        **params
+    ):
+        ...
+
+    @util.class_method_variant("_cls_pdf")
+    def pdf(  # type: ignore
         self,
         api_key=None,
         api_version=None,

--- a/stripe/api_resources/quote.py
+++ b/stripe/api_resources/quote.py
@@ -12,13 +12,12 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -115,7 +114,7 @@ class Quote(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsLineItemPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]
@@ -221,7 +220,7 @@ class Quote(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class ModifyParamsLineItemPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]

--- a/stripe/api_resources/quote.py
+++ b/stripe/api_resources/quote.py
@@ -319,7 +319,7 @@ class Quote(
         ...
 
     @class_method_variant("_cls_accept")
-    def accept(  # type: ignore
+    def accept(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Quote.AcceptParams"]
@@ -380,7 +380,7 @@ class Quote(
         ...
 
     @class_method_variant("_cls_cancel")
-    def cancel(  # type: ignore
+    def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Quote.CancelParams"]
@@ -463,7 +463,7 @@ class Quote(
         ...
 
     @class_method_variant("_cls_finalize_quote")
-    def finalize_quote(  # type: ignore
+    def finalize_quote(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Quote.FinalizeQuoteParams"]
@@ -549,7 +549,7 @@ class Quote(
         ...
 
     @class_method_variant("_cls_list_computed_upfront_line_items")
-    def list_computed_upfront_line_items(  # type: ignore
+    def list_computed_upfront_line_items(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Quote.ListComputedUpfrontLineItemsParams"]
@@ -610,7 +610,7 @@ class Quote(
         ...
 
     @class_method_variant("_cls_list_line_items")
-    def list_line_items(  # type: ignore
+    def list_line_items(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Quote.ListLineItemsParams"]

--- a/stripe/api_resources/radar/value_list.py
+++ b/stripe/api_resources/radar/value_list.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     DeletableAPIResource,
@@ -9,12 +8,14 @@ from stripe.api_resources.abstract import (
 )
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -129,8 +130,21 @@ class ValueList(
             cls._static_request("delete", url, params=params),
         )
 
-    @util.class_method_variant("_cls_delete")
+    @overload
+    @classmethod
     def delete(
+        cls, sid: str, **params: Unpack["ValueList.DeleteParams"]
+    ) -> "ValueList":
+        ...
+
+    @overload
+    def delete(
+        self, **params: Unpack["ValueList.DeleteParams"]
+    ) -> "ValueList":
+        ...
+
+    @class_method_variant("_cls_delete")
+    def delete(  # type: ignore
         self, **params: Unpack["ValueList.DeleteParams"]
     ) -> "ValueList":
         return self._request_and_refresh(

--- a/stripe/api_resources/radar/value_list.py
+++ b/stripe/api_resources/radar/value_list.py
@@ -143,7 +143,7 @@ class ValueList(
         ...
 
     @class_method_variant("_cls_delete")
-    def delete(  # type: ignore
+    def delete(  # pyright: ignore[reportGeneralTypeIssues]
         self, **params: Unpack["ValueList.DeleteParams"]
     ) -> "ValueList":
         return self._request_and_refresh(

--- a/stripe/api_resources/radar/value_list.py
+++ b/stripe/api_resources/radar/value_list.py
@@ -9,13 +9,12 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus

--- a/stripe/api_resources/radar/value_list_item.py
+++ b/stripe/api_resources/radar/value_list_item.py
@@ -8,13 +8,12 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.util import class_method_variant
-from typing import ClassVar, List, Optional, cast
+from typing import ClassVar, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus

--- a/stripe/api_resources/radar/value_list_item.py
+++ b/stripe/api_resources/radar/value_list_item.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     DeletableAPIResource,
@@ -8,12 +7,14 @@ from stripe.api_resources.abstract import (
 )
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
+from stripe.util import class_method_variant
 from typing import ClassVar, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -102,8 +103,21 @@ class ValueListItem(
             cls._static_request("delete", url, params=params),
         )
 
-    @util.class_method_variant("_cls_delete")
+    @overload
+    @classmethod
     def delete(
+        cls, sid: str, **params: Unpack["ValueListItem.DeleteParams"]
+    ) -> "ValueListItem":
+        ...
+
+    @overload
+    def delete(
+        self, **params: Unpack["ValueListItem.DeleteParams"]
+    ) -> "ValueListItem":
+        ...
+
+    @class_method_variant("_cls_delete")
+    def delete(  # type: ignore
         self, **params: Unpack["ValueListItem.DeleteParams"]
     ) -> "ValueListItem":
         return self._request_and_refresh(

--- a/stripe/api_resources/radar/value_list_item.py
+++ b/stripe/api_resources/radar/value_list_item.py
@@ -116,7 +116,7 @@ class ValueListItem(
         ...
 
     @class_method_variant("_cls_delete")
-    def delete(  # type: ignore
+    def delete(  # pyright: ignore[reportGeneralTypeIssues]
         self, **params: Unpack["ValueListItem.DeleteParams"]
     ) -> "ValueListItem":
         return self._request_and_refresh(

--- a/stripe/api_resources/refund.py
+++ b/stripe/api_resources/refund.py
@@ -146,7 +146,7 @@ class Refund(
     ) -> "Refund":
         ...
 
-    @class_method_variant(_cls_cancel)
+    @class_method_variant("_cls_cancel")
     def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -275,7 +275,7 @@ class Refund(
         ) -> "Refund":
             ...
 
-        @class_method_variant(_cls_expire)
+        @class_method_variant("_cls_expire")
         def expire(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/refund.py
+++ b/stripe/api_resources/refund.py
@@ -11,8 +11,16 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
-from typing_extensions import Literal, NotRequired, Type, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    Literal,
+    NotRequired,
+    Type,
+    Unpack,
+    overload,
+    TYPE_CHECKING,
+)
 from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
@@ -125,8 +133,28 @@ class Refund(
             ),
         )
 
-    @util.class_method_variant("_cls_cancel")
+    @overload
+    @classmethod
     def cancel(
+        cls,
+        refund: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Refund.CancelParams"]
+    ) -> "Refund":
+        ...
+
+    @overload
+    def cancel(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Refund.CancelParams"]
+    ) -> "Refund":
+        ...
+
+    @class_method_variant(_cls_cancel)
+    def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Refund.CancelParams"]
@@ -234,8 +262,28 @@ class Refund(
                 ),
             )
 
-        @util.class_method_variant("_cls_expire")
+        @overload
+        @classmethod
         def expire(
+            cls,
+            refund: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Refund.ExpireParams"]
+        ) -> "Refund":
+            ...
+
+        @overload
+        def expire(
+            self,
+            idempotency_key: Optional[str] = None,
+            **params: Unpack["Refund.ExpireParams"]
+        ) -> "Refund":
+            ...
+
+        @class_method_variant(_cls_expire)
+        def expire(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Refund.ExpireParams"]

--- a/stripe/api_resources/refund.py
+++ b/stripe/api_resources/refund.py
@@ -12,15 +12,8 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
-from typing_extensions import (
-    Literal,
-    NotRequired,
-    Type,
-    Unpack,
-    overload,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, Dict, List, Optional, cast, overload
+from typing_extensions import Literal, NotRequired, Type, Unpack, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 if TYPE_CHECKING:

--- a/stripe/api_resources/refund.py
+++ b/stripe/api_resources/refund.py
@@ -147,7 +147,7 @@ class Refund(
         ...
 
     @class_method_variant("_cls_cancel")
-    def cancel(  # type: ignore
+    def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Refund.CancelParams"]
@@ -276,7 +276,7 @@ class Refund(
             ...
 
         @class_method_variant("_cls_expire")
-        def expire(  # type: ignore
+        def expire(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Refund.ExpireParams"]

--- a/stripe/api_resources/review.py
+++ b/stripe/api_resources/review.py
@@ -6,12 +6,14 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 
@@ -92,8 +94,28 @@ class Review(ListableAPIResource["Review"]):
             ),
         )
 
-    @util.class_method_variant("_cls_approve")
+    @overload
+    @classmethod
     def approve(
+        cls,
+        review: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Review.ApproveParams"]
+    ) -> "Review":
+        ...
+
+    @overload
+    def approve(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Review.ApproveParams"]
+    ) -> "Review":
+        ...
+
+    @class_method_variant(_cls_approve)
+    def approve(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Review.ApproveParams"]

--- a/stripe/api_resources/review.py
+++ b/stripe/api_resources/review.py
@@ -113,7 +113,7 @@ class Review(ListableAPIResource["Review"]):
     ) -> "Review":
         ...
 
-    @class_method_variant(_cls_approve)
+    @class_method_variant("_cls_approve")
     def approve(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/review.py
+++ b/stripe/api_resources/review.py
@@ -7,13 +7,12 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, List, Optional, cast
+from typing import ClassVar, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 

--- a/stripe/api_resources/review.py
+++ b/stripe/api_resources/review.py
@@ -114,7 +114,7 @@ class Review(ListableAPIResource["Review"]):
         ...
 
     @class_method_variant("_cls_approve")
-    def approve(  # type: ignore
+    def approve(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Review.ApproveParams"]

--- a/stripe/api_resources/setup_intent.py
+++ b/stripe/api_resources/setup_intent.py
@@ -11,13 +11,12 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus

--- a/stripe/api_resources/setup_intent.py
+++ b/stripe/api_resources/setup_intent.py
@@ -1509,7 +1509,7 @@ class SetupIntent(
     ) -> "SetupIntent":
         ...
 
-    @class_method_variant(_cls_cancel)
+    @class_method_variant("_cls_cancel")
     def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -1570,7 +1570,7 @@ class SetupIntent(
     ) -> "SetupIntent":
         ...
 
-    @class_method_variant(_cls_confirm)
+    @class_method_variant("_cls_confirm")
     def confirm(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -1696,7 +1696,7 @@ class SetupIntent(
     ) -> "SetupIntent":
         ...
 
-    @class_method_variant(_cls_verify_microdeposits)
+    @class_method_variant("_cls_verify_microdeposits")
     def verify_microdeposits(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/setup_intent.py
+++ b/stripe/api_resources/setup_intent.py
@@ -1510,7 +1510,7 @@ class SetupIntent(
         ...
 
     @class_method_variant("_cls_cancel")
-    def cancel(  # type: ignore
+    def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["SetupIntent.CancelParams"]
@@ -1571,7 +1571,7 @@ class SetupIntent(
         ...
 
     @class_method_variant("_cls_confirm")
-    def confirm(  # type: ignore
+    def confirm(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["SetupIntent.ConfirmParams"]
@@ -1697,7 +1697,7 @@ class SetupIntent(
         ...
 
     @class_method_variant("_cls_verify_microdeposits")
-    def verify_microdeposits(  # type: ignore
+    def verify_microdeposits(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["SetupIntent.VerifyMicrodepositsParams"]

--- a/stripe/api_resources/setup_intent.py
+++ b/stripe/api_resources/setup_intent.py
@@ -10,12 +10,14 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -1488,8 +1490,28 @@ class SetupIntent(
             ),
         )
 
-    @util.class_method_variant("_cls_cancel")
+    @overload
+    @classmethod
     def cancel(
+        cls,
+        intent: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["SetupIntent.CancelParams"]
+    ) -> "SetupIntent":
+        ...
+
+    @overload
+    def cancel(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["SetupIntent.CancelParams"]
+    ) -> "SetupIntent":
+        ...
+
+    @class_method_variant(_cls_cancel)
+    def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["SetupIntent.CancelParams"]
@@ -1529,8 +1551,28 @@ class SetupIntent(
             ),
         )
 
-    @util.class_method_variant("_cls_confirm")
+    @overload
+    @classmethod
     def confirm(
+        cls,
+        intent: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["SetupIntent.ConfirmParams"]
+    ) -> "SetupIntent":
+        ...
+
+    @overload
+    def confirm(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["SetupIntent.ConfirmParams"]
+    ) -> "SetupIntent":
+        ...
+
+    @class_method_variant(_cls_confirm)
+    def confirm(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["SetupIntent.ConfirmParams"]
@@ -1635,8 +1677,28 @@ class SetupIntent(
             ),
         )
 
-    @util.class_method_variant("_cls_verify_microdeposits")
+    @overload
+    @classmethod
     def verify_microdeposits(
+        cls,
+        intent: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["SetupIntent.VerifyMicrodepositsParams"]
+    ) -> "SetupIntent":
+        ...
+
+    @overload
+    def verify_microdeposits(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["SetupIntent.VerifyMicrodepositsParams"]
+    ) -> "SetupIntent":
+        ...
+
+    @class_method_variant(_cls_verify_microdeposits)
+    def verify_microdeposits(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["SetupIntent.VerifyMicrodepositsParams"]

--- a/stripe/api_resources/source.py
+++ b/stripe/api_resources/source.py
@@ -9,12 +9,14 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -352,8 +354,28 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
             ),
         )
 
-    @util.class_method_variant("_cls_list_source_transactions")
+    @overload
+    @classmethod
     def list_source_transactions(
+        cls,
+        source: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Source.ListSourceTransactionsParams"]
+    ) -> ListObject["SourceTransaction"]:
+        ...
+
+    @overload
+    def list_source_transactions(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Source.ListSourceTransactionsParams"]
+    ) -> ListObject["SourceTransaction"]:
+        ...
+
+    @class_method_variant(_cls_list_source_transactions)
+    def list_source_transactions(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Source.ListSourceTransactionsParams"]
@@ -411,8 +433,28 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
             ),
         )
 
-    @util.class_method_variant("_cls_verify")
+    @overload
+    @classmethod
     def verify(
+        cls,
+        source: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Source.VerifyParams"]
+    ) -> "Source":
+        ...
+
+    @overload
+    def verify(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Source.VerifyParams"]
+    ) -> "Source":
+        ...
+
+    @class_method_variant(_cls_verify)
+    def verify(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Source.VerifyParams"]

--- a/stripe/api_resources/source.py
+++ b/stripe/api_resources/source.py
@@ -10,13 +10,12 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus

--- a/stripe/api_resources/source.py
+++ b/stripe/api_resources/source.py
@@ -374,7 +374,7 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
         ...
 
     @class_method_variant("_cls_list_source_transactions")
-    def list_source_transactions(  # type: ignore
+    def list_source_transactions(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Source.ListSourceTransactionsParams"]
@@ -453,7 +453,7 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
         ...
 
     @class_method_variant("_cls_verify")
-    def verify(  # type: ignore
+    def verify(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Source.VerifyParams"]

--- a/stripe/api_resources/source.py
+++ b/stripe/api_resources/source.py
@@ -373,7 +373,7 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
     ) -> ListObject["SourceTransaction"]:
         ...
 
-    @class_method_variant(_cls_list_source_transactions)
+    @class_method_variant("_cls_list_source_transactions")
     def list_source_transactions(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -452,7 +452,7 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
     ) -> "Source":
         ...
 
-    @class_method_variant(_cls_verify)
+    @class_method_variant("_cls_verify")
     def verify(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/subscription.py
+++ b/stripe/api_resources/subscription.py
@@ -14,13 +14,21 @@ from stripe.api_resources.search_result_object import SearchResultObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, Iterator, List, Optional, Union, cast
+from typing import (
+    ClassVar,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Union,
+    cast,
+    overload,
+)
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -280,7 +288,7 @@ class Subscription(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsItemPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]
@@ -311,7 +319,7 @@ class Subscription(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class DeleteDiscountParams(RequestOptions):
             pass
@@ -583,7 +591,7 @@ class Subscription(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class ModifyParamsItemPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]
@@ -620,7 +628,7 @@ class Subscription(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class ResumeParams(RequestOptions):
             billing_cycle_anchor: NotRequired[

--- a/stripe/api_resources/subscription.py
+++ b/stripe/api_resources/subscription.py
@@ -13,12 +13,14 @@ from stripe.api_resources.list_object import ListObject
 from stripe.api_resources.search_result_object import SearchResultObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, Iterator, List, Optional, Union, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -719,8 +721,28 @@ class Subscription(
             ),
         )
 
-    @util.class_method_variant("_cls_cancel")
+    @overload
+    @classmethod
     def cancel(
+        cls,
+        subscription_exposed_id: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Subscription.CancelParams"]
+    ) -> "Subscription":
+        ...
+
+    @overload
+    def cancel(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Subscription.CancelParams"]
+    ) -> "Subscription":
+        ...
+
+    @class_method_variant(_cls_cancel)
+    def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Subscription.CancelParams"]
@@ -784,8 +806,28 @@ class Subscription(
             ),
         )
 
-    @util.class_method_variant("_cls_delete_discount")
+    @overload
+    @classmethod
     def delete_discount(
+        cls,
+        subscription_exposed_id: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Subscription.DeleteDiscountParams"]
+    ) -> "Discount":
+        ...
+
+    @overload
+    def delete_discount(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Subscription.DeleteDiscountParams"]
+    ) -> "Discount":
+        ...
+
+    @class_method_variant(_cls_delete_discount)
+    def delete_discount(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Subscription.DeleteDiscountParams"]
@@ -860,8 +902,28 @@ class Subscription(
             ),
         )
 
-    @util.class_method_variant("_cls_resume")
+    @overload
+    @classmethod
     def resume(
+        cls,
+        subscription: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Subscription.ResumeParams"]
+    ) -> "Subscription":
+        ...
+
+    @overload
+    def resume(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Subscription.ResumeParams"]
+    ) -> "Subscription":
+        ...
+
+    @class_method_variant(_cls_resume)
+    def resume(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Subscription.ResumeParams"]

--- a/stripe/api_resources/subscription.py
+++ b/stripe/api_resources/subscription.py
@@ -749,7 +749,7 @@ class Subscription(
     ) -> "Subscription":
         ...
 
-    @class_method_variant(_cls_cancel)
+    @class_method_variant("_cls_cancel")
     def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -834,7 +834,7 @@ class Subscription(
     ) -> "Discount":
         ...
 
-    @class_method_variant(_cls_delete_discount)
+    @class_method_variant("_cls_delete_discount")
     def delete_discount(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -930,7 +930,7 @@ class Subscription(
     ) -> "Subscription":
         ...
 
-    @class_method_variant(_cls_resume)
+    @class_method_variant("_cls_resume")
     def resume(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/subscription.py
+++ b/stripe/api_resources/subscription.py
@@ -750,7 +750,7 @@ class Subscription(
         ...
 
     @class_method_variant("_cls_cancel")
-    def cancel(  # type: ignore
+    def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Subscription.CancelParams"]
@@ -835,7 +835,7 @@ class Subscription(
         ...
 
     @class_method_variant("_cls_delete_discount")
-    def delete_discount(  # type: ignore
+    def delete_discount(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Subscription.DeleteDiscountParams"]
@@ -931,7 +931,7 @@ class Subscription(
         ...
 
     @class_method_variant("_cls_resume")
-    def resume(  # type: ignore
+    def resume(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Subscription.ResumeParams"]

--- a/stripe/api_resources/subscription_item.py
+++ b/stripe/api_resources/subscription_item.py
@@ -211,7 +211,7 @@ class SubscriptionItem(
         ...
 
     @class_method_variant("_cls_delete")
-    def delete(  # type: ignore
+    def delete(  # pyright: ignore[reportGeneralTypeIssues]
         self, **params: Unpack["SubscriptionItem.DeleteParams"]
     ) -> "SubscriptionItem":
         return self._request_and_refresh(

--- a/stripe/api_resources/subscription_item.py
+++ b/stripe/api_resources/subscription_item.py
@@ -11,12 +11,14 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -196,8 +198,21 @@ class SubscriptionItem(
             cls._static_request("delete", url, params=params),
         )
 
-    @util.class_method_variant("_cls_delete")
+    @overload
+    @classmethod
     def delete(
+        cls, sid: str, **params: Unpack["SubscriptionItem.DeleteParams"]
+    ) -> "SubscriptionItem":
+        ...
+
+    @overload
+    def delete(
+        self, **params: Unpack["SubscriptionItem.DeleteParams"]
+    ) -> "SubscriptionItem":
+        ...
+
+    @class_method_variant("_cls_delete")
+    def delete(  # type: ignore
         self, **params: Unpack["SubscriptionItem.DeleteParams"]
     ) -> "SubscriptionItem":
         return self._request_and_refresh(

--- a/stripe/api_resources/subscription_item.py
+++ b/stripe/api_resources/subscription_item.py
@@ -12,13 +12,12 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -77,7 +76,7 @@ class SubscriptionItem(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]
@@ -130,7 +129,7 @@ class SubscriptionItem(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class ModifyParamsPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]

--- a/stripe/api_resources/subscription_schedule.py
+++ b/stripe/api_resources/subscription_schedule.py
@@ -474,7 +474,7 @@ class SubscriptionSchedule(
         ...
 
     @class_method_variant("_cls_cancel")
-    def cancel(  # type: ignore
+    def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["SubscriptionSchedule.CancelParams"]
@@ -592,7 +592,7 @@ class SubscriptionSchedule(
         ...
 
     @class_method_variant("_cls_release")
-    def release(  # type: ignore
+    def release(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["SubscriptionSchedule.ReleaseParams"]

--- a/stripe/api_resources/subscription_schedule.py
+++ b/stripe/api_resources/subscription_schedule.py
@@ -10,12 +10,14 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -452,8 +454,28 @@ class SubscriptionSchedule(
             ),
         )
 
-    @util.class_method_variant("_cls_cancel")
+    @overload
+    @classmethod
     def cancel(
+        cls,
+        schedule: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["SubscriptionSchedule.CancelParams"]
+    ) -> "SubscriptionSchedule":
+        ...
+
+    @overload
+    def cancel(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["SubscriptionSchedule.CancelParams"]
+    ) -> "SubscriptionSchedule":
+        ...
+
+    @class_method_variant(_cls_cancel)
+    def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["SubscriptionSchedule.CancelParams"]
@@ -550,8 +572,28 @@ class SubscriptionSchedule(
             ),
         )
 
-    @util.class_method_variant("_cls_release")
+    @overload
+    @classmethod
     def release(
+        cls,
+        schedule: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["SubscriptionSchedule.ReleaseParams"]
+    ) -> "SubscriptionSchedule":
+        ...
+
+    @overload
+    def release(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["SubscriptionSchedule.ReleaseParams"]
+    ) -> "SubscriptionSchedule":
+        ...
+
+    @class_method_variant(_cls_release)
+    def release(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["SubscriptionSchedule.ReleaseParams"]

--- a/stripe/api_resources/subscription_schedule.py
+++ b/stripe/api_resources/subscription_schedule.py
@@ -11,13 +11,12 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -130,7 +129,7 @@ class SubscriptionSchedule(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsPhaseItemPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]
@@ -164,7 +163,7 @@ class SubscriptionSchedule(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class CreateParamsDefaultSettings(TypedDict):
             application_fee_percent: NotRequired["float|None"]
@@ -329,7 +328,7 @@ class SubscriptionSchedule(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class ModifyParamsPhaseItemPriceDataRecurring(TypedDict):
             interval: Literal["day", "month", "week", "year"]
@@ -363,7 +362,7 @@ class SubscriptionSchedule(
                 "Literal['exclusive', 'inclusive', 'unspecified']|None"
             ]
             unit_amount: NotRequired["int|None"]
-            unit_amount_decimal: NotRequired["float|None"]
+            unit_amount_decimal: NotRequired["str|None"]
 
         class ModifyParamsDefaultSettings(TypedDict):
             application_fee_percent: NotRequired["float|None"]

--- a/stripe/api_resources/subscription_schedule.py
+++ b/stripe/api_resources/subscription_schedule.py
@@ -473,7 +473,7 @@ class SubscriptionSchedule(
     ) -> "SubscriptionSchedule":
         ...
 
-    @class_method_variant(_cls_cancel)
+    @class_method_variant("_cls_cancel")
     def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -591,7 +591,7 @@ class SubscriptionSchedule(
     ) -> "SubscriptionSchedule":
         ...
 
-    @class_method_variant(_cls_release)
+    @class_method_variant("_cls_release")
     def release(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/tax/calculation.py
+++ b/stripe/api_resources/tax/calculation.py
@@ -236,7 +236,7 @@ class Calculation(CreateableAPIResource["Calculation"]):
     ) -> ListObject["CalculationLineItem"]:
         ...
 
-    @class_method_variant(_cls_list_line_items)
+    @class_method_variant("_cls_list_line_items")
     def list_line_items(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/tax/calculation.py
+++ b/stripe/api_resources/tax/calculation.py
@@ -237,7 +237,7 @@ class Calculation(CreateableAPIResource["Calculation"]):
         ...
 
     @class_method_variant("_cls_list_line_items")
-    def list_line_items(  # type: ignore
+    def list_line_items(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Calculation.ListLineItemsParams"]

--- a/stripe/api_resources/tax/calculation.py
+++ b/stripe/api_resources/tax/calculation.py
@@ -6,13 +6,12 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, List, Optional, cast
+from typing import ClassVar, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 

--- a/stripe/api_resources/tax/calculation.py
+++ b/stripe/api_resources/tax/calculation.py
@@ -5,12 +5,14 @@ from stripe.api_resources.abstract import CreateableAPIResource
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 
@@ -215,8 +217,28 @@ class Calculation(CreateableAPIResource["Calculation"]):
             ),
         )
 
-    @util.class_method_variant("_cls_list_line_items")
+    @overload
+    @classmethod
     def list_line_items(
+        cls,
+        calculation: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Calculation.ListLineItemsParams"]
+    ) -> ListObject["CalculationLineItem"]:
+        ...
+
+    @overload
+    def list_line_items(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Calculation.ListLineItemsParams"]
+    ) -> ListObject["CalculationLineItem"]:
+        ...
+
+    @class_method_variant(_cls_list_line_items)
+    def list_line_items(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Calculation.ListLineItemsParams"]

--- a/stripe/api_resources/tax/transaction.py
+++ b/stripe/api_resources/tax/transaction.py
@@ -6,13 +6,12 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 

--- a/stripe/api_resources/tax/transaction.py
+++ b/stripe/api_resources/tax/transaction.py
@@ -170,7 +170,7 @@ class Transaction(APIResource["Transaction"]):
     ) -> ListObject["TransactionLineItem"]:
         ...
 
-    @class_method_variant(_cls_list_line_items)
+    @class_method_variant("_cls_list_line_items")
     def list_line_items(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/tax/transaction.py
+++ b/stripe/api_resources/tax/transaction.py
@@ -171,7 +171,7 @@ class Transaction(APIResource["Transaction"]):
         ...
 
     @class_method_variant("_cls_list_line_items")
-    def list_line_items(  # type: ignore
+    def list_line_items(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Transaction.ListLineItemsParams"]

--- a/stripe/api_resources/tax/transaction.py
+++ b/stripe/api_resources/tax/transaction.py
@@ -5,12 +5,14 @@ from stripe.api_resources.abstract import APIResource
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 
@@ -149,8 +151,28 @@ class Transaction(APIResource["Transaction"]):
             ),
         )
 
-    @util.class_method_variant("_cls_list_line_items")
+    @overload
+    @classmethod
     def list_line_items(
+        cls,
+        transaction: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Transaction.ListLineItemsParams"]
+    ) -> ListObject["TransactionLineItem"]:
+        ...
+
+    @overload
+    def list_line_items(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Transaction.ListLineItemsParams"]
+    ) -> ListObject["TransactionLineItem"]:
+        ...
+
+    @class_method_variant(_cls_list_line_items)
+    def list_line_items(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Transaction.ListLineItemsParams"]

--- a/stripe/api_resources/terminal/configuration.py
+++ b/stripe/api_resources/terminal/configuration.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     DeletableAPIResource,
@@ -10,12 +9,14 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -311,8 +312,21 @@ class Configuration(
             cls._static_request("delete", url, params=params),
         )
 
-    @util.class_method_variant("_cls_delete")
+    @overload
+    @classmethod
     def delete(
+        cls, sid: str, **params: Unpack["Configuration.DeleteParams"]
+    ) -> "Configuration":
+        ...
+
+    @overload
+    def delete(
+        self, **params: Unpack["Configuration.DeleteParams"]
+    ) -> "Configuration":
+        ...
+
+    @class_method_variant("_cls_delete")
+    def delete(  # type: ignore
         self, **params: Unpack["Configuration.DeleteParams"]
     ) -> "Configuration":
         return self._request_and_refresh(

--- a/stripe/api_resources/terminal/configuration.py
+++ b/stripe/api_resources/terminal/configuration.py
@@ -10,13 +10,12 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, List, Optional, cast
+from typing import ClassVar, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus

--- a/stripe/api_resources/terminal/configuration.py
+++ b/stripe/api_resources/terminal/configuration.py
@@ -325,7 +325,7 @@ class Configuration(
         ...
 
     @class_method_variant("_cls_delete")
-    def delete(  # type: ignore
+    def delete(  # pyright: ignore[reportGeneralTypeIssues]
         self, **params: Unpack["Configuration.DeleteParams"]
     ) -> "Configuration":
         return self._request_and_refresh(

--- a/stripe/api_resources/terminal/location.py
+++ b/stripe/api_resources/terminal/location.py
@@ -131,7 +131,7 @@ class Location(
         ...
 
     @class_method_variant("_cls_delete")
-    def delete(  # type: ignore
+    def delete(  # pyright: ignore[reportGeneralTypeIssues]
         self, **params: Unpack["Location.DeleteParams"]
     ) -> "Location":
         return self._request_and_refresh(

--- a/stripe/api_resources/terminal/location.py
+++ b/stripe/api_resources/terminal/location.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     DeletableAPIResource,
@@ -10,12 +9,14 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -119,8 +120,21 @@ class Location(
             cls._static_request("delete", url, params=params),
         )
 
-    @util.class_method_variant("_cls_delete")
+    @overload
+    @classmethod
+    def delete(
+        cls, sid: str, **params: Unpack["Location.DeleteParams"]
+    ) -> "Location":
+        ...
+
+    @overload
     def delete(self, **params: Unpack["Location.DeleteParams"]) -> "Location":
+        ...
+
+    @class_method_variant("_cls_delete")
+    def delete(  # type: ignore
+        self, **params: Unpack["Location.DeleteParams"]
+    ) -> "Location":
         return self._request_and_refresh(
             "delete",
             self.instance_url(),

--- a/stripe/api_resources/terminal/location.py
+++ b/stripe/api_resources/terminal/location.py
@@ -10,13 +10,12 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus

--- a/stripe/api_resources/terminal/reader.py
+++ b/stripe/api_resources/terminal/reader.py
@@ -13,14 +13,13 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     Type,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus

--- a/stripe/api_resources/terminal/reader.py
+++ b/stripe/api_resources/terminal/reader.py
@@ -211,7 +211,7 @@ class Reader(
     ) -> "Reader":
         ...
 
-    @class_method_variant(_cls_cancel_action)
+    @class_method_variant("_cls_cancel_action")
     def cancel_action(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -360,7 +360,7 @@ class Reader(
     ) -> "Reader":
         ...
 
-    @class_method_variant(_cls_process_payment_intent)
+    @class_method_variant("_cls_process_payment_intent")
     def process_payment_intent(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -421,7 +421,7 @@ class Reader(
     ) -> "Reader":
         ...
 
-    @class_method_variant(_cls_process_setup_intent)
+    @class_method_variant("_cls_process_setup_intent")
     def process_setup_intent(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -482,7 +482,7 @@ class Reader(
     ) -> "Reader":
         ...
 
-    @class_method_variant(_cls_refund_payment)
+    @class_method_variant("_cls_refund_payment")
     def refund_payment(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -551,7 +551,7 @@ class Reader(
     ) -> "Reader":
         ...
 
-    @class_method_variant(_cls_set_reader_display)
+    @class_method_variant("_cls_set_reader_display")
     def set_reader_display(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -615,7 +615,7 @@ class Reader(
         ) -> "Reader":
             ...
 
-        @class_method_variant(_cls_present_payment_method)
+        @class_method_variant("_cls_present_payment_method")
         def present_payment_method(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/terminal/reader.py
+++ b/stripe/api_resources/terminal/reader.py
@@ -212,7 +212,7 @@ class Reader(
         ...
 
     @class_method_variant("_cls_cancel_action")
-    def cancel_action(  # type: ignore
+    def cancel_action(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Reader.CancelActionParams"]
@@ -273,7 +273,7 @@ class Reader(
         ...
 
     @class_method_variant("_cls_delete")
-    def delete(  # type: ignore
+    def delete(  # pyright: ignore[reportGeneralTypeIssues]
         self, **params: Unpack["Reader.DeleteParams"]
     ) -> "Reader":
         return self._request_and_refresh(
@@ -361,7 +361,7 @@ class Reader(
         ...
 
     @class_method_variant("_cls_process_payment_intent")
-    def process_payment_intent(  # type: ignore
+    def process_payment_intent(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Reader.ProcessPaymentIntentParams"]
@@ -422,7 +422,7 @@ class Reader(
         ...
 
     @class_method_variant("_cls_process_setup_intent")
-    def process_setup_intent(  # type: ignore
+    def process_setup_intent(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Reader.ProcessSetupIntentParams"]
@@ -483,7 +483,7 @@ class Reader(
         ...
 
     @class_method_variant("_cls_refund_payment")
-    def refund_payment(  # type: ignore
+    def refund_payment(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Reader.RefundPaymentParams"]
@@ -552,7 +552,7 @@ class Reader(
         ...
 
     @class_method_variant("_cls_set_reader_display")
-    def set_reader_display(  # type: ignore
+    def set_reader_display(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Reader.SetReaderDisplayParams"]
@@ -616,7 +616,7 @@ class Reader(
             ...
 
         @class_method_variant("_cls_present_payment_method")
-        def present_payment_method(  # type: ignore
+        def present_payment_method(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Reader.PresentPaymentMethodParams"]

--- a/stripe/api_resources/terminal/reader.py
+++ b/stripe/api_resources/terminal/reader.py
@@ -12,6 +12,7 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
@@ -19,6 +20,7 @@ from typing_extensions import (
     Type,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -190,8 +192,28 @@ class Reader(
             ),
         )
 
-    @util.class_method_variant("_cls_cancel_action")
+    @overload
+    @classmethod
     def cancel_action(
+        cls,
+        reader: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Reader.CancelActionParams"]
+    ) -> "Reader":
+        ...
+
+    @overload
+    def cancel_action(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Reader.CancelActionParams"]
+    ) -> "Reader":
+        ...
+
+    @class_method_variant(_cls_cancel_action)
+    def cancel_action(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Reader.CancelActionParams"]
@@ -240,8 +262,21 @@ class Reader(
             cls._static_request("delete", url, params=params),
         )
 
-    @util.class_method_variant("_cls_delete")
+    @overload
+    @classmethod
+    def delete(
+        cls, sid: str, **params: Unpack["Reader.DeleteParams"]
+    ) -> "Reader":
+        ...
+
+    @overload
     def delete(self, **params: Unpack["Reader.DeleteParams"]) -> "Reader":
+        ...
+
+    @class_method_variant("_cls_delete")
+    def delete(  # type: ignore
+        self, **params: Unpack["Reader.DeleteParams"]
+    ) -> "Reader":
         return self._request_and_refresh(
             "delete",
             self.instance_url(),
@@ -306,8 +341,28 @@ class Reader(
             ),
         )
 
-    @util.class_method_variant("_cls_process_payment_intent")
+    @overload
+    @classmethod
     def process_payment_intent(
+        cls,
+        reader: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Reader.ProcessPaymentIntentParams"]
+    ) -> "Reader":
+        ...
+
+    @overload
+    def process_payment_intent(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Reader.ProcessPaymentIntentParams"]
+    ) -> "Reader":
+        ...
+
+    @class_method_variant(_cls_process_payment_intent)
+    def process_payment_intent(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Reader.ProcessPaymentIntentParams"]
@@ -347,8 +402,28 @@ class Reader(
             ),
         )
 
-    @util.class_method_variant("_cls_process_setup_intent")
+    @overload
+    @classmethod
     def process_setup_intent(
+        cls,
+        reader: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Reader.ProcessSetupIntentParams"]
+    ) -> "Reader":
+        ...
+
+    @overload
+    def process_setup_intent(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Reader.ProcessSetupIntentParams"]
+    ) -> "Reader":
+        ...
+
+    @class_method_variant(_cls_process_setup_intent)
+    def process_setup_intent(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Reader.ProcessSetupIntentParams"]
@@ -388,8 +463,28 @@ class Reader(
             ),
         )
 
-    @util.class_method_variant("_cls_refund_payment")
+    @overload
+    @classmethod
     def refund_payment(
+        cls,
+        reader: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Reader.RefundPaymentParams"]
+    ) -> "Reader":
+        ...
+
+    @overload
+    def refund_payment(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Reader.RefundPaymentParams"]
+    ) -> "Reader":
+        ...
+
+    @class_method_variant(_cls_refund_payment)
+    def refund_payment(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Reader.RefundPaymentParams"]
@@ -437,8 +532,28 @@ class Reader(
             ),
         )
 
-    @util.class_method_variant("_cls_set_reader_display")
+    @overload
+    @classmethod
     def set_reader_display(
+        cls,
+        reader: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Reader.SetReaderDisplayParams"]
+    ) -> "Reader":
+        ...
+
+    @overload
+    def set_reader_display(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Reader.SetReaderDisplayParams"]
+    ) -> "Reader":
+        ...
+
+    @class_method_variant(_cls_set_reader_display)
+    def set_reader_display(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Reader.SetReaderDisplayParams"]
@@ -481,8 +596,28 @@ class Reader(
                 ),
             )
 
-        @util.class_method_variant("_cls_present_payment_method")
+        @overload
+        @classmethod
         def present_payment_method(
+            cls,
+            reader: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Reader.PresentPaymentMethodParams"]
+        ) -> "Reader":
+            ...
+
+        @overload
+        def present_payment_method(
+            self,
+            idempotency_key: Optional[str] = None,
+            **params: Unpack["Reader.PresentPaymentMethodParams"]
+        ) -> "Reader":
+            ...
+
+        @class_method_variant(_cls_present_payment_method)
+        def present_payment_method(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["Reader.PresentPaymentMethodParams"]

--- a/stripe/api_resources/test_helpers/test_clock.py
+++ b/stripe/api_resources/test_helpers/test_clock.py
@@ -9,14 +9,8 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.util import class_method_variant
-from typing import ClassVar, List, Optional, cast
-from typing_extensions import (
-    Literal,
-    NotRequired,
-    Unpack,
-    overload,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, List, Optional, cast, overload
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 

--- a/stripe/api_resources/test_helpers/test_clock.py
+++ b/stripe/api_resources/test_helpers/test_clock.py
@@ -104,7 +104,7 @@ class TestClock(
     ) -> "TestClock":
         ...
 
-    @class_method_variant(_cls_advance)
+    @class_method_variant("_cls_advance")
     def advance(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/test_helpers/test_clock.py
+++ b/stripe/api_resources/test_helpers/test_clock.py
@@ -105,7 +105,7 @@ class TestClock(
         ...
 
     @class_method_variant("_cls_advance")
-    def advance(  # type: ignore
+    def advance(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["TestClock.AdvanceParams"]
@@ -168,7 +168,7 @@ class TestClock(
         ...
 
     @class_method_variant("_cls_delete")
-    def delete(  # type: ignore
+    def delete(  # pyright: ignore[reportGeneralTypeIssues]
         self, **params: Unpack["TestClock.DeleteParams"]
     ) -> "TestClock":
         return self._request_and_refresh(

--- a/stripe/api_resources/test_helpers/test_clock.py
+++ b/stripe/api_resources/test_helpers/test_clock.py
@@ -8,8 +8,15 @@ from stripe.api_resources.abstract import (
 )
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
+from stripe.util import class_method_variant
 from typing import ClassVar, List, Optional, cast
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    Literal,
+    NotRequired,
+    Unpack,
+    overload,
+    TYPE_CHECKING,
+)
 from urllib.parse import quote_plus
 
 
@@ -83,8 +90,28 @@ class TestClock(
             ),
         )
 
-    @util.class_method_variant("_cls_advance")
+    @overload
+    @classmethod
     def advance(
+        cls,
+        test_clock: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["TestClock.AdvanceParams"]
+    ) -> "TestClock":
+        ...
+
+    @overload
+    def advance(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["TestClock.AdvanceParams"]
+    ) -> "TestClock":
+        ...
+
+    @class_method_variant(_cls_advance)
+    def advance(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["TestClock.AdvanceParams"]
@@ -133,8 +160,21 @@ class TestClock(
             cls._static_request("delete", url, params=params),
         )
 
-    @util.class_method_variant("_cls_delete")
+    @overload
+    @classmethod
     def delete(
+        cls, sid: str, **params: Unpack["TestClock.DeleteParams"]
+    ) -> "TestClock":
+        ...
+
+    @overload
+    def delete(
+        self, **params: Unpack["TestClock.DeleteParams"]
+    ) -> "TestClock":
+        ...
+
+    @class_method_variant("_cls_delete")
+    def delete(  # type: ignore
         self, **params: Unpack["TestClock.DeleteParams"]
     ) -> "TestClock":
         return self._request_and_refresh(

--- a/stripe/api_resources/topup.py
+++ b/stripe/api_resources/topup.py
@@ -145,7 +145,7 @@ class Topup(
     ) -> "Topup":
         ...
 
-    @class_method_variant(_cls_cancel)
+    @class_method_variant("_cls_cancel")
     def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/topup.py
+++ b/stripe/api_resources/topup.py
@@ -10,13 +10,12 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus

--- a/stripe/api_resources/topup.py
+++ b/stripe/api_resources/topup.py
@@ -146,7 +146,7 @@ class Topup(
         ...
 
     @class_method_variant("_cls_cancel")
-    def cancel(  # type: ignore
+    def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Topup.CancelParams"]

--- a/stripe/api_resources/topup.py
+++ b/stripe/api_resources/topup.py
@@ -9,12 +9,14 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -124,8 +126,28 @@ class Topup(
             ),
         )
 
-    @util.class_method_variant("_cls_cancel")
+    @overload
+    @classmethod
     def cancel(
+        cls,
+        topup: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Topup.CancelParams"]
+    ) -> "Topup":
+        ...
+
+    @overload
+    def cancel(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["Topup.CancelParams"]
+    ) -> "Topup":
+        ...
+
+    @class_method_variant(_cls_cancel)
+    def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["Topup.CancelParams"]

--- a/stripe/api_resources/treasury/financial_account.py
+++ b/stripe/api_resources/treasury/financial_account.py
@@ -10,13 +10,12 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus

--- a/stripe/api_resources/treasury/financial_account.py
+++ b/stripe/api_resources/treasury/financial_account.py
@@ -9,12 +9,14 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 from urllib.parse import quote_plus
@@ -471,8 +473,28 @@ class FinancialAccount(
             ),
         )
 
-    @util.class_method_variant("_cls_retrieve_features")
+    @overload
+    @classmethod
     def retrieve_features(
+        cls,
+        financial_account: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["FinancialAccount.RetrieveFeaturesParams"]
+    ) -> "FinancialAccountFeatures":
+        ...
+
+    @overload
+    def retrieve_features(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["FinancialAccount.RetrieveFeaturesParams"]
+    ) -> "FinancialAccountFeatures":
+        ...
+
+    @class_method_variant(_cls_retrieve_features)
+    def retrieve_features(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["FinancialAccount.RetrieveFeaturesParams"]
@@ -512,8 +534,28 @@ class FinancialAccount(
             ),
         )
 
-    @util.class_method_variant("_cls_update_features")
+    @overload
+    @classmethod
     def update_features(
+        cls,
+        financial_account: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["FinancialAccount.UpdateFeaturesParams"]
+    ) -> "FinancialAccountFeatures":
+        ...
+
+    @overload
+    def update_features(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["FinancialAccount.UpdateFeaturesParams"]
+    ) -> "FinancialAccountFeatures":
+        ...
+
+    @class_method_variant(_cls_update_features)
+    def update_features(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["FinancialAccount.UpdateFeaturesParams"]

--- a/stripe/api_resources/treasury/financial_account.py
+++ b/stripe/api_resources/treasury/financial_account.py
@@ -492,7 +492,7 @@ class FinancialAccount(
     ) -> "FinancialAccountFeatures":
         ...
 
-    @class_method_variant(_cls_retrieve_features)
+    @class_method_variant("_cls_retrieve_features")
     def retrieve_features(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -553,7 +553,7 @@ class FinancialAccount(
     ) -> "FinancialAccountFeatures":
         ...
 
-    @class_method_variant(_cls_update_features)
+    @class_method_variant("_cls_update_features")
     def update_features(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/treasury/financial_account.py
+++ b/stripe/api_resources/treasury/financial_account.py
@@ -493,7 +493,7 @@ class FinancialAccount(
         ...
 
     @class_method_variant("_cls_retrieve_features")
-    def retrieve_features(  # type: ignore
+    def retrieve_features(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["FinancialAccount.RetrieveFeaturesParams"]
@@ -554,7 +554,7 @@ class FinancialAccount(
         ...
 
     @class_method_variant("_cls_update_features")
-    def update_features(  # type: ignore
+    def update_features(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["FinancialAccount.UpdateFeaturesParams"]

--- a/stripe/api_resources/treasury/inbound_transfer.py
+++ b/stripe/api_resources/treasury/inbound_transfer.py
@@ -11,14 +11,13 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     Type,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 

--- a/stripe/api_resources/treasury/inbound_transfer.py
+++ b/stripe/api_resources/treasury/inbound_transfer.py
@@ -146,7 +146,7 @@ class InboundTransfer(
         ...
 
     @class_method_variant("_cls_cancel")
-    def cancel(  # type: ignore
+    def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["InboundTransfer.CancelParams"]
@@ -265,7 +265,7 @@ class InboundTransfer(
             ...
 
         @class_method_variant("_cls_fail")
-        def fail(  # type: ignore
+        def fail(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["InboundTransfer.FailParams"]
@@ -326,7 +326,7 @@ class InboundTransfer(
             ...
 
         @class_method_variant("_cls_return_inbound_transfer")
-        def return_inbound_transfer(  # type: ignore
+        def return_inbound_transfer(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["InboundTransfer.ReturnInboundTransferParams"]
@@ -387,7 +387,7 @@ class InboundTransfer(
             ...
 
         @class_method_variant("_cls_succeed")
-        def succeed(  # type: ignore
+        def succeed(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["InboundTransfer.SucceedParams"]

--- a/stripe/api_resources/treasury/inbound_transfer.py
+++ b/stripe/api_resources/treasury/inbound_transfer.py
@@ -10,6 +10,7 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
@@ -17,6 +18,7 @@ from typing_extensions import (
     Type,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 
@@ -124,8 +126,28 @@ class InboundTransfer(
             ),
         )
 
-    @util.class_method_variant("_cls_cancel")
+    @overload
+    @classmethod
     def cancel(
+        cls,
+        inbound_transfer: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["InboundTransfer.CancelParams"]
+    ) -> "InboundTransfer":
+        ...
+
+    @overload
+    def cancel(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["InboundTransfer.CancelParams"]
+    ) -> "InboundTransfer":
+        ...
+
+    @class_method_variant(_cls_cancel)
+    def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["InboundTransfer.CancelParams"]
@@ -223,8 +245,28 @@ class InboundTransfer(
                 ),
             )
 
-        @util.class_method_variant("_cls_fail")
+        @overload
+        @classmethod
         def fail(
+            cls,
+            id: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["InboundTransfer.FailParams"]
+        ) -> "InboundTransfer":
+            ...
+
+        @overload
+        def fail(
+            self,
+            idempotency_key: Optional[str] = None,
+            **params: Unpack["InboundTransfer.FailParams"]
+        ) -> "InboundTransfer":
+            ...
+
+        @class_method_variant(_cls_fail)
+        def fail(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["InboundTransfer.FailParams"]
@@ -264,8 +306,28 @@ class InboundTransfer(
                 ),
             )
 
-        @util.class_method_variant("_cls_return_inbound_transfer")
+        @overload
+        @classmethod
         def return_inbound_transfer(
+            cls,
+            id: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"]
+        ) -> "InboundTransfer":
+            ...
+
+        @overload
+        def return_inbound_transfer(
+            self,
+            idempotency_key: Optional[str] = None,
+            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"]
+        ) -> "InboundTransfer":
+            ...
+
+        @class_method_variant(_cls_return_inbound_transfer)
+        def return_inbound_transfer(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["InboundTransfer.ReturnInboundTransferParams"]
@@ -305,8 +367,28 @@ class InboundTransfer(
                 ),
             )
 
-        @util.class_method_variant("_cls_succeed")
+        @overload
+        @classmethod
         def succeed(
+            cls,
+            id: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["InboundTransfer.SucceedParams"]
+        ) -> "InboundTransfer":
+            ...
+
+        @overload
+        def succeed(
+            self,
+            idempotency_key: Optional[str] = None,
+            **params: Unpack["InboundTransfer.SucceedParams"]
+        ) -> "InboundTransfer":
+            ...
+
+        @class_method_variant(_cls_succeed)
+        def succeed(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["InboundTransfer.SucceedParams"]

--- a/stripe/api_resources/treasury/inbound_transfer.py
+++ b/stripe/api_resources/treasury/inbound_transfer.py
@@ -145,7 +145,7 @@ class InboundTransfer(
     ) -> "InboundTransfer":
         ...
 
-    @class_method_variant(_cls_cancel)
+    @class_method_variant("_cls_cancel")
     def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -264,7 +264,7 @@ class InboundTransfer(
         ) -> "InboundTransfer":
             ...
 
-        @class_method_variant(_cls_fail)
+        @class_method_variant("_cls_fail")
         def fail(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
@@ -325,7 +325,7 @@ class InboundTransfer(
         ) -> "InboundTransfer":
             ...
 
-        @class_method_variant(_cls_return_inbound_transfer)
+        @class_method_variant("_cls_return_inbound_transfer")
         def return_inbound_transfer(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
@@ -386,7 +386,7 @@ class InboundTransfer(
         ) -> "InboundTransfer":
             ...
 
-        @class_method_variant(_cls_succeed)
+        @class_method_variant("_cls_succeed")
         def succeed(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/treasury/outbound_payment.py
+++ b/stripe/api_resources/treasury/outbound_payment.py
@@ -10,6 +10,7 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
@@ -17,6 +18,7 @@ from typing_extensions import (
     Type,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 
@@ -192,8 +194,28 @@ class OutboundPayment(
             ),
         )
 
-    @util.class_method_variant("_cls_cancel")
+    @overload
+    @classmethod
     def cancel(
+        cls,
+        id: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["OutboundPayment.CancelParams"]
+    ) -> "OutboundPayment":
+        ...
+
+    @overload
+    def cancel(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["OutboundPayment.CancelParams"]
+    ) -> "OutboundPayment":
+        ...
+
+    @class_method_variant(_cls_cancel)
+    def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["OutboundPayment.CancelParams"]
@@ -291,8 +313,28 @@ class OutboundPayment(
                 ),
             )
 
-        @util.class_method_variant("_cls_fail")
+        @overload
+        @classmethod
         def fail(
+            cls,
+            id: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["OutboundPayment.FailParams"]
+        ) -> "OutboundPayment":
+            ...
+
+        @overload
+        def fail(
+            self,
+            idempotency_key: Optional[str] = None,
+            **params: Unpack["OutboundPayment.FailParams"]
+        ) -> "OutboundPayment":
+            ...
+
+        @class_method_variant(_cls_fail)
+        def fail(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["OutboundPayment.FailParams"]
@@ -332,8 +374,28 @@ class OutboundPayment(
                 ),
             )
 
-        @util.class_method_variant("_cls_post")
+        @overload
+        @classmethod
         def post(
+            cls,
+            id: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["OutboundPayment.PostParams"]
+        ) -> "OutboundPayment":
+            ...
+
+        @overload
+        def post(
+            self,
+            idempotency_key: Optional[str] = None,
+            **params: Unpack["OutboundPayment.PostParams"]
+        ) -> "OutboundPayment":
+            ...
+
+        @class_method_variant(_cls_post)
+        def post(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["OutboundPayment.PostParams"]
@@ -373,8 +435,28 @@ class OutboundPayment(
                 ),
             )
 
-        @util.class_method_variant("_cls_return_outbound_payment")
+        @overload
+        @classmethod
         def return_outbound_payment(
+            cls,
+            id: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"]
+        ) -> "OutboundPayment":
+            ...
+
+        @overload
+        def return_outbound_payment(
+            self,
+            idempotency_key: Optional[str] = None,
+            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"]
+        ) -> "OutboundPayment":
+            ...
+
+        @class_method_variant(_cls_return_outbound_payment)
+        def return_outbound_payment(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"]

--- a/stripe/api_resources/treasury/outbound_payment.py
+++ b/stripe/api_resources/treasury/outbound_payment.py
@@ -11,14 +11,13 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     Type,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 

--- a/stripe/api_resources/treasury/outbound_payment.py
+++ b/stripe/api_resources/treasury/outbound_payment.py
@@ -213,7 +213,7 @@ class OutboundPayment(
     ) -> "OutboundPayment":
         ...
 
-    @class_method_variant(_cls_cancel)
+    @class_method_variant("_cls_cancel")
     def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -332,7 +332,7 @@ class OutboundPayment(
         ) -> "OutboundPayment":
             ...
 
-        @class_method_variant(_cls_fail)
+        @class_method_variant("_cls_fail")
         def fail(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
@@ -393,7 +393,7 @@ class OutboundPayment(
         ) -> "OutboundPayment":
             ...
 
-        @class_method_variant(_cls_post)
+        @class_method_variant("_cls_post")
         def post(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
@@ -454,7 +454,7 @@ class OutboundPayment(
         ) -> "OutboundPayment":
             ...
 
-        @class_method_variant(_cls_return_outbound_payment)
+        @class_method_variant("_cls_return_outbound_payment")
         def return_outbound_payment(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/treasury/outbound_payment.py
+++ b/stripe/api_resources/treasury/outbound_payment.py
@@ -214,7 +214,7 @@ class OutboundPayment(
         ...
 
     @class_method_variant("_cls_cancel")
-    def cancel(  # type: ignore
+    def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["OutboundPayment.CancelParams"]
@@ -333,7 +333,7 @@ class OutboundPayment(
             ...
 
         @class_method_variant("_cls_fail")
-        def fail(  # type: ignore
+        def fail(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["OutboundPayment.FailParams"]
@@ -394,7 +394,7 @@ class OutboundPayment(
             ...
 
         @class_method_variant("_cls_post")
-        def post(  # type: ignore
+        def post(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["OutboundPayment.PostParams"]
@@ -455,7 +455,7 @@ class OutboundPayment(
             ...
 
         @class_method_variant("_cls_return_outbound_payment")
-        def return_outbound_payment(  # type: ignore
+        def return_outbound_payment(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"]

--- a/stripe/api_resources/treasury/outbound_transfer.py
+++ b/stripe/api_resources/treasury/outbound_transfer.py
@@ -11,14 +11,13 @@ from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
+from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
     NotRequired,
     Type,
     TypedDict,
     Unpack,
-    overload,
     TYPE_CHECKING,
 )
 

--- a/stripe/api_resources/treasury/outbound_transfer.py
+++ b/stripe/api_resources/treasury/outbound_transfer.py
@@ -160,7 +160,7 @@ class OutboundTransfer(
         ...
 
     @class_method_variant("_cls_cancel")
-    def cancel(  # type: ignore
+    def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["OutboundTransfer.CancelParams"]
@@ -279,7 +279,7 @@ class OutboundTransfer(
             ...
 
         @class_method_variant("_cls_fail")
-        def fail(  # type: ignore
+        def fail(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["OutboundTransfer.FailParams"]
@@ -342,7 +342,7 @@ class OutboundTransfer(
             ...
 
         @class_method_variant("_cls_post")
-        def post(  # type: ignore
+        def post(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["OutboundTransfer.PostParams"]
@@ -405,7 +405,7 @@ class OutboundTransfer(
             ...
 
         @class_method_variant("_cls_return_outbound_transfer")
-        def return_outbound_transfer(  # type: ignore
+        def return_outbound_transfer(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"]

--- a/stripe/api_resources/treasury/outbound_transfer.py
+++ b/stripe/api_resources/treasury/outbound_transfer.py
@@ -159,7 +159,7 @@ class OutboundTransfer(
     ) -> "OutboundTransfer":
         ...
 
-    @class_method_variant(_cls_cancel)
+    @class_method_variant("_cls_cancel")
     def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
@@ -278,7 +278,7 @@ class OutboundTransfer(
         ) -> "OutboundTransfer":
             ...
 
-        @class_method_variant(_cls_fail)
+        @class_method_variant("_cls_fail")
         def fail(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
@@ -341,7 +341,7 @@ class OutboundTransfer(
         ) -> "OutboundTransfer":
             ...
 
-        @class_method_variant(_cls_post)
+        @class_method_variant("_cls_post")
         def post(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
@@ -404,7 +404,7 @@ class OutboundTransfer(
         ) -> "OutboundTransfer":
             ...
 
-        @class_method_variant(_cls_return_outbound_transfer)
+        @class_method_variant("_cls_return_outbound_transfer")
         def return_outbound_transfer(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/treasury/outbound_transfer.py
+++ b/stripe/api_resources/treasury/outbound_transfer.py
@@ -10,6 +10,7 @@ from stripe.api_resources.expandable_field import ExpandableField
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.stripe_object import StripeObject
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
@@ -17,6 +18,7 @@ from typing_extensions import (
     Type,
     TypedDict,
     Unpack,
+    overload,
     TYPE_CHECKING,
 )
 
@@ -138,8 +140,28 @@ class OutboundTransfer(
             ),
         )
 
-    @util.class_method_variant("_cls_cancel")
+    @overload
+    @classmethod
     def cancel(
+        cls,
+        outbound_transfer: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["OutboundTransfer.CancelParams"]
+    ) -> "OutboundTransfer":
+        ...
+
+    @overload
+    def cancel(
+        self,
+        idempotency_key: Optional[str] = None,
+        **params: Unpack["OutboundTransfer.CancelParams"]
+    ) -> "OutboundTransfer":
+        ...
+
+    @class_method_variant(_cls_cancel)
+    def cancel(  # type: ignore
         self,
         idempotency_key: Optional[str] = None,
         **params: Unpack["OutboundTransfer.CancelParams"]
@@ -237,8 +259,28 @@ class OutboundTransfer(
                 ),
             )
 
-        @util.class_method_variant("_cls_fail")
+        @overload
+        @classmethod
         def fail(
+            cls,
+            outbound_transfer: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["OutboundTransfer.FailParams"]
+        ) -> "OutboundTransfer":
+            ...
+
+        @overload
+        def fail(
+            self,
+            idempotency_key: Optional[str] = None,
+            **params: Unpack["OutboundTransfer.FailParams"]
+        ) -> "OutboundTransfer":
+            ...
+
+        @class_method_variant(_cls_fail)
+        def fail(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["OutboundTransfer.FailParams"]
@@ -280,8 +322,28 @@ class OutboundTransfer(
                 ),
             )
 
-        @util.class_method_variant("_cls_post")
+        @overload
+        @classmethod
         def post(
+            cls,
+            outbound_transfer: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["OutboundTransfer.PostParams"]
+        ) -> "OutboundTransfer":
+            ...
+
+        @overload
+        def post(
+            self,
+            idempotency_key: Optional[str] = None,
+            **params: Unpack["OutboundTransfer.PostParams"]
+        ) -> "OutboundTransfer":
+            ...
+
+        @class_method_variant(_cls_post)
+        def post(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["OutboundTransfer.PostParams"]
@@ -323,8 +385,28 @@ class OutboundTransfer(
                 ),
             )
 
-        @util.class_method_variant("_cls_return_outbound_transfer")
+        @overload
+        @classmethod
         def return_outbound_transfer(
+            cls,
+            outbound_transfer: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"]
+        ) -> "OutboundTransfer":
+            ...
+
+        @overload
+        def return_outbound_transfer(
+            self,
+            idempotency_key: Optional[str] = None,
+            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"]
+        ) -> "OutboundTransfer":
+            ...
+
+        @class_method_variant(_cls_return_outbound_transfer)
+        def return_outbound_transfer(  # type: ignore
             self,
             idempotency_key: Optional[str] = None,
             **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"]

--- a/stripe/api_resources/webhook_endpoint.py
+++ b/stripe/api_resources/webhook_endpoint.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import util
 from stripe.api_resources.abstract import (
     CreateableAPIResource,
     DeletableAPIResource,
@@ -9,8 +8,15 @@ from stripe.api_resources.abstract import (
 )
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
+from stripe.util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import (
+    Literal,
+    NotRequired,
+    Unpack,
+    overload,
+    TYPE_CHECKING,
+)
 from urllib.parse import quote_plus
 
 
@@ -341,8 +347,21 @@ class WebhookEndpoint(
             cls._static_request("delete", url, params=params),
         )
 
-    @util.class_method_variant("_cls_delete")
+    @overload
+    @classmethod
     def delete(
+        cls, sid: str, **params: Unpack["WebhookEndpoint.DeleteParams"]
+    ) -> "WebhookEndpoint":
+        ...
+
+    @overload
+    def delete(
+        self, **params: Unpack["WebhookEndpoint.DeleteParams"]
+    ) -> "WebhookEndpoint":
+        ...
+
+    @class_method_variant("_cls_delete")
+    def delete(  # type: ignore
         self, **params: Unpack["WebhookEndpoint.DeleteParams"]
     ) -> "WebhookEndpoint":
         return self._request_and_refresh(

--- a/stripe/api_resources/webhook_endpoint.py
+++ b/stripe/api_resources/webhook_endpoint.py
@@ -355,7 +355,7 @@ class WebhookEndpoint(
         ...
 
     @class_method_variant("_cls_delete")
-    def delete(  # type: ignore
+    def delete(  # pyright: ignore[reportGeneralTypeIssues]
         self, **params: Unpack["WebhookEndpoint.DeleteParams"]
     ) -> "WebhookEndpoint":
         return self._request_and_refresh(

--- a/stripe/api_resources/webhook_endpoint.py
+++ b/stripe/api_resources/webhook_endpoint.py
@@ -9,14 +9,8 @@ from stripe.api_resources.abstract import (
 from stripe.api_resources.list_object import ListObject
 from stripe.request_options import RequestOptions
 from stripe.util import class_method_variant
-from typing import ClassVar, Dict, List, Optional, cast
-from typing_extensions import (
-    Literal,
-    NotRequired,
-    Unpack,
-    overload,
-    TYPE_CHECKING,
-)
+from typing import ClassVar, Dict, List, Optional, cast, overload
+from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
 from urllib.parse import quote_plus
 
 

--- a/stripe/util.py
+++ b/stripe/util.py
@@ -366,9 +366,13 @@ class class_method_variant(object):
     def __init__(self, class_method_name):
         self.class_method_name = class_method_name
 
-    def __call__(self, method):
+    T = TypeVar("T")
+
+    method: Any
+
+    def __call__(self, method: T) -> T:
         self.method = method
-        return self
+        return cast(T, self)
 
     def __get__(self, obj, objtype: Optional[Type[Any]] = None):
         @functools.wraps(self.method)


### PR DESCRIPTION
`@util.class_method_variant("...")` was basically swallowing the types of custom methods and delete methods.

This PR:

* Changes the decorator to preserve the type of the method it wraps. (Suppresses some type errors, it is hard to type the implementation of the decorator in a satisfying way)
* Adds correctly-typed overloads to all the methods that use the decorator.
* Suppresses a type error on the implementation complaining about how it doesn't match the overloads. The type here shouldn't matter, users will only experience the type of the overloads.
