### PR TITLE
Add types for error object

### DIFF
--- a/stripe/api_resources/error_object.py
+++ b/stripe/api_resources/error_object.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from stripe.api_resources.source import Source
     from stripe.api_resources.payment_method import PaymentMethod
 
+
 class ErrorObject(StripeObject):
     charge: Optional[str]
     code: int

--- a/stripe/api_resources/error_object.py
+++ b/stripe/api_resources/error_object.py
@@ -2,10 +2,9 @@ from typing import Optional
 from stripe.api_resources.payment_intent import PaymentIntent
 from stripe.api_resources.setup_intent import SetupIntent
 from stripe.api_resources.source import Source
+from stripe.api_resources.payment_method import PaymentMethod
 from stripe.util import merge_dicts
 from stripe.stripe_object import StripeObject
-
-from api_resources.payment_method import PaymentMethod
 
 
 class ErrorObject(StripeObject):

--- a/stripe/api_resources/error_object.py
+++ b/stripe/api_resources/error_object.py
@@ -1,8 +1,26 @@
+from typing import Optional
+from stripe.api_resources.payment_intent import PaymentIntent
+from stripe.api_resources.setup_intent import SetupIntent
+from stripe.api_resources.source import Source
 from stripe.util import merge_dicts
 from stripe.stripe_object import StripeObject
 
+from api_resources.payment_method import PaymentMethod
+
 
 class ErrorObject(StripeObject):
+    charge: Optional[str]
+    code: int
+    decline_code: Optional[str]
+    doc_url: Optional[str]
+    message: Optional[str]
+    param: Optional[str]
+    payment_intent: Optional[PaymentIntent]
+    payment_method: Optional[PaymentMethod]
+    setup_intent: Optional[SetupIntent]
+    source: Optional[Source]
+    type: str
+
     def refresh_from(
         self,
         values,

--- a/stripe/api_resources/error_object.py
+++ b/stripe/api_resources/error_object.py
@@ -1,11 +1,13 @@
 from typing import Optional
-from stripe.api_resources.payment_intent import PaymentIntent
-from stripe.api_resources.setup_intent import SetupIntent
-from stripe.api_resources.source import Source
-from stripe.api_resources.payment_method import PaymentMethod
+from typing_extensions import TYPE_CHECKING
 from stripe.util import merge_dicts
 from stripe.stripe_object import StripeObject
 
+if TYPE_CHECKING:
+    from stripe.api_resources.payment_intent import PaymentIntent
+    from stripe.api_resources.setup_intent import SetupIntent
+    from stripe.api_resources.source import Source
+    from stripe.api_resources.payment_method import PaymentMethod
 
 class ErrorObject(StripeObject):
     charge: Optional[str]
@@ -14,10 +16,10 @@ class ErrorObject(StripeObject):
     doc_url: Optional[str]
     message: Optional[str]
     param: Optional[str]
-    payment_intent: Optional[PaymentIntent]
-    payment_method: Optional[PaymentMethod]
-    setup_intent: Optional[SetupIntent]
-    source: Optional[Source]
+    payment_intent: Optional["PaymentIntent"]
+    payment_method: Optional["PaymentMethod"]
+    setup_intent: Optional["SetupIntent"]
+    source: Optional["Source"]
     type: str
 
     def refresh_from(


### PR DESCRIPTION
Fixes #1114 

Sanity checked against our definitions in [another library](https://github.com/stripe/stripe-node/blob/b9e3b91a3f68e9ef7de0f6d0a21c7f94cb92ae9c/types/Errors.d.ts#L13)