### PR TITLE
Add @staticmethod overloads

### DIFF
--- a/stripe/api_resources/account.py
+++ b/stripe/api_resources/account.py
@@ -3545,20 +3545,6 @@ class Account(
         )
 
     @overload
-    @classmethod
-    def delete(
-        cls, sid: str, **params: Unpack["Account.DeleteParams"]
-    ) -> "Account":
-        """
-        With [Connect](https://stripe.com/docs/connect), you can delete accounts you manage.
-
-        Accounts created using test-mode keys can be deleted at any time. Standard accounts created using live-mode keys cannot be deleted. Custom or Express accounts created using live-mode keys can only be deleted once all balances are zero.
-
-        If you want to delete your own account, use the [account information tab in your account settings](https://dashboard.stripe.com/settings/account) instead.
-        """
-        ...
-
-    @overload
     @staticmethod
     def delete(
         sid: str, **params: Unpack["Account.DeleteParams"]
@@ -3655,21 +3641,6 @@ class Account(
         )
 
     @overload
-    @classmethod
-    def persons(
-        cls,
-        account: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Account.PersonsParams"]
-    ) -> ListObject["Person"]:
-        """
-        Returns a list of people associated with the account's legal entity. The people are returned sorted by creation date, with the most recent people appearing first.
-        """
-        ...
-
-    @overload
     @staticmethod
     def persons(
         account: str,
@@ -3742,23 +3713,6 @@ class Account(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def reject(
-        cls,
-        account: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Account.RejectParams"]
-    ) -> "Account":
-        """
-        With [Connect](https://stripe.com/docs/connect), you may flag accounts as suspicious.
-
-        Test-mode Custom and Express accounts can be rejected at any time. Accounts created using live-mode keys may only be rejected once all balances are zero.
-        """
-        ...
 
     @overload
     @staticmethod

--- a/stripe/api_resources/account.py
+++ b/stripe/api_resources/account.py
@@ -3559,6 +3559,20 @@ class Account(
         ...
 
     @overload
+    @staticmethod
+    def delete(
+        sid: str, **params: Unpack["Account.DeleteParams"]
+    ) -> "Account":
+        """
+        With [Connect](https://stripe.com/docs/connect), you can delete accounts you manage.
+
+        Accounts created using test-mode keys can be deleted at any time. Standard accounts created using live-mode keys cannot be deleted. Custom or Express accounts created using live-mode keys can only be deleted once all balances are zero.
+
+        If you want to delete your own account, use the [account information tab in your account settings](https://dashboard.stripe.com/settings/account) instead.
+        """
+        ...
+
+    @overload
     def delete(self, **params: Unpack["Account.DeleteParams"]) -> "Account":
         """
         With [Connect](https://stripe.com/docs/connect), you can delete accounts you manage.
@@ -3656,6 +3670,20 @@ class Account(
         ...
 
     @overload
+    @staticmethod
+    def persons(
+        account: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Account.PersonsParams"]
+    ) -> ListObject["Person"]:
+        """
+        Returns a list of people associated with the account's legal entity. The people are returned sorted by creation date, with the most recent people appearing first.
+        """
+        ...
+
+    @overload
     def persons(
         self,
         idempotency_key: Optional[str] = None,
@@ -3719,6 +3747,22 @@ class Account(
     @classmethod
     def reject(
         cls,
+        account: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Account.RejectParams"]
+    ) -> "Account":
+        """
+        With [Connect](https://stripe.com/docs/connect), you may flag accounts as suspicious.
+
+        Test-mode Custom and Express accounts can be rejected at any time. Accounts created using live-mode keys may only be rejected once all balances are zero.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def reject(
         account: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,

--- a/stripe/api_resources/apple_pay_domain.py
+++ b/stripe/api_resources/apple_pay_domain.py
@@ -127,6 +127,16 @@ class ApplePayDomain(
         ...
 
     @overload
+    @staticmethod
+    def delete(
+        sid: str, **params: Unpack["ApplePayDomain.DeleteParams"]
+    ) -> "ApplePayDomain":
+        """
+        Delete an apple pay domain.
+        """
+        ...
+
+    @overload
     def delete(
         self, **params: Unpack["ApplePayDomain.DeleteParams"]
     ) -> "ApplePayDomain":

--- a/stripe/api_resources/apple_pay_domain.py
+++ b/stripe/api_resources/apple_pay_domain.py
@@ -117,16 +117,6 @@ class ApplePayDomain(
         )
 
     @overload
-    @classmethod
-    def delete(
-        cls, sid: str, **params: Unpack["ApplePayDomain.DeleteParams"]
-    ) -> "ApplePayDomain":
-        """
-        Delete an apple pay domain.
-        """
-        ...
-
-    @overload
     @staticmethod
     def delete(
         sid: str, **params: Unpack["ApplePayDomain.DeleteParams"]

--- a/stripe/api_resources/application_fee.py
+++ b/stripe/api_resources/application_fee.py
@@ -262,29 +262,6 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
         )
 
     @overload
-    @classmethod
-    def refund(
-        cls,
-        id: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["ApplicationFee.RefundParams"]
-    ) -> "ApplicationFeeRefund":
-        """
-        Refunds an application fee that has previously been collected but not yet refunded.
-        Funds will be refunded to the Stripe account from which the fee was originally collected.
-
-        You can optionally refund only part of an application fee.
-        You can do so multiple times, until the entire fee has been refunded.
-
-        Once entirely refunded, an application fee can't be refunded again.
-        This method will raise an error when called on an already-refunded application fee,
-        or when trying to refund more money than is left on an application fee.
-        """
-        ...
-
-    @overload
     @staticmethod
     def refund(
         id: str,

--- a/stripe/api_resources/application_fee.py
+++ b/stripe/api_resources/application_fee.py
@@ -285,6 +285,28 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
         ...
 
     @overload
+    @staticmethod
+    def refund(
+        id: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["ApplicationFee.RefundParams"]
+    ) -> "ApplicationFeeRefund":
+        """
+        Refunds an application fee that has previously been collected but not yet refunded.
+        Funds will be refunded to the Stripe account from which the fee was originally collected.
+
+        You can optionally refund only part of an application fee.
+        You can do so multiple times, until the entire fee has been refunded.
+
+        Once entirely refunded, an application fee can't be refunded again.
+        This method will raise an error when called on an already-refunded application fee,
+        or when trying to refund more money than is left on an application fee.
+        """
+        ...
+
+    @overload
     def refund(
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/bank_account.py
+++ b/stripe/api_resources/bank_account.py
@@ -381,16 +381,6 @@ class BankAccount(
         )
 
     @overload
-    @classmethod
-    def delete(
-        cls, sid: str, **params: Unpack["BankAccount.DeleteParams"]
-    ) -> Union["BankAccount", "Card"]:
-        """
-        Delete a specified external account for a given account.
-        """
-        ...
-
-    @overload
     @staticmethod
     def delete(
         sid: str, **params: Unpack["BankAccount.DeleteParams"]

--- a/stripe/api_resources/bank_account.py
+++ b/stripe/api_resources/bank_account.py
@@ -391,6 +391,16 @@ class BankAccount(
         ...
 
     @overload
+    @staticmethod
+    def delete(
+        sid: str, **params: Unpack["BankAccount.DeleteParams"]
+    ) -> Union["BankAccount", "Card"]:
+        """
+        Delete a specified external account for a given account.
+        """
+        ...
+
+    @overload
     def delete(
         self, **params: Unpack["BankAccount.DeleteParams"]
     ) -> Union["BankAccount", "Card"]:

--- a/stripe/api_resources/card.py
+++ b/stripe/api_resources/card.py
@@ -178,16 +178,6 @@ class Card(DeletableAPIResource["Card"], UpdateableAPIResource["Card"]):
         )
 
     @overload
-    @classmethod
-    def delete(
-        cls, sid: str, **params: Unpack["Card.DeleteParams"]
-    ) -> Union["BankAccount", "Card"]:
-        """
-        Delete a specified external account for a given account.
-        """
-        ...
-
-    @overload
     @staticmethod
     def delete(
         sid: str, **params: Unpack["Card.DeleteParams"]

--- a/stripe/api_resources/card.py
+++ b/stripe/api_resources/card.py
@@ -188,6 +188,16 @@ class Card(DeletableAPIResource["Card"], UpdateableAPIResource["Card"]):
         ...
 
     @overload
+    @staticmethod
+    def delete(
+        sid: str, **params: Unpack["Card.DeleteParams"]
+    ) -> Union["BankAccount", "Card"]:
+        """
+        Delete a specified external account for a given account.
+        """
+        ...
+
+    @overload
     def delete(
         self, **params: Unpack["Card.DeleteParams"]
     ) -> Union["BankAccount", "Card"]:

--- a/stripe/api_resources/charge.py
+++ b/stripe/api_resources/charge.py
@@ -2203,25 +2203,6 @@ class Charge(
         )
 
     @overload
-    @classmethod
-    def capture(
-        cls,
-        charge: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Charge.CaptureParams"]
-    ) -> "Charge":
-        """
-        Capture the payment of an existing, uncaptured charge that was created with the capture option set to false.
-
-        Uncaptured payments expire a set number of days after they are created ([7 by default](https://stripe.com/docs/charges/placing-a-hold)), after which they are marked as refunded and capture attempts will fail.
-
-        Don't use this method to capture a PaymentIntent-initiated charge. Use [Capture a PaymentIntent](https://stripe.com/docs/api/payment_intents/capture).
-        """
-        ...
-
-    @overload
     @staticmethod
     def capture(
         charge: str,

--- a/stripe/api_resources/charge.py
+++ b/stripe/api_resources/charge.py
@@ -2222,6 +2222,24 @@ class Charge(
         ...
 
     @overload
+    @staticmethod
+    def capture(
+        charge: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Charge.CaptureParams"]
+    ) -> "Charge":
+        """
+        Capture the payment of an existing, uncaptured charge that was created with the capture option set to false.
+
+        Uncaptured payments expire a set number of days after they are created ([7 by default](https://stripe.com/docs/charges/placing-a-hold)), after which they are marked as refunded and capture attempts will fail.
+
+        Don't use this method to capture a PaymentIntent-initiated charge. Use [Capture a PaymentIntent](https://stripe.com/docs/api/payment_intents/capture).
+        """
+        ...
+
+    @overload
     def capture(
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/checkout/session.py
+++ b/stripe/api_resources/checkout/session.py
@@ -3644,23 +3644,6 @@ class Session(
         )
 
     @overload
-    @classmethod
-    def expire(
-        cls,
-        session: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Session.ExpireParams"]
-    ) -> "Session":
-        """
-        A Session can be expired when it is in one of these statuses: open
-
-        After it expires, a customer can't complete a Session and customers loading the Session see a message saying the Session is expired.
-        """
-        ...
-
-    @overload
     @staticmethod
     def expire(
         session: str,
@@ -3765,21 +3748,6 @@ class Session(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def list_line_items(
-        cls,
-        session: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Session.ListLineItemsParams"]
-    ) -> ListObject["LineItem"]:
-        """
-        When retrieving a Checkout Session, there is an includable line_items property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.
-        """
-        ...
 
     @overload
     @staticmethod

--- a/stripe/api_resources/checkout/session.py
+++ b/stripe/api_resources/checkout/session.py
@@ -3661,6 +3661,22 @@ class Session(
         ...
 
     @overload
+    @staticmethod
+    def expire(
+        session: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Session.ExpireParams"]
+    ) -> "Session":
+        """
+        A Session can be expired when it is in one of these statuses: open
+
+        After it expires, a customer can't complete a Session and customers loading the Session see a message saying the Session is expired.
+        """
+        ...
+
+    @overload
     def expire(
         self,
         idempotency_key: Optional[str] = None,
@@ -3754,6 +3770,20 @@ class Session(
     @classmethod
     def list_line_items(
         cls,
+        session: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Session.ListLineItemsParams"]
+    ) -> ListObject["LineItem"]:
+        """
+        When retrieving a Checkout Session, there is an includable line_items property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def list_line_items(
         session: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,

--- a/stripe/api_resources/coupon.py
+++ b/stripe/api_resources/coupon.py
@@ -305,16 +305,6 @@ class Coupon(
         )
 
     @overload
-    @classmethod
-    def delete(
-        cls, sid: str, **params: Unpack["Coupon.DeleteParams"]
-    ) -> "Coupon":
-        """
-        You can delete coupons via the [coupon management](https://dashboard.stripe.com/coupons) page of the Stripe dashboard. However, deleting a coupon does not affect any customers who have already applied the coupon; it means that new customers can't redeem the coupon. You can also delete coupons via the API.
-        """
-        ...
-
-    @overload
     @staticmethod
     def delete(sid: str, **params: Unpack["Coupon.DeleteParams"]) -> "Coupon":
         """

--- a/stripe/api_resources/coupon.py
+++ b/stripe/api_resources/coupon.py
@@ -315,6 +315,14 @@ class Coupon(
         ...
 
     @overload
+    @staticmethod
+    def delete(sid: str, **params: Unpack["Coupon.DeleteParams"]) -> "Coupon":
+        """
+        You can delete coupons via the [coupon management](https://dashboard.stripe.com/coupons) page of the Stripe dashboard. However, deleting a coupon does not affect any customers who have already applied the coupon; it means that new customers can't redeem the coupon. You can also delete coupons via the API.
+        """
+        ...
+
+    @overload
     def delete(self, **params: Unpack["Coupon.DeleteParams"]) -> "Coupon":
         """
         You can delete coupons via the [coupon management](https://dashboard.stripe.com/coupons) page of the Stripe dashboard. However, deleting a coupon does not affect any customers who have already applied the coupon; it means that new customers can't redeem the coupon. You can also delete coupons via the API.

--- a/stripe/api_resources/credit_note.py
+++ b/stripe/api_resources/credit_note.py
@@ -841,6 +841,20 @@ class CreditNote(
         ...
 
     @overload
+    @staticmethod
+    def void_credit_note(
+        id: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["CreditNote.VoidCreditNoteParams"]
+    ) -> "CreditNote":
+        """
+        Marks a credit note as void. Learn more about [voiding credit notes](https://stripe.com/docs/billing/invoices/credit-notes#voiding).
+        """
+        ...
+
+    @overload
     def void_credit_note(
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/credit_note.py
+++ b/stripe/api_resources/credit_note.py
@@ -826,21 +826,6 @@ class CreditNote(
         )
 
     @overload
-    @classmethod
-    def void_credit_note(
-        cls,
-        id: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["CreditNote.VoidCreditNoteParams"]
-    ) -> "CreditNote":
-        """
-        Marks a credit note as void. Learn more about [voiding credit notes](https://stripe.com/docs/billing/invoices/credit-notes#voiding).
-        """
-        ...
-
-    @overload
     @staticmethod
     def void_credit_note(
         id: str,

--- a/stripe/api_resources/customer.py
+++ b/stripe/api_resources/customer.py
@@ -1459,23 +1459,6 @@ class Customer(
         )
 
     @overload
-    @classmethod
-    def create_funding_instructions(
-        cls,
-        customer: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.CreateFundingInstructionsParams"]
-    ) -> "FundingInstructions":
-        """
-        Retrieve funding instructions for a customer cash balance. If funding instructions do not yet exist for the customer, new
-        funding instructions will be created. If funding instructions have already been created for a given customer, the same
-        funding instructions will be retrieved. In other words, we will return the same funding instructions each time.
-        """
-        ...
-
-    @overload
     @staticmethod
     def create_funding_instructions(
         customer: str,
@@ -1541,16 +1524,6 @@ class Customer(
         )
 
     @overload
-    @classmethod
-    def delete(
-        cls, sid: str, **params: Unpack["Customer.DeleteParams"]
-    ) -> "Customer":
-        """
-        Permanently deletes a customer. It cannot be undone. Also immediately cancels any active subscriptions on the customer.
-        """
-        ...
-
-    @overload
     @staticmethod
     def delete(
         sid: str, **params: Unpack["Customer.DeleteParams"]
@@ -1605,21 +1578,6 @@ class Customer(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def delete_discount(
-        cls,
-        customer: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.DeleteDiscountParams"]
-    ) -> "Discount":
-        """
-        Removes the currently applied discount on a customer.
-        """
-        ...
 
     @overload
     @staticmethod
@@ -1722,21 +1680,6 @@ class Customer(
         )
 
     @overload
-    @classmethod
-    def list_payment_methods(
-        cls,
-        customer: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.ListPaymentMethodsParams"]
-    ) -> ListObject["PaymentMethod"]:
-        """
-        Returns a list of PaymentMethods for a given Customer
-        """
-        ...
-
-    @overload
     @staticmethod
     def list_payment_methods(
         customer: str,
@@ -1835,22 +1778,6 @@ class Customer(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def retrieve_payment_method(
-        cls,
-        customer: str,
-        payment_method: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.RetrievePaymentMethodParams"]
-    ) -> "PaymentMethod":
-        """
-        Retrieves a PaymentMethod object for a given Customer.
-        """
-        ...
 
     @overload
     @staticmethod
@@ -2410,21 +2337,6 @@ class Customer(
                     params=params,
                 ),
             )
-
-        @overload
-        @classmethod
-        def fund_cash_balance(
-            cls,
-            customer: str,
-            api_key: Optional[str] = None,
-            stripe_version: Optional[str] = None,
-            stripe_account: Optional[str] = None,
-            **params: Unpack["Customer.FundCashBalanceParams"]
-        ) -> "CustomerCashBalanceTransaction":
-            """
-            Create an incoming testmode bank transfer
-            """
-            ...
 
         @overload
         @staticmethod

--- a/stripe/api_resources/customer.py
+++ b/stripe/api_resources/customer.py
@@ -1476,6 +1476,22 @@ class Customer(
         ...
 
     @overload
+    @staticmethod
+    def create_funding_instructions(
+        customer: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Customer.CreateFundingInstructionsParams"]
+    ) -> "FundingInstructions":
+        """
+        Retrieve funding instructions for a customer cash balance. If funding instructions do not yet exist for the customer, new
+        funding instructions will be created. If funding instructions have already been created for a given customer, the same
+        funding instructions will be retrieved. In other words, we will return the same funding instructions each time.
+        """
+        ...
+
+    @overload
     def create_funding_instructions(
         self,
         idempotency_key: Optional[str] = None,
@@ -1535,6 +1551,16 @@ class Customer(
         ...
 
     @overload
+    @staticmethod
+    def delete(
+        sid: str, **params: Unpack["Customer.DeleteParams"]
+    ) -> "Customer":
+        """
+        Permanently deletes a customer. It cannot be undone. Also immediately cancels any active subscriptions on the customer.
+        """
+        ...
+
+    @overload
     def delete(self, **params: Unpack["Customer.DeleteParams"]) -> "Customer":
         """
         Permanently deletes a customer. It cannot be undone. Also immediately cancels any active subscriptions on the customer.
@@ -1584,6 +1610,20 @@ class Customer(
     @classmethod
     def delete_discount(
         cls,
+        customer: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Customer.DeleteDiscountParams"]
+    ) -> "Discount":
+        """
+        Removes the currently applied discount on a customer.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def delete_discount(
         customer: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
@@ -1697,6 +1737,20 @@ class Customer(
         ...
 
     @overload
+    @staticmethod
+    def list_payment_methods(
+        customer: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Customer.ListPaymentMethodsParams"]
+    ) -> ListObject["PaymentMethod"]:
+        """
+        Returns a list of PaymentMethods for a given Customer
+        """
+        ...
+
+    @overload
     def list_payment_methods(
         self,
         idempotency_key: Optional[str] = None,
@@ -1786,6 +1840,21 @@ class Customer(
     @classmethod
     def retrieve_payment_method(
         cls,
+        customer: str,
+        payment_method: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Customer.RetrievePaymentMethodParams"]
+    ) -> "PaymentMethod":
+        """
+        Retrieves a PaymentMethod object for a given Customer.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def retrieve_payment_method(
         customer: str,
         payment_method: str,
         api_key: Optional[str] = None,
@@ -2346,6 +2415,20 @@ class Customer(
         @classmethod
         def fund_cash_balance(
             cls,
+            customer: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Customer.FundCashBalanceParams"]
+        ) -> "CustomerCashBalanceTransaction":
+            """
+            Create an incoming testmode bank transfer
+            """
+            ...
+
+        @overload
+        @staticmethod
+        def fund_cash_balance(
             customer: str,
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,

--- a/stripe/api_resources/dispute.py
+++ b/stripe/api_resources/dispute.py
@@ -473,23 +473,6 @@ class Dispute(
         )
 
     @overload
-    @classmethod
-    def close(
-        cls,
-        dispute: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Dispute.CloseParams"]
-    ) -> "Dispute":
-        """
-        Closing the dispute for a charge indicates that you do not have any evidence to submit and are essentially dismissing the dispute, acknowledging it as lost.
-
-        The status of the dispute will change from needs_response to lost. Closing a dispute is irreversible.
-        """
-        ...
-
-    @overload
     @staticmethod
     def close(
         dispute: str,

--- a/stripe/api_resources/dispute.py
+++ b/stripe/api_resources/dispute.py
@@ -490,6 +490,22 @@ class Dispute(
         ...
 
     @overload
+    @staticmethod
+    def close(
+        dispute: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Dispute.CloseParams"]
+    ) -> "Dispute":
+        """
+        Closing the dispute for a charge indicates that you do not have any evidence to submit and are essentially dismissing the dispute, acknowledging it as lost.
+
+        The status of the dispute will change from needs_response to lost. Closing a dispute is irreversible.
+        """
+        ...
+
+    @overload
     def close(
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/ephemeral_key.py
+++ b/stripe/api_resources/ephemeral_key.py
@@ -68,6 +68,16 @@ class EphemeralKey(DeletableAPIResource["EphemeralKey"]):
         ...
 
     @overload
+    @staticmethod
+    def delete(
+        sid: str, **params: Unpack["EphemeralKey.DeleteParams"]
+    ) -> "EphemeralKey":
+        """
+        Invalidates a short-lived API key for a given resource.
+        """
+        ...
+
+    @overload
     def delete(
         self, **params: Unpack["EphemeralKey.DeleteParams"]
     ) -> "EphemeralKey":

--- a/stripe/api_resources/ephemeral_key.py
+++ b/stripe/api_resources/ephemeral_key.py
@@ -58,16 +58,6 @@ class EphemeralKey(DeletableAPIResource["EphemeralKey"]):
         )
 
     @overload
-    @classmethod
-    def delete(
-        cls, sid: str, **params: Unpack["EphemeralKey.DeleteParams"]
-    ) -> "EphemeralKey":
-        """
-        Invalidates a short-lived API key for a given resource.
-        """
-        ...
-
-    @overload
     @staticmethod
     def delete(
         sid: str, **params: Unpack["EphemeralKey.DeleteParams"]

--- a/stripe/api_resources/financial_connections/account.py
+++ b/stripe/api_resources/financial_connections/account.py
@@ -328,6 +328,20 @@ class Account(ListableAPIResource["Account"]):
         ...
 
     @overload
+    @staticmethod
+    def disconnect(
+        account: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Account.DisconnectParams"]
+    ) -> "Account":
+        """
+        Disables your access to a Financial Connections Account. You will no longer be able to access data associated with the account (e.g. balances, transactions).
+        """
+        ...
+
+    @overload
     def disconnect(
         self,
         idempotency_key: Optional[str] = None,
@@ -429,6 +443,20 @@ class Account(ListableAPIResource["Account"]):
         ...
 
     @overload
+    @staticmethod
+    def list_owners(
+        account: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Account.ListOwnersParams"]
+    ) -> ListObject["AccountOwner"]:
+        """
+        Lists all owners for a given Account
+        """
+        ...
+
+    @overload
     def list_owners(
         self,
         idempotency_key: Optional[str] = None,
@@ -490,6 +518,20 @@ class Account(ListableAPIResource["Account"]):
     @classmethod
     def refresh_account(
         cls,
+        account: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Account.RefreshAccountParams"]
+    ) -> "Account":
+        """
+        Refreshes the data associated with a Financial Connections Account.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def refresh_account(
         account: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,

--- a/stripe/api_resources/financial_connections/account.py
+++ b/stripe/api_resources/financial_connections/account.py
@@ -313,21 +313,6 @@ class Account(ListableAPIResource["Account"]):
         )
 
     @overload
-    @classmethod
-    def disconnect(
-        cls,
-        account: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Account.DisconnectParams"]
-    ) -> "Account":
-        """
-        Disables your access to a Financial Connections Account. You will no longer be able to access data associated with the account (e.g. balances, transactions).
-        """
-        ...
-
-    @overload
     @staticmethod
     def disconnect(
         account: str,
@@ -428,21 +413,6 @@ class Account(ListableAPIResource["Account"]):
         )
 
     @overload
-    @classmethod
-    def list_owners(
-        cls,
-        account: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Account.ListOwnersParams"]
-    ) -> ListObject["AccountOwner"]:
-        """
-        Lists all owners for a given Account
-        """
-        ...
-
-    @overload
     @staticmethod
     def list_owners(
         account: str,
@@ -513,21 +483,6 @@ class Account(ListableAPIResource["Account"]):
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def refresh_account(
-        cls,
-        account: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Account.RefreshAccountParams"]
-    ) -> "Account":
-        """
-        Refreshes the data associated with a Financial Connections Account.
-        """
-        ...
 
     @overload
     @staticmethod

--- a/stripe/api_resources/identity/verification_session.py
+++ b/stripe/api_resources/identity/verification_session.py
@@ -447,6 +447,22 @@ class VerificationSession(
         ...
 
     @overload
+    @staticmethod
+    def cancel(
+        session: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["VerificationSession.CancelParams"]
+    ) -> "VerificationSession":
+        """
+        A VerificationSession object can be canceled when it is in requires_input [status](https://stripe.com/docs/identity/how-sessions-work).
+
+        Once canceled, future submission attempts are disabled. This cannot be undone. [Learn more](https://stripe.com/docs/identity/verification-sessions#cancel).
+        """
+        ...
+
+    @overload
     def cancel(
         self,
         idempotency_key: Optional[str] = None,
@@ -605,6 +621,38 @@ class VerificationSession(
     @classmethod
     def redact(
         cls,
+        session: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["VerificationSession.RedactParams"]
+    ) -> "VerificationSession":
+        """
+        Redact a VerificationSession to remove all collected information from Stripe. This will redact
+        the VerificationSession and all objects related to it, including VerificationReports, Events,
+        request logs, etc.
+
+        A VerificationSession object can be redacted when it is in requires_input or verified
+        [status](https://stripe.com/docs/identity/how-sessions-work). Redacting a VerificationSession in requires_action
+        state will automatically cancel it.
+
+        The redaction process may take up to four days. When the redaction process is in progress, the
+        VerificationSession's redaction.status field will be set to processing; when the process is
+        finished, it will change to redacted and an identity.verification_session.redacted event
+        will be emitted.
+
+        Redaction is irreversible. Redacted objects are still accessible in the Stripe API, but all the
+        fields that contain personal data will be replaced by the string [redacted] or a similar
+        placeholder. The metadata field will also be erased. Redacted objects cannot be updated or
+        used for any purpose.
+
+        [Learn more](https://stripe.com/docs/identity/verification-sessions#redact).
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def redact(
         session: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,

--- a/stripe/api_resources/identity/verification_session.py
+++ b/stripe/api_resources/identity/verification_session.py
@@ -430,23 +430,6 @@ class VerificationSession(
         )
 
     @overload
-    @classmethod
-    def cancel(
-        cls,
-        session: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["VerificationSession.CancelParams"]
-    ) -> "VerificationSession":
-        """
-        A VerificationSession object can be canceled when it is in requires_input [status](https://stripe.com/docs/identity/how-sessions-work).
-
-        Once canceled, future submission attempts are disabled. This cannot be undone. [Learn more](https://stripe.com/docs/identity/verification-sessions#cancel).
-        """
-        ...
-
-    @overload
     @staticmethod
     def cancel(
         session: str,
@@ -616,39 +599,6 @@ class VerificationSession(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def redact(
-        cls,
-        session: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["VerificationSession.RedactParams"]
-    ) -> "VerificationSession":
-        """
-        Redact a VerificationSession to remove all collected information from Stripe. This will redact
-        the VerificationSession and all objects related to it, including VerificationReports, Events,
-        request logs, etc.
-
-        A VerificationSession object can be redacted when it is in requires_input or verified
-        [status](https://stripe.com/docs/identity/how-sessions-work). Redacting a VerificationSession in requires_action
-        state will automatically cancel it.
-
-        The redaction process may take up to four days. When the redaction process is in progress, the
-        VerificationSession's redaction.status field will be set to processing; when the process is
-        finished, it will change to redacted and an identity.verification_session.redacted event
-        will be emitted.
-
-        Redaction is irreversible. Redacted objects are still accessible in the Stripe API, but all the
-        fields that contain personal data will be replaced by the string [redacted] or a similar
-        placeholder. The metadata field will also be erased. Redacted objects cannot be updated or
-        used for any purpose.
-
-        [Learn more](https://stripe.com/docs/identity/verification-sessions#redact).
-        """
-        ...
 
     @overload
     @staticmethod

--- a/stripe/api_resources/invoice.py
+++ b/stripe/api_resources/invoice.py
@@ -3644,16 +3644,6 @@ class Invoice(
         )
 
     @overload
-    @classmethod
-    def delete(
-        cls, sid: str, **params: Unpack["Invoice.DeleteParams"]
-    ) -> "Invoice":
-        """
-        Permanently deletes a one-off invoice draft. This cannot be undone. Attempts to delete invoices that are no longer in a draft state will fail; once an invoice has been finalized or if an invoice is for a subscription, it must be [voided](https://stripe.com/docs/api#void_invoice).
-        """
-        ...
-
-    @overload
     @staticmethod
     def delete(
         sid: str, **params: Unpack["Invoice.DeleteParams"]
@@ -3708,21 +3698,6 @@ class Invoice(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def finalize_invoice(
-        cls,
-        invoice: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Invoice.FinalizeInvoiceParams"]
-    ) -> "Invoice":
-        """
-        Stripe automatically finalizes drafts before sending and attempting payment on invoices. However, if you'd like to finalize a draft invoice manually, you can do so using this method.
-        """
-        ...
 
     @overload
     @staticmethod
@@ -3825,21 +3800,6 @@ class Invoice(
         )
 
     @overload
-    @classmethod
-    def mark_uncollectible(
-        cls,
-        invoice: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Invoice.MarkUncollectibleParams"]
-    ) -> "Invoice":
-        """
-        Marking an invoice as uncollectible is useful for keeping track of bad debts that can be written off for accounting purposes.
-        """
-        ...
-
-    @overload
     @staticmethod
     def mark_uncollectible(
         invoice: str,
@@ -3930,21 +3890,6 @@ class Invoice(
         )
 
     @overload
-    @classmethod
-    def pay(
-        cls,
-        invoice: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Invoice.PayParams"]
-    ) -> "Invoice":
-        """
-        Stripe automatically creates and then attempts to collect payment on invoices for customers on subscriptions according to your [subscriptions settings](https://dashboard.stripe.com/account/billing/automatic). However, if you'd like to attempt payment on an invoice out of the normal collection schedule or for some other reason, you can do so.
-        """
-        ...
-
-    @overload
     @staticmethod
     def pay(
         invoice: str,
@@ -4028,23 +3973,6 @@ class Invoice(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def send_invoice(
-        cls,
-        invoice: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Invoice.SendInvoiceParams"]
-    ) -> "Invoice":
-        """
-        Stripe will automatically send invoices to customers according to your [subscriptions settings](https://dashboard.stripe.com/account/billing/automatic). However, if you'd like to manually send an invoice to your customer out of the normal schedule, you can do so. When sending invoices that have already been paid, there will be no reference to the payment in the email.
-
-        Requests made in test-mode result in no emails being sent, despite sending an invoice.sent event.
-        """
-        ...
 
     @overload
     @staticmethod
@@ -4173,21 +4101,6 @@ class Invoice(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def void_invoice(
-        cls,
-        invoice: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Invoice.VoidInvoiceParams"]
-    ) -> "Invoice":
-        """
-        Mark a finalized invoice as void. This cannot be undone. Voiding an invoice is similar to [deletion](https://stripe.com/docs/api#delete_invoice), however it only applies to finalized invoices and maintains a papertrail where the invoice can still be found.
-        """
-        ...
 
     @overload
     @staticmethod

--- a/stripe/api_resources/invoice.py
+++ b/stripe/api_resources/invoice.py
@@ -3654,6 +3654,16 @@ class Invoice(
         ...
 
     @overload
+    @staticmethod
+    def delete(
+        sid: str, **params: Unpack["Invoice.DeleteParams"]
+    ) -> "Invoice":
+        """
+        Permanently deletes a one-off invoice draft. This cannot be undone. Attempts to delete invoices that are no longer in a draft state will fail; once an invoice has been finalized or if an invoice is for a subscription, it must be [voided](https://stripe.com/docs/api#void_invoice).
+        """
+        ...
+
+    @overload
     def delete(self, **params: Unpack["Invoice.DeleteParams"]) -> "Invoice":
         """
         Permanently deletes a one-off invoice draft. This cannot be undone. Attempts to delete invoices that are no longer in a draft state will fail; once an invoice has been finalized or if an invoice is for a subscription, it must be [voided](https://stripe.com/docs/api#void_invoice).
@@ -3703,6 +3713,20 @@ class Invoice(
     @classmethod
     def finalize_invoice(
         cls,
+        invoice: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Invoice.FinalizeInvoiceParams"]
+    ) -> "Invoice":
+        """
+        Stripe automatically finalizes drafts before sending and attempting payment on invoices. However, if you'd like to finalize a draft invoice manually, you can do so using this method.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def finalize_invoice(
         invoice: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
@@ -3816,6 +3840,20 @@ class Invoice(
         ...
 
     @overload
+    @staticmethod
+    def mark_uncollectible(
+        invoice: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Invoice.MarkUncollectibleParams"]
+    ) -> "Invoice":
+        """
+        Marking an invoice as uncollectible is useful for keeping track of bad debts that can be written off for accounting purposes.
+        """
+        ...
+
+    @overload
     def mark_uncollectible(
         self,
         idempotency_key: Optional[str] = None,
@@ -3907,6 +3945,20 @@ class Invoice(
         ...
 
     @overload
+    @staticmethod
+    def pay(
+        invoice: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Invoice.PayParams"]
+    ) -> "Invoice":
+        """
+        Stripe automatically creates and then attempts to collect payment on invoices for customers on subscriptions according to your [subscriptions settings](https://dashboard.stripe.com/account/billing/automatic). However, if you'd like to attempt payment on an invoice out of the normal collection schedule or for some other reason, you can do so.
+        """
+        ...
+
+    @overload
     def pay(
         self,
         idempotency_key: Optional[str] = None,
@@ -3981,6 +4033,22 @@ class Invoice(
     @classmethod
     def send_invoice(
         cls,
+        invoice: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Invoice.SendInvoiceParams"]
+    ) -> "Invoice":
+        """
+        Stripe will automatically send invoices to customers according to your [subscriptions settings](https://dashboard.stripe.com/account/billing/automatic). However, if you'd like to manually send an invoice to your customer out of the normal schedule, you can do so. When sending invoices that have already been paid, there will be no reference to the payment in the email.
+
+        Requests made in test-mode result in no emails being sent, despite sending an invoice.sent event.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def send_invoice(
         invoice: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
@@ -4110,6 +4178,20 @@ class Invoice(
     @classmethod
     def void_invoice(
         cls,
+        invoice: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Invoice.VoidInvoiceParams"]
+    ) -> "Invoice":
+        """
+        Mark a finalized invoice as void. This cannot be undone. Voiding an invoice is similar to [deletion](https://stripe.com/docs/api#delete_invoice), however it only applies to finalized invoices and maintains a papertrail where the invoice can still be found.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def void_invoice(
         invoice: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,

--- a/stripe/api_resources/invoice_item.py
+++ b/stripe/api_resources/invoice_item.py
@@ -503,6 +503,16 @@ class InvoiceItem(
         ...
 
     @overload
+    @staticmethod
+    def delete(
+        sid: str, **params: Unpack["InvoiceItem.DeleteParams"]
+    ) -> "InvoiceItem":
+        """
+        Deletes an invoice item, removing it from an invoice. Deleting invoice items is only possible when they're not attached to invoices, or if it's attached to a draft invoice.
+        """
+        ...
+
+    @overload
     def delete(
         self, **params: Unpack["InvoiceItem.DeleteParams"]
     ) -> "InvoiceItem":

--- a/stripe/api_resources/invoice_item.py
+++ b/stripe/api_resources/invoice_item.py
@@ -493,16 +493,6 @@ class InvoiceItem(
         )
 
     @overload
-    @classmethod
-    def delete(
-        cls, sid: str, **params: Unpack["InvoiceItem.DeleteParams"]
-    ) -> "InvoiceItem":
-        """
-        Deletes an invoice item, removing it from an invoice. Deleting invoice items is only possible when they're not attached to invoices, or if it's attached to a draft invoice.
-        """
-        ...
-
-    @overload
     @staticmethod
     def delete(
         sid: str, **params: Unpack["InvoiceItem.DeleteParams"]

--- a/stripe/api_resources/issuing/authorization.py
+++ b/stripe/api_resources/issuing/authorization.py
@@ -780,6 +780,21 @@ class Authorization(
         ...
 
     @overload
+    @staticmethod
+    def approve(
+        authorization: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Authorization.ApproveParams"]
+    ) -> "Authorization":
+        """
+        [Deprecated] Approves a pending Issuing Authorization object. This request should be made within the timeout window of the [real-time authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations) flow.
+        This method is deprecated. Instead, [respond directly to the webhook request to approve an authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations#authorization-handling).
+        """
+        ...
+
+    @overload
     def approve(
         self,
         idempotency_key: Optional[str] = None,
@@ -844,6 +859,21 @@ class Authorization(
     @classmethod
     def decline(
         cls,
+        authorization: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Authorization.DeclineParams"]
+    ) -> "Authorization":
+        """
+        [Deprecated] Declines a pending Issuing Authorization object. This request should be made within the timeout window of the [real time authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations) flow.
+        This method is deprecated. Instead, [respond directly to the webhook request to decline an authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations#authorization-handling).
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def decline(
         authorization: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
@@ -987,6 +1017,20 @@ class Authorization(
             ...
 
         @overload
+        @staticmethod
+        def capture(
+            authorization: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Authorization.CaptureParams"]
+        ) -> "Authorization":
+            """
+            Capture a test-mode authorization.
+            """
+            ...
+
+        @overload
         def capture(
             self,
             idempotency_key: Optional[str] = None,
@@ -1083,6 +1127,20 @@ class Authorization(
             ...
 
         @overload
+        @staticmethod
+        def expire(
+            authorization: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Authorization.ExpireParams"]
+        ) -> "Authorization":
+            """
+            Expire a test-mode Authorization.
+            """
+            ...
+
+        @overload
         def expire(
             self,
             idempotency_key: Optional[str] = None,
@@ -1156,6 +1214,20 @@ class Authorization(
             ...
 
         @overload
+        @staticmethod
+        def increment(
+            authorization: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Authorization.IncrementParams"]
+        ) -> "Authorization":
+            """
+            Increment a test-mode Authorization.
+            """
+            ...
+
+        @overload
         def increment(
             self,
             idempotency_key: Optional[str] = None,
@@ -1217,6 +1289,20 @@ class Authorization(
         @classmethod
         def reverse(
             cls,
+            authorization: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Authorization.ReverseParams"]
+        ) -> "Authorization":
+            """
+            Reverse a test-mode Authorization.
+            """
+            ...
+
+        @overload
+        @staticmethod
+        def reverse(
             authorization: str,
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,

--- a/stripe/api_resources/issuing/authorization.py
+++ b/stripe/api_resources/issuing/authorization.py
@@ -764,22 +764,6 @@ class Authorization(
         )
 
     @overload
-    @classmethod
-    def approve(
-        cls,
-        authorization: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Authorization.ApproveParams"]
-    ) -> "Authorization":
-        """
-        [Deprecated] Approves a pending Issuing Authorization object. This request should be made within the timeout window of the [real-time authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations) flow.
-        This method is deprecated. Instead, [respond directly to the webhook request to approve an authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations#authorization-handling).
-        """
-        ...
-
-    @overload
     @staticmethod
     def approve(
         authorization: str,
@@ -854,22 +838,6 @@ class Authorization(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def decline(
-        cls,
-        authorization: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Authorization.DeclineParams"]
-    ) -> "Authorization":
-        """
-        [Deprecated] Declines a pending Issuing Authorization object. This request should be made within the timeout window of the [real time authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations) flow.
-        This method is deprecated. Instead, [respond directly to the webhook request to decline an authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations#authorization-handling).
-        """
-        ...
 
     @overload
     @staticmethod
@@ -1002,21 +970,6 @@ class Authorization(
             )
 
         @overload
-        @classmethod
-        def capture(
-            cls,
-            authorization: str,
-            api_key: Optional[str] = None,
-            stripe_version: Optional[str] = None,
-            stripe_account: Optional[str] = None,
-            **params: Unpack["Authorization.CaptureParams"]
-        ) -> "Authorization":
-            """
-            Capture a test-mode authorization.
-            """
-            ...
-
-        @overload
         @staticmethod
         def capture(
             authorization: str,
@@ -1112,21 +1065,6 @@ class Authorization(
             )
 
         @overload
-        @classmethod
-        def expire(
-            cls,
-            authorization: str,
-            api_key: Optional[str] = None,
-            stripe_version: Optional[str] = None,
-            stripe_account: Optional[str] = None,
-            **params: Unpack["Authorization.ExpireParams"]
-        ) -> "Authorization":
-            """
-            Expire a test-mode Authorization.
-            """
-            ...
-
-        @overload
         @staticmethod
         def expire(
             authorization: str,
@@ -1199,21 +1137,6 @@ class Authorization(
             )
 
         @overload
-        @classmethod
-        def increment(
-            cls,
-            authorization: str,
-            api_key: Optional[str] = None,
-            stripe_version: Optional[str] = None,
-            stripe_account: Optional[str] = None,
-            **params: Unpack["Authorization.IncrementParams"]
-        ) -> "Authorization":
-            """
-            Increment a test-mode Authorization.
-            """
-            ...
-
-        @overload
         @staticmethod
         def increment(
             authorization: str,
@@ -1284,21 +1207,6 @@ class Authorization(
                     params=params,
                 ),
             )
-
-        @overload
-        @classmethod
-        def reverse(
-            cls,
-            authorization: str,
-            api_key: Optional[str] = None,
-            stripe_version: Optional[str] = None,
-            stripe_account: Optional[str] = None,
-            **params: Unpack["Authorization.ReverseParams"]
-        ) -> "Authorization":
-            """
-            Reverse a test-mode Authorization.
-            """
-            ...
 
         @overload
         @staticmethod

--- a/stripe/api_resources/issuing/card.py
+++ b/stripe/api_resources/issuing/card.py
@@ -1653,6 +1653,20 @@ class Card(
             ...
 
         @overload
+        @staticmethod
+        def deliver_card(
+            card: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Card.DeliverCardParams"]
+        ) -> "Card":
+            """
+            Updates the shipping status of the specified Issuing Card object to delivered.
+            """
+            ...
+
+        @overload
         def deliver_card(
             self,
             idempotency_key: Optional[str] = None,
@@ -1714,6 +1728,20 @@ class Card(
         @classmethod
         def fail_card(
             cls,
+            card: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Card.FailCardParams"]
+        ) -> "Card":
+            """
+            Updates the shipping status of the specified Issuing Card object to failure.
+            """
+            ...
+
+        @overload
+        @staticmethod
+        def fail_card(
             card: str,
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
@@ -1799,6 +1827,20 @@ class Card(
             ...
 
         @overload
+        @staticmethod
+        def return_card(
+            card: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Card.ReturnCardParams"]
+        ) -> "Card":
+            """
+            Updates the shipping status of the specified Issuing Card object to returned.
+            """
+            ...
+
+        @overload
         def return_card(
             self,
             idempotency_key: Optional[str] = None,
@@ -1860,6 +1902,20 @@ class Card(
         @classmethod
         def ship_card(
             cls,
+            card: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Card.ShipCardParams"]
+        ) -> "Card":
+            """
+            Updates the shipping status of the specified Issuing Card object to shipped.
+            """
+            ...
+
+        @overload
+        @staticmethod
+        def ship_card(
             card: str,
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,

--- a/stripe/api_resources/issuing/card.py
+++ b/stripe/api_resources/issuing/card.py
@@ -1638,21 +1638,6 @@ class Card(
             )
 
         @overload
-        @classmethod
-        def deliver_card(
-            cls,
-            card: str,
-            api_key: Optional[str] = None,
-            stripe_version: Optional[str] = None,
-            stripe_account: Optional[str] = None,
-            **params: Unpack["Card.DeliverCardParams"]
-        ) -> "Card":
-            """
-            Updates the shipping status of the specified Issuing Card object to delivered.
-            """
-            ...
-
-        @overload
         @staticmethod
         def deliver_card(
             card: str,
@@ -1723,21 +1708,6 @@ class Card(
                     params=params,
                 ),
             )
-
-        @overload
-        @classmethod
-        def fail_card(
-            cls,
-            card: str,
-            api_key: Optional[str] = None,
-            stripe_version: Optional[str] = None,
-            stripe_account: Optional[str] = None,
-            **params: Unpack["Card.FailCardParams"]
-        ) -> "Card":
-            """
-            Updates the shipping status of the specified Issuing Card object to failure.
-            """
-            ...
 
         @overload
         @staticmethod
@@ -1812,21 +1782,6 @@ class Card(
             )
 
         @overload
-        @classmethod
-        def return_card(
-            cls,
-            card: str,
-            api_key: Optional[str] = None,
-            stripe_version: Optional[str] = None,
-            stripe_account: Optional[str] = None,
-            **params: Unpack["Card.ReturnCardParams"]
-        ) -> "Card":
-            """
-            Updates the shipping status of the specified Issuing Card object to returned.
-            """
-            ...
-
-        @overload
         @staticmethod
         def return_card(
             card: str,
@@ -1897,21 +1852,6 @@ class Card(
                     params=params,
                 ),
             )
-
-        @overload
-        @classmethod
-        def ship_card(
-            cls,
-            card: str,
-            api_key: Optional[str] = None,
-            stripe_version: Optional[str] = None,
-            stripe_account: Optional[str] = None,
-            **params: Unpack["Card.ShipCardParams"]
-        ) -> "Card":
-            """
-            Updates the shipping status of the specified Issuing Card object to shipped.
-            """
-            ...
 
         @overload
         @staticmethod

--- a/stripe/api_resources/issuing/dispute.py
+++ b/stripe/api_resources/issuing/dispute.py
@@ -966,21 +966,6 @@ class Dispute(
         )
 
     @overload
-    @classmethod
-    def submit(
-        cls,
-        dispute: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Dispute.SubmitParams"]
-    ) -> "Dispute":
-        """
-        Submits an Issuing Dispute to the card network. Stripe validates that all evidence fields required for the dispute's reason are present. For more details, see [Dispute reasons and evidence](https://stripe.com/docs/issuing/purchases/disputes#dispute-reasons-and-evidence).
-        """
-        ...
-
-    @overload
     @staticmethod
     def submit(
         dispute: str,

--- a/stripe/api_resources/issuing/dispute.py
+++ b/stripe/api_resources/issuing/dispute.py
@@ -981,6 +981,20 @@ class Dispute(
         ...
 
     @overload
+    @staticmethod
+    def submit(
+        dispute: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Dispute.SubmitParams"]
+    ) -> "Dispute":
+        """
+        Submits an Issuing Dispute to the card network. Stripe validates that all evidence fields required for the dispute's reason are present. For more details, see [Dispute reasons and evidence](https://stripe.com/docs/issuing/purchases/disputes#dispute-reasons-and-evidence).
+        """
+        ...
+
+    @overload
     def submit(
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/issuing/transaction.py
+++ b/stripe/api_resources/issuing/transaction.py
@@ -884,21 +884,6 @@ class Transaction(
             )
 
         @overload
-        @classmethod
-        def refund(
-            cls,
-            transaction: str,
-            api_key: Optional[str] = None,
-            stripe_version: Optional[str] = None,
-            stripe_account: Optional[str] = None,
-            **params: Unpack["Transaction.RefundParams"]
-        ) -> "Transaction":
-            """
-            Refund a test-mode Transaction.
-            """
-            ...
-
-        @overload
         @staticmethod
         def refund(
             transaction: str,

--- a/stripe/api_resources/issuing/transaction.py
+++ b/stripe/api_resources/issuing/transaction.py
@@ -899,6 +899,20 @@ class Transaction(
             ...
 
         @overload
+        @staticmethod
+        def refund(
+            transaction: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Transaction.RefundParams"]
+        ) -> "Transaction":
+            """
+            Refund a test-mode Transaction.
+            """
+            ...
+
+        @overload
         def refund(
             self,
             idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/payment_intent.py
+++ b/stripe/api_resources/payment_intent.py
@@ -7457,21 +7457,6 @@ class PaymentIntent(
         )
 
     @overload
-    @classmethod
-    def apply_customer_balance(
-        cls,
-        intent: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentIntent.ApplyCustomerBalanceParams"]
-    ) -> "PaymentIntent":
-        """
-        Manually reconcile the remaining amount for a customer_balance PaymentIntent.
-        """
-        ...
-
-    @overload
     @staticmethod
     def apply_customer_balance(
         intent: str,
@@ -7546,25 +7531,6 @@ class PaymentIntent(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def cancel(
-        cls,
-        intent: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentIntent.CancelParams"]
-    ) -> "PaymentIntent":
-        """
-        You can cancel a PaymentIntent object when it's in one of these statuses: requires_payment_method, requires_capture, requires_confirmation, requires_action or, [in rare cases](https://stripe.com/docs/payments/intents), processing.
-
-        After it's canceled, no additional charges are made by the PaymentIntent and any operations on the PaymentIntent fail with an error. For PaymentIntents with a status of requires_capture, the remaining amount_capturable is automatically refunded.
-
-        You can't cancel the PaymentIntent for a Checkout Session. [Expire the Checkout Session](https://stripe.com/docs/api/checkout/sessions/expire) instead.
-        """
-        ...
 
     @overload
     @staticmethod
@@ -7653,25 +7619,6 @@ class PaymentIntent(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def capture(
-        cls,
-        intent: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentIntent.CaptureParams"]
-    ) -> "PaymentIntent":
-        """
-        Capture the funds of an existing uncaptured PaymentIntent when its status is requires_capture.
-
-        Uncaptured PaymentIntents are cancelled a set number of days (7 by default) after their creation.
-
-        Learn more about [separate authorization and capture](https://stripe.com/docs/payments/capture-later).
-        """
-        ...
 
     @overload
     @staticmethod
@@ -7778,43 +7725,6 @@ class PaymentIntent(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def confirm(
-        cls,
-        intent: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentIntent.ConfirmParams"]
-    ) -> "PaymentIntent":
-        """
-        Confirm that your customer intends to pay with current or provided
-        payment method. Upon confirmation, the PaymentIntent will attempt to initiate
-        a payment.
-        If the selected payment method requires additional authentication steps, the
-        PaymentIntent will transition to the requires_action status and
-        suggest additional actions via next_action. If payment fails,
-        the PaymentIntent transitions to the requires_payment_method status or the
-        canceled status if the confirmation limit is reached. If
-        payment succeeds, the PaymentIntent will transition to the succeeded
-        status (or requires_capture, if capture_method is set to manual).
-        If the confirmation_method is automatic, payment may be attempted
-        using our [client SDKs](https://stripe.com/docs/stripe-js/reference#stripe-handle-card-payment)
-        and the PaymentIntent's [client_secret](https://stripe.com/docs/api#payment_intent_object-client_secret).
-        After next_actions are handled by the client, no additional
-        confirmation is required to complete the payment.
-        If the confirmation_method is manual, all payment attempts must be
-        initiated using a secret key.
-        If any actions are required for the payment, the PaymentIntent will
-        return to the requires_confirmation state
-        after those actions are completed. Your server needs to then
-        explicitly re-confirm the PaymentIntent to initiate the next payment
-        attempt. Read the [expanded documentation](https://stripe.com/docs/payments/payment-intents/web-manual)
-        to learn more about manual confirmation.
-        """
-        ...
 
     @overload
     @staticmethod
@@ -8010,44 +7920,6 @@ class PaymentIntent(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def increment_authorization(
-        cls,
-        intent: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentIntent.IncrementAuthorizationParams"]
-    ) -> "PaymentIntent":
-        """
-        Perform an incremental authorization on an eligible
-        [PaymentIntent](https://stripe.com/docs/api/payment_intents/object). To be eligible, the
-        PaymentIntent's status must be requires_capture and
-        [incremental_authorization_supported](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card_present-incremental_authorization_supported)
-        must be true.
-
-        Incremental authorizations attempt to increase the authorized amount on
-        your customer's card to the new, higher amount provided. Similar to the
-        initial authorization, incremental authorizations can be declined. A
-        single PaymentIntent can call this endpoint multiple times to further
-        increase the authorized amount.
-
-        If the incremental authorization succeeds, the PaymentIntent object
-        returns with the updated
-        [amount](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-amount).
-        If the incremental authorization fails, a
-        [card_declined](https://stripe.com/docs/error-codes#card-declined) error returns, and no other
-        fields on the PaymentIntent or Charge update. The PaymentIntent
-        object remains capturable for the previously authorized amount.
-
-        Each PaymentIntent can have a maximum of 10 incremental authorization attempts, including declines.
-        After it's captured, a PaymentIntent can no longer be incremented.
-
-        Learn more about [incremental authorizations](https://stripe.com/docs/terminal/features/incremental-authorizations).
-        """
-        ...
 
     @overload
     @staticmethod
@@ -8251,21 +8123,6 @@ class PaymentIntent(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def verify_microdeposits(
-        cls,
-        intent: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentIntent.VerifyMicrodepositsParams"]
-    ) -> "PaymentIntent":
-        """
-        Verifies microdeposits on a PaymentIntent object.
-        """
-        ...
 
     @overload
     @staticmethod

--- a/stripe/api_resources/payment_intent.py
+++ b/stripe/api_resources/payment_intent.py
@@ -7472,6 +7472,20 @@ class PaymentIntent(
         ...
 
     @overload
+    @staticmethod
+    def apply_customer_balance(
+        intent: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["PaymentIntent.ApplyCustomerBalanceParams"]
+    ) -> "PaymentIntent":
+        """
+        Manually reconcile the remaining amount for a customer_balance PaymentIntent.
+        """
+        ...
+
+    @overload
     def apply_customer_balance(
         self,
         idempotency_key: Optional[str] = None,
@@ -7537,6 +7551,24 @@ class PaymentIntent(
     @classmethod
     def cancel(
         cls,
+        intent: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["PaymentIntent.CancelParams"]
+    ) -> "PaymentIntent":
+        """
+        You can cancel a PaymentIntent object when it's in one of these statuses: requires_payment_method, requires_capture, requires_confirmation, requires_action or, [in rare cases](https://stripe.com/docs/payments/intents), processing.
+
+        After it's canceled, no additional charges are made by the PaymentIntent and any operations on the PaymentIntent fail with an error. For PaymentIntents with a status of requires_capture, the remaining amount_capturable is automatically refunded.
+
+        You can't cancel the PaymentIntent for a Checkout Session. [Expire the Checkout Session](https://stripe.com/docs/api/checkout/sessions/expire) instead.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def cancel(
         intent: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
@@ -7626,6 +7658,24 @@ class PaymentIntent(
     @classmethod
     def capture(
         cls,
+        intent: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["PaymentIntent.CaptureParams"]
+    ) -> "PaymentIntent":
+        """
+        Capture the funds of an existing uncaptured PaymentIntent when its status is requires_capture.
+
+        Uncaptured PaymentIntents are cancelled a set number of days (7 by default) after their creation.
+
+        Learn more about [separate authorization and capture](https://stripe.com/docs/payments/capture-later).
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def capture(
         intent: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
@@ -7733,6 +7783,42 @@ class PaymentIntent(
     @classmethod
     def confirm(
         cls,
+        intent: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["PaymentIntent.ConfirmParams"]
+    ) -> "PaymentIntent":
+        """
+        Confirm that your customer intends to pay with current or provided
+        payment method. Upon confirmation, the PaymentIntent will attempt to initiate
+        a payment.
+        If the selected payment method requires additional authentication steps, the
+        PaymentIntent will transition to the requires_action status and
+        suggest additional actions via next_action. If payment fails,
+        the PaymentIntent transitions to the requires_payment_method status or the
+        canceled status if the confirmation limit is reached. If
+        payment succeeds, the PaymentIntent will transition to the succeeded
+        status (or requires_capture, if capture_method is set to manual).
+        If the confirmation_method is automatic, payment may be attempted
+        using our [client SDKs](https://stripe.com/docs/stripe-js/reference#stripe-handle-card-payment)
+        and the PaymentIntent's [client_secret](https://stripe.com/docs/api#payment_intent_object-client_secret).
+        After next_actions are handled by the client, no additional
+        confirmation is required to complete the payment.
+        If the confirmation_method is manual, all payment attempts must be
+        initiated using a secret key.
+        If any actions are required for the payment, the PaymentIntent will
+        return to the requires_confirmation state
+        after those actions are completed. Your server needs to then
+        explicitly re-confirm the PaymentIntent to initiate the next payment
+        attempt. Read the [expanded documentation](https://stripe.com/docs/payments/payment-intents/web-manual)
+        to learn more about manual confirmation.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def confirm(
         intent: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
@@ -7964,6 +8050,43 @@ class PaymentIntent(
         ...
 
     @overload
+    @staticmethod
+    def increment_authorization(
+        intent: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["PaymentIntent.IncrementAuthorizationParams"]
+    ) -> "PaymentIntent":
+        """
+        Perform an incremental authorization on an eligible
+        [PaymentIntent](https://stripe.com/docs/api/payment_intents/object). To be eligible, the
+        PaymentIntent's status must be requires_capture and
+        [incremental_authorization_supported](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card_present-incremental_authorization_supported)
+        must be true.
+
+        Incremental authorizations attempt to increase the authorized amount on
+        your customer's card to the new, higher amount provided. Similar to the
+        initial authorization, incremental authorizations can be declined. A
+        single PaymentIntent can call this endpoint multiple times to further
+        increase the authorized amount.
+
+        If the incremental authorization succeeds, the PaymentIntent object
+        returns with the updated
+        [amount](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-amount).
+        If the incremental authorization fails, a
+        [card_declined](https://stripe.com/docs/error-codes#card-declined) error returns, and no other
+        fields on the PaymentIntent or Charge update. The PaymentIntent
+        object remains capturable for the previously authorized amount.
+
+        Each PaymentIntent can have a maximum of 10 incremental authorization attempts, including declines.
+        After it's captured, a PaymentIntent can no longer be incremented.
+
+        Learn more about [incremental authorizations](https://stripe.com/docs/terminal/features/incremental-authorizations).
+        """
+        ...
+
+    @overload
     def increment_authorization(
         self,
         idempotency_key: Optional[str] = None,
@@ -8133,6 +8256,20 @@ class PaymentIntent(
     @classmethod
     def verify_microdeposits(
         cls,
+        intent: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["PaymentIntent.VerifyMicrodepositsParams"]
+    ) -> "PaymentIntent":
+        """
+        Verifies microdeposits on a PaymentIntent object.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def verify_microdeposits(
         intent: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,

--- a/stripe/api_resources/payment_link.py
+++ b/stripe/api_resources/payment_link.py
@@ -2195,6 +2195,20 @@ class PaymentLink(
         ...
 
     @overload
+    @staticmethod
+    def list_line_items(
+        payment_link: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["PaymentLink.ListLineItemsParams"]
+    ) -> ListObject["LineItem"]:
+        """
+        When retrieving a payment link, there is an includable line_items property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.
+        """
+        ...
+
+    @overload
     def list_line_items(
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/payment_link.py
+++ b/stripe/api_resources/payment_link.py
@@ -2180,21 +2180,6 @@ class PaymentLink(
         )
 
     @overload
-    @classmethod
-    def list_line_items(
-        cls,
-        payment_link: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentLink.ListLineItemsParams"]
-    ) -> ListObject["LineItem"]:
-        """
-        When retrieving a payment link, there is an includable line_items property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.
-        """
-        ...
-
-    @overload
     @staticmethod
     def list_line_items(
         payment_link: str,

--- a/stripe/api_resources/payment_method.py
+++ b/stripe/api_resources/payment_method.py
@@ -1759,6 +1759,32 @@ class PaymentMethod(
         ...
 
     @overload
+    @staticmethod
+    def attach(
+        payment_method: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["PaymentMethod.AttachParams"]
+    ) -> "PaymentMethod":
+        """
+        Attaches a PaymentMethod object to a Customer.
+
+        To attach a new PaymentMethod to a customer for future payments, we recommend you use a [SetupIntent](https://stripe.com/docs/api/setup_intents)
+        or a PaymentIntent with [setup_future_usage](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-setup_future_usage).
+        These approaches will perform any necessary steps to set up the PaymentMethod for future payments. Using the /v1/payment_methods/:id/attach
+        endpoint without first using a SetupIntent or PaymentIntent with setup_future_usage does not optimize the PaymentMethod for
+        future use, which makes later declines and payment friction more likely.
+        See [Optimizing cards for future payments](https://stripe.com/docs/payments/payment-intents#future-usage) for more information about setting up
+        future payments.
+
+        To use this PaymentMethod as the default for invoice or subscription payments,
+        set [invoice_settings.default_payment_method](https://stripe.com/docs/api/customers/update#update_customer-invoice_settings-default_payment_method),
+        on the Customer to the PaymentMethod's ID.
+        """
+        ...
+
+    @overload
     def attach(
         self,
         idempotency_key: Optional[str] = None,
@@ -1871,6 +1897,20 @@ class PaymentMethod(
     @classmethod
     def detach(
         cls,
+        payment_method: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["PaymentMethod.DetachParams"]
+    ) -> "PaymentMethod":
+        """
+        Detaches a PaymentMethod object from a Customer. After a PaymentMethod is detached, it can no longer be used for a payment or re-attached to a Customer.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def detach(
         payment_method: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,

--- a/stripe/api_resources/payment_method.py
+++ b/stripe/api_resources/payment_method.py
@@ -1732,33 +1732,6 @@ class PaymentMethod(
         )
 
     @overload
-    @classmethod
-    def attach(
-        cls,
-        payment_method: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentMethod.AttachParams"]
-    ) -> "PaymentMethod":
-        """
-        Attaches a PaymentMethod object to a Customer.
-
-        To attach a new PaymentMethod to a customer for future payments, we recommend you use a [SetupIntent](https://stripe.com/docs/api/setup_intents)
-        or a PaymentIntent with [setup_future_usage](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-setup_future_usage).
-        These approaches will perform any necessary steps to set up the PaymentMethod for future payments. Using the /v1/payment_methods/:id/attach
-        endpoint without first using a SetupIntent or PaymentIntent with setup_future_usage does not optimize the PaymentMethod for
-        future use, which makes later declines and payment friction more likely.
-        See [Optimizing cards for future payments](https://stripe.com/docs/payments/payment-intents#future-usage) for more information about setting up
-        future payments.
-
-        To use this PaymentMethod as the default for invoice or subscription payments,
-        set [invoice_settings.default_payment_method](https://stripe.com/docs/api/customers/update#update_customer-invoice_settings-default_payment_method),
-        on the Customer to the PaymentMethod's ID.
-        """
-        ...
-
-    @overload
     @staticmethod
     def attach(
         payment_method: str,
@@ -1892,21 +1865,6 @@ class PaymentMethod(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def detach(
-        cls,
-        payment_method: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentMethod.DetachParams"]
-    ) -> "PaymentMethod":
-        """
-        Detaches a PaymentMethod object from a Customer. After a PaymentMethod is detached, it can no longer be used for a payment or re-attached to a Customer.
-        """
-        ...
 
     @overload
     @staticmethod

--- a/stripe/api_resources/payment_method_domain.py
+++ b/stripe/api_resources/payment_method_domain.py
@@ -315,26 +315,6 @@ class PaymentMethodDomain(
         )
 
     @overload
-    @classmethod
-    def validate(
-        cls,
-        payment_method_domain: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentMethodDomain.ValidateParams"]
-    ) -> "PaymentMethodDomain":
-        """
-        Some payment methods such as Apple Pay require additional steps to verify a domain. If the requirements weren't satisfied when the domain was created, the payment method will be inactive on the domain.
-        The payment method doesn't appear in Elements for this domain until it is active.
-
-        To activate a payment method on an existing payment method domain, complete the required validation steps specific to the payment method, and then validate the payment method domain with this endpoint.
-
-        Related guides: [Payment method domains](https://stripe.com/docs/payments/payment-methods/pmd-registration).
-        """
-        ...
-
-    @overload
     @staticmethod
     def validate(
         payment_method_domain: str,

--- a/stripe/api_resources/payment_method_domain.py
+++ b/stripe/api_resources/payment_method_domain.py
@@ -335,6 +335,25 @@ class PaymentMethodDomain(
         ...
 
     @overload
+    @staticmethod
+    def validate(
+        payment_method_domain: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["PaymentMethodDomain.ValidateParams"]
+    ) -> "PaymentMethodDomain":
+        """
+        Some payment methods such as Apple Pay require additional steps to verify a domain. If the requirements weren't satisfied when the domain was created, the payment method will be inactive on the domain.
+        The payment method doesn't appear in Elements for this domain until it is active.
+
+        To activate a payment method on an existing payment method domain, complete the required validation steps specific to the payment method, and then validate the payment method domain with this endpoint.
+
+        Related guides: [Payment method domains](https://stripe.com/docs/payments/payment-methods/pmd-registration).
+        """
+        ...
+
+    @overload
     def validate(
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/payout.py
+++ b/stripe/api_resources/payout.py
@@ -305,21 +305,6 @@ class Payout(
         )
 
     @overload
-    @classmethod
-    def cancel(
-        cls,
-        payout: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Payout.CancelParams"]
-    ) -> "Payout":
-        """
-        You can cancel a previously created payout if it hasn't been paid out yet. Stripe refunds the funds to your available balance. You can't cancel automatic Stripe payouts.
-        """
-        ...
-
-    @overload
     @staticmethod
     def cancel(
         payout: str,
@@ -473,23 +458,6 @@ class Payout(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def reverse(
-        cls,
-        payout: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Payout.ReverseParams"]
-    ) -> "Payout":
-        """
-        Reverses a payout by debiting the destination bank account. At this time, you can only reverse payouts for connected accounts to US bank accounts. If the payout is in the pending status, use /v1/payouts/:id/cancel instead.
-
-        By requesting a reversal through /v1/payouts/:id/reverse, you confirm that the authorized signatory of the selected bank account authorizes the debit on the bank account and that no other authorization is required.
-        """
-        ...
 
     @overload
     @staticmethod

--- a/stripe/api_resources/payout.py
+++ b/stripe/api_resources/payout.py
@@ -320,6 +320,20 @@ class Payout(
         ...
 
     @overload
+    @staticmethod
+    def cancel(
+        payout: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Payout.CancelParams"]
+    ) -> "Payout":
+        """
+        You can cancel a previously created payout if it hasn't been paid out yet. Stripe refunds the funds to your available balance. You can't cancel automatic Stripe payouts.
+        """
+        ...
+
+    @overload
     def cancel(
         self,
         idempotency_key: Optional[str] = None,
@@ -464,6 +478,22 @@ class Payout(
     @classmethod
     def reverse(
         cls,
+        payout: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Payout.ReverseParams"]
+    ) -> "Payout":
+        """
+        Reverses a payout by debiting the destination bank account. At this time, you can only reverse payouts for connected accounts to US bank accounts. If the payout is in the pending status, use /v1/payouts/:id/cancel instead.
+
+        By requesting a reversal through /v1/payouts/:id/reverse, you confirm that the authorized signatory of the selected bank account authorizes the debit on the bank account and that no other authorization is required.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def reverse(
         payout: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,

--- a/stripe/api_resources/plan.py
+++ b/stripe/api_resources/plan.py
@@ -426,14 +426,6 @@ class Plan(
         )
 
     @overload
-    @classmethod
-    def delete(cls, sid: str, **params: Unpack["Plan.DeleteParams"]) -> "Plan":
-        """
-        Deleting plans means new subscribers can't be added. Existing subscribers aren't affected.
-        """
-        ...
-
-    @overload
     @staticmethod
     def delete(sid: str, **params: Unpack["Plan.DeleteParams"]) -> "Plan":
         """

--- a/stripe/api_resources/plan.py
+++ b/stripe/api_resources/plan.py
@@ -434,6 +434,14 @@ class Plan(
         ...
 
     @overload
+    @staticmethod
+    def delete(sid: str, **params: Unpack["Plan.DeleteParams"]) -> "Plan":
+        """
+        Deleting plans means new subscribers can't be added. Existing subscribers aren't affected.
+        """
+        ...
+
+    @overload
     def delete(self, **params: Unpack["Plan.DeleteParams"]) -> "Plan":
         """
         Deleting plans means new subscribers can't be added. Existing subscribers aren't affected.

--- a/stripe/api_resources/product.py
+++ b/stripe/api_resources/product.py
@@ -588,16 +588,6 @@ class Product(
         )
 
     @overload
-    @classmethod
-    def delete(
-        cls, sid: str, **params: Unpack["Product.DeleteParams"]
-    ) -> "Product":
-        """
-        Delete a product. Deleting a product is only possible if it has no prices associated with it. Additionally, deleting a product with type=good is only possible if it has no SKUs associated with it.
-        """
-        ...
-
-    @overload
     @staticmethod
     def delete(
         sid: str, **params: Unpack["Product.DeleteParams"]

--- a/stripe/api_resources/product.py
+++ b/stripe/api_resources/product.py
@@ -598,6 +598,16 @@ class Product(
         ...
 
     @overload
+    @staticmethod
+    def delete(
+        sid: str, **params: Unpack["Product.DeleteParams"]
+    ) -> "Product":
+        """
+        Delete a product. Deleting a product is only possible if it has no prices associated with it. Additionally, deleting a product with type=good is only possible if it has no SKUs associated with it.
+        """
+        ...
+
+    @overload
     def delete(self, **params: Unpack["Product.DeleteParams"]) -> "Product":
         """
         Delete a product. Deleting a product is only possible if it has no prices associated with it. Additionally, deleting a product with type=good is only possible if it has no SKUs associated with it.

--- a/stripe/api_resources/quote.py
+++ b/stripe/api_resources/quote.py
@@ -1056,21 +1056,6 @@ class Quote(
         )
 
     @overload
-    @classmethod
-    def accept(
-        cls,
-        quote: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Quote.AcceptParams"]
-    ) -> "Quote":
-        """
-        Accepts the specified quote.
-        """
-        ...
-
-    @overload
     @staticmethod
     def accept(
         quote: str,
@@ -1141,21 +1126,6 @@ class Quote(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def cancel(
-        cls,
-        quote: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Quote.CancelParams"]
-    ) -> "Quote":
-        """
-        Cancels the quote.
-        """
-        ...
 
     @overload
     @staticmethod
@@ -1253,21 +1223,6 @@ class Quote(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def finalize_quote(
-        cls,
-        quote: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Quote.FinalizeQuoteParams"]
-    ) -> "Quote":
-        """
-        Finalizes the quote.
-        """
-        ...
 
     @overload
     @staticmethod
@@ -1370,21 +1325,6 @@ class Quote(
         )
 
     @overload
-    @classmethod
-    def list_computed_upfront_line_items(
-        cls,
-        quote: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Quote.ListComputedUpfrontLineItemsParams"]
-    ) -> ListObject["LineItem"]:
-        """
-        When retrieving a quote, there is an includable [computed.upfront.line_items](https://stripe.com/docs/api/quotes/object#quote_object-computed-upfront-line_items) property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of upfront line items.
-        """
-        ...
-
-    @overload
     @staticmethod
     def list_computed_upfront_line_items(
         quote: str,
@@ -1455,21 +1395,6 @@ class Quote(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def list_line_items(
-        cls,
-        quote: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Quote.ListLineItemsParams"]
-    ) -> ListObject["LineItem"]:
-        """
-        When retrieving a quote, there is an includable line_items property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.
-        """
-        ...
 
     @overload
     @staticmethod

--- a/stripe/api_resources/quote.py
+++ b/stripe/api_resources/quote.py
@@ -1071,6 +1071,20 @@ class Quote(
         ...
 
     @overload
+    @staticmethod
+    def accept(
+        quote: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Quote.AcceptParams"]
+    ) -> "Quote":
+        """
+        Accepts the specified quote.
+        """
+        ...
+
+    @overload
     def accept(
         self,
         idempotency_key: Optional[str] = None,
@@ -1132,6 +1146,20 @@ class Quote(
     @classmethod
     def cancel(
         cls,
+        quote: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Quote.CancelParams"]
+    ) -> "Quote":
+        """
+        Cancels the quote.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def cancel(
         quote: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
@@ -1230,6 +1258,20 @@ class Quote(
     @classmethod
     def finalize_quote(
         cls,
+        quote: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Quote.FinalizeQuoteParams"]
+    ) -> "Quote":
+        """
+        Finalizes the quote.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def finalize_quote(
         quote: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
@@ -1343,6 +1385,20 @@ class Quote(
         ...
 
     @overload
+    @staticmethod
+    def list_computed_upfront_line_items(
+        quote: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Quote.ListComputedUpfrontLineItemsParams"]
+    ) -> ListObject["LineItem"]:
+        """
+        When retrieving a quote, there is an includable [computed.upfront.line_items](https://stripe.com/docs/api/quotes/object#quote_object-computed-upfront-line_items) property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of upfront line items.
+        """
+        ...
+
+    @overload
     def list_computed_upfront_line_items(
         self,
         idempotency_key: Optional[str] = None,
@@ -1404,6 +1460,20 @@ class Quote(
     @classmethod
     def list_line_items(
         cls,
+        quote: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Quote.ListLineItemsParams"]
+    ) -> ListObject["LineItem"]:
+        """
+        When retrieving a quote, there is an includable line_items property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def list_line_items(
         quote: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,

--- a/stripe/api_resources/radar/value_list.py
+++ b/stripe/api_resources/radar/value_list.py
@@ -229,16 +229,6 @@ class ValueList(
         )
 
     @overload
-    @classmethod
-    def delete(
-        cls, sid: str, **params: Unpack["ValueList.DeleteParams"]
-    ) -> "ValueList":
-        """
-        Deletes a ValueList object, also deleting any items contained within the value list. To be deleted, a value list must not be referenced in any rules.
-        """
-        ...
-
-    @overload
     @staticmethod
     def delete(
         sid: str, **params: Unpack["ValueList.DeleteParams"]

--- a/stripe/api_resources/radar/value_list.py
+++ b/stripe/api_resources/radar/value_list.py
@@ -239,6 +239,16 @@ class ValueList(
         ...
 
     @overload
+    @staticmethod
+    def delete(
+        sid: str, **params: Unpack["ValueList.DeleteParams"]
+    ) -> "ValueList":
+        """
+        Deletes a ValueList object, also deleting any items contained within the value list. To be deleted, a value list must not be referenced in any rules.
+        """
+        ...
+
+    @overload
     def delete(
         self, **params: Unpack["ValueList.DeleteParams"]
     ) -> "ValueList":

--- a/stripe/api_resources/radar/value_list_item.py
+++ b/stripe/api_resources/radar/value_list_item.py
@@ -175,16 +175,6 @@ class ValueListItem(
         )
 
     @overload
-    @classmethod
-    def delete(
-        cls, sid: str, **params: Unpack["ValueListItem.DeleteParams"]
-    ) -> "ValueListItem":
-        """
-        Deletes a ValueListItem object, removing it from its parent value list.
-        """
-        ...
-
-    @overload
     @staticmethod
     def delete(
         sid: str, **params: Unpack["ValueListItem.DeleteParams"]

--- a/stripe/api_resources/radar/value_list_item.py
+++ b/stripe/api_resources/radar/value_list_item.py
@@ -185,6 +185,16 @@ class ValueListItem(
         ...
 
     @overload
+    @staticmethod
+    def delete(
+        sid: str, **params: Unpack["ValueListItem.DeleteParams"]
+    ) -> "ValueListItem":
+        """
+        Deletes a ValueListItem object, removing it from its parent value list.
+        """
+        ...
+
+    @overload
     def delete(
         self, **params: Unpack["ValueListItem.DeleteParams"]
     ) -> "ValueListItem":

--- a/stripe/api_resources/refund.py
+++ b/stripe/api_resources/refund.py
@@ -295,6 +295,22 @@ class Refund(
         ...
 
     @overload
+    @staticmethod
+    def cancel(
+        refund: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Refund.CancelParams"]
+    ) -> "Refund":
+        """
+        Cancels a refund with a status of requires_action.
+
+        You can't cancel refunds in other states. Only refunds for payment methods that require customer action can enter the requires_action state.
+        """
+        ...
+
+    @overload
     def cancel(
         self,
         idempotency_key: Optional[str] = None,
@@ -452,6 +468,20 @@ class Refund(
         @classmethod
         def expire(
             cls,
+            refund: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Refund.ExpireParams"]
+        ) -> "Refund":
+            """
+            Expire a refund with a status of requires_action.
+            """
+            ...
+
+        @overload
+        @staticmethod
+        def expire(
             refund: str,
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,

--- a/stripe/api_resources/refund.py
+++ b/stripe/api_resources/refund.py
@@ -278,23 +278,6 @@ class Refund(
         )
 
     @overload
-    @classmethod
-    def cancel(
-        cls,
-        refund: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Refund.CancelParams"]
-    ) -> "Refund":
-        """
-        Cancels a refund with a status of requires_action.
-
-        You can't cancel refunds in other states. Only refunds for payment methods that require customer action can enter the requires_action state.
-        """
-        ...
-
-    @overload
     @staticmethod
     def cancel(
         refund: str,
@@ -463,21 +446,6 @@ class Refund(
                     params=params,
                 ),
             )
-
-        @overload
-        @classmethod
-        def expire(
-            cls,
-            refund: str,
-            api_key: Optional[str] = None,
-            stripe_version: Optional[str] = None,
-            stripe_account: Optional[str] = None,
-            **params: Unpack["Refund.ExpireParams"]
-        ) -> "Refund":
-            """
-            Expire a refund with a status of requires_action.
-            """
-            ...
 
         @overload
         @staticmethod

--- a/stripe/api_resources/review.py
+++ b/stripe/api_resources/review.py
@@ -225,6 +225,20 @@ class Review(ListableAPIResource["Review"]):
         ...
 
     @overload
+    @staticmethod
+    def approve(
+        review: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Review.ApproveParams"]
+    ) -> "Review":
+        """
+        Approves a Review object, closing it and removing it from the list of reviews.
+        """
+        ...
+
+    @overload
     def approve(
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/review.py
+++ b/stripe/api_resources/review.py
@@ -210,21 +210,6 @@ class Review(ListableAPIResource["Review"]):
         )
 
     @overload
-    @classmethod
-    def approve(
-        cls,
-        review: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Review.ApproveParams"]
-    ) -> "Review":
-        """
-        Approves a Review object, closing it and removing it from the list of reviews.
-        """
-        ...
-
-    @overload
     @staticmethod
     def approve(
         review: str,

--- a/stripe/api_resources/setup_intent.py
+++ b/stripe/api_resources/setup_intent.py
@@ -3352,23 +3352,6 @@ class SetupIntent(
         )
 
     @overload
-    @classmethod
-    def cancel(
-        cls,
-        intent: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["SetupIntent.CancelParams"]
-    ) -> "SetupIntent":
-        """
-        You can cancel a SetupIntent object when it's in one of these statuses: requires_payment_method, requires_confirmation, or requires_action.
-
-        After you cancel it, setup is abandoned and any operations on the SetupIntent fail with an error.
-        """
-        ...
-
-    @overload
     @staticmethod
     def cancel(
         intent: str,
@@ -3458,34 +3441,6 @@ class SetupIntent(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def confirm(
-        cls,
-        intent: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["SetupIntent.ConfirmParams"]
-    ) -> "SetupIntent":
-        """
-        Confirm that your customer intends to set up the current or
-        provided payment method. For example, you would confirm a SetupIntent
-        when a customer hits the “Save” button on a payment method management
-        page on your website.
-
-        If the selected payment method does not require any additional
-        steps from the customer, the SetupIntent will transition to the
-        succeeded status.
-
-        Otherwise, it will transition to the requires_action status and
-        suggest additional actions via next_action. If setup fails,
-        the SetupIntent will transition to the
-        requires_payment_method status or the canceled status if the
-        confirmation limit is reached.
-        """
-        ...
 
     @overload
     @staticmethod
@@ -3681,21 +3636,6 @@ class SetupIntent(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def verify_microdeposits(
-        cls,
-        intent: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["SetupIntent.VerifyMicrodepositsParams"]
-    ) -> "SetupIntent":
-        """
-        Verifies microdeposits on a SetupIntent object.
-        """
-        ...
 
     @overload
     @staticmethod

--- a/stripe/api_resources/setup_intent.py
+++ b/stripe/api_resources/setup_intent.py
@@ -3369,6 +3369,22 @@ class SetupIntent(
         ...
 
     @overload
+    @staticmethod
+    def cancel(
+        intent: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["SetupIntent.CancelParams"]
+    ) -> "SetupIntent":
+        """
+        You can cancel a SetupIntent object when it's in one of these statuses: requires_payment_method, requires_confirmation, or requires_action.
+
+        After you cancel it, setup is abandoned and any operations on the SetupIntent fail with an error.
+        """
+        ...
+
+    @overload
     def cancel(
         self,
         idempotency_key: Optional[str] = None,
@@ -3447,6 +3463,33 @@ class SetupIntent(
     @classmethod
     def confirm(
         cls,
+        intent: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["SetupIntent.ConfirmParams"]
+    ) -> "SetupIntent":
+        """
+        Confirm that your customer intends to set up the current or
+        provided payment method. For example, you would confirm a SetupIntent
+        when a customer hits the “Save” button on a payment method management
+        page on your website.
+
+        If the selected payment method does not require any additional
+        steps from the customer, the SetupIntent will transition to the
+        succeeded status.
+
+        Otherwise, it will transition to the requires_action status and
+        suggest additional actions via next_action. If setup fails,
+        the SetupIntent will transition to the
+        requires_payment_method status or the canceled status if the
+        confirmation limit is reached.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def confirm(
         intent: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
@@ -3643,6 +3686,20 @@ class SetupIntent(
     @classmethod
     def verify_microdeposits(
         cls,
+        intent: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["SetupIntent.VerifyMicrodepositsParams"]
+    ) -> "SetupIntent":
+        """
+        Verifies microdeposits on a SetupIntent object.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def verify_microdeposits(
         intent: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,

--- a/stripe/api_resources/source.py
+++ b/stripe/api_resources/source.py
@@ -1205,6 +1205,20 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
         ...
 
     @overload
+    @staticmethod
+    def list_source_transactions(
+        source: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Source.ListSourceTransactionsParams"]
+    ) -> ListObject["SourceTransaction"]:
+        """
+        List source transactions for a given source.
+        """
+        ...
+
+    @overload
     def list_source_transactions(
         self,
         idempotency_key: Optional[str] = None,
@@ -1292,6 +1306,20 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
     @classmethod
     def verify(
         cls,
+        source: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Source.VerifyParams"]
+    ) -> "Source":
+        """
+        Verify a given source.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def verify(
         source: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,

--- a/stripe/api_resources/source.py
+++ b/stripe/api_resources/source.py
@@ -1190,21 +1190,6 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
         )
 
     @overload
-    @classmethod
-    def list_source_transactions(
-        cls,
-        source: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Source.ListSourceTransactionsParams"]
-    ) -> ListObject["SourceTransaction"]:
-        """
-        List source transactions for a given source.
-        """
-        ...
-
-    @overload
     @staticmethod
     def list_source_transactions(
         source: str,
@@ -1301,21 +1286,6 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def verify(
-        cls,
-        source: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Source.VerifyParams"]
-    ) -> "Source":
-        """
-        Verify a given source.
-        """
-        ...
 
     @overload
     @staticmethod

--- a/stripe/api_resources/subscription.py
+++ b/stripe/api_resources/subscription.py
@@ -1915,6 +1915,24 @@ class Subscription(
         ...
 
     @overload
+    @staticmethod
+    def cancel(
+        subscription_exposed_id: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Subscription.CancelParams"]
+    ) -> "Subscription":
+        """
+        Cancels a customer's subscription immediately. The customer will not be charged again for the subscription.
+
+        Note, however, that any pending invoice items that you've created will still be charged for at the end of the period, unless manually [deleted](https://stripe.com/docs/api#delete_invoiceitem). If you've set the subscription to cancel at the end of the period, any pending prorations will also be left in place and collected at the end of the period. But if the subscription is set to cancel immediately, pending prorations will be removed.
+
+        By default, upon subscription cancellation, Stripe will stop automatic collection of all finalized invoices for the customer. This is intended to prevent unexpected payment attempts after the customer has canceled a subscription. However, you can resume automatic collection of the invoices manually after subscription cancellation to have us proceed. Or, you could check for unpaid invoices before allowing the customer to cancel the subscription at all.
+        """
+        ...
+
+    @overload
     def cancel(
         self,
         idempotency_key: Optional[str] = None,
@@ -2017,6 +2035,20 @@ class Subscription(
     @classmethod
     def delete_discount(
         cls,
+        subscription_exposed_id: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Subscription.DeleteDiscountParams"]
+    ) -> "Discount":
+        """
+        Removes the currently applied discount on a subscription.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def delete_discount(
         subscription_exposed_id: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
@@ -2151,6 +2183,20 @@ class Subscription(
     @classmethod
     def resume(
         cls,
+        subscription: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Subscription.ResumeParams"]
+    ) -> "Subscription":
+        """
+        Initiates resumption of a paused subscription, optionally resetting the billing cycle anchor and creating prorations. If a resumption invoice is generated, it must be paid or marked uncollectible before the subscription will be unpaused. If payment succeeds the subscription will become active, and if payment fails the subscription will be past_due. The resumption invoice will void automatically if not paid by the expiration date.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def resume(
         subscription: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,

--- a/stripe/api_resources/subscription.py
+++ b/stripe/api_resources/subscription.py
@@ -1896,25 +1896,6 @@ class Subscription(
         )
 
     @overload
-    @classmethod
-    def cancel(
-        cls,
-        subscription_exposed_id: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Subscription.CancelParams"]
-    ) -> "Subscription":
-        """
-        Cancels a customer's subscription immediately. The customer will not be charged again for the subscription.
-
-        Note, however, that any pending invoice items that you've created will still be charged for at the end of the period, unless manually [deleted](https://stripe.com/docs/api#delete_invoiceitem). If you've set the subscription to cancel at the end of the period, any pending prorations will also be left in place and collected at the end of the period. But if the subscription is set to cancel immediately, pending prorations will be removed.
-
-        By default, upon subscription cancellation, Stripe will stop automatic collection of all finalized invoices for the customer. This is intended to prevent unexpected payment attempts after the customer has canceled a subscription. However, you can resume automatic collection of the invoices manually after subscription cancellation to have us proceed. Or, you could check for unpaid invoices before allowing the customer to cancel the subscription at all.
-        """
-        ...
-
-    @overload
     @staticmethod
     def cancel(
         subscription_exposed_id: str,
@@ -2030,21 +2011,6 @@ class Subscription(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def delete_discount(
-        cls,
-        subscription_exposed_id: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Subscription.DeleteDiscountParams"]
-    ) -> "Discount":
-        """
-        Removes the currently applied discount on a subscription.
-        """
-        ...
 
     @overload
     @staticmethod
@@ -2178,21 +2144,6 @@ class Subscription(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def resume(
-        cls,
-        subscription: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Subscription.ResumeParams"]
-    ) -> "Subscription":
-        """
-        Initiates resumption of a paused subscription, optionally resetting the billing cycle anchor and creating prorations. If a resumption invoice is generated, it must be paid or marked uncollectible before the subscription will be unpaused. If payment succeeds the subscription will become active, and if payment fails the subscription will be past_due. The resumption invoice will void automatically if not paid by the expiration date.
-        """
-        ...
 
     @overload
     @staticmethod

--- a/stripe/api_resources/subscription_item.py
+++ b/stripe/api_resources/subscription_item.py
@@ -445,16 +445,6 @@ class SubscriptionItem(
         )
 
     @overload
-    @classmethod
-    def delete(
-        cls, sid: str, **params: Unpack["SubscriptionItem.DeleteParams"]
-    ) -> "SubscriptionItem":
-        """
-        Deletes an item from the subscription. Removing a subscription item from a subscription will not cancel the subscription.
-        """
-        ...
-
-    @overload
     @staticmethod
     def delete(
         sid: str, **params: Unpack["SubscriptionItem.DeleteParams"]

--- a/stripe/api_resources/subscription_item.py
+++ b/stripe/api_resources/subscription_item.py
@@ -455,6 +455,16 @@ class SubscriptionItem(
         ...
 
     @overload
+    @staticmethod
+    def delete(
+        sid: str, **params: Unpack["SubscriptionItem.DeleteParams"]
+    ) -> "SubscriptionItem":
+        """
+        Deletes an item from the subscription. Removing a subscription item from a subscription will not cancel the subscription.
+        """
+        ...
+
+    @overload
     def delete(
         self, **params: Unpack["SubscriptionItem.DeleteParams"]
     ) -> "SubscriptionItem":

--- a/stripe/api_resources/subscription_schedule.py
+++ b/stripe/api_resources/subscription_schedule.py
@@ -1323,21 +1323,6 @@ class SubscriptionSchedule(
         )
 
     @overload
-    @classmethod
-    def cancel(
-        cls,
-        schedule: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["SubscriptionSchedule.CancelParams"]
-    ) -> "SubscriptionSchedule":
-        """
-        Cancels a subscription schedule and its associated subscription immediately (if the subscription schedule has an active subscription). A subscription schedule can only be canceled if its status is not_started or active.
-        """
-        ...
-
-    @overload
     @staticmethod
     def cancel(
         schedule: str,
@@ -1474,21 +1459,6 @@ class SubscriptionSchedule(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def release(
-        cls,
-        schedule: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["SubscriptionSchedule.ReleaseParams"]
-    ) -> "SubscriptionSchedule":
-        """
-        Releases the subscription schedule immediately, which will stop scheduling of its phases, but leave any existing subscription in place. A schedule can only be released if its status is not_started or active. If the subscription schedule is currently associated with a subscription, releasing it will remove its subscription property and set the subscription's ID to the released_subscription property.
-        """
-        ...
 
     @overload
     @staticmethod

--- a/stripe/api_resources/subscription_schedule.py
+++ b/stripe/api_resources/subscription_schedule.py
@@ -1338,6 +1338,20 @@ class SubscriptionSchedule(
         ...
 
     @overload
+    @staticmethod
+    def cancel(
+        schedule: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["SubscriptionSchedule.CancelParams"]
+    ) -> "SubscriptionSchedule":
+        """
+        Cancels a subscription schedule and its associated subscription immediately (if the subscription schedule has an active subscription). A subscription schedule can only be canceled if its status is not_started or active.
+        """
+        ...
+
+    @overload
     def cancel(
         self,
         idempotency_key: Optional[str] = None,
@@ -1465,6 +1479,20 @@ class SubscriptionSchedule(
     @classmethod
     def release(
         cls,
+        schedule: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["SubscriptionSchedule.ReleaseParams"]
+    ) -> "SubscriptionSchedule":
+        """
+        Releases the subscription schedule immediately, which will stop scheduling of its phases, but leave any existing subscription in place. A schedule can only be released if its status is not_started or active. If the subscription schedule is currently associated with a subscription, releasing it will remove its subscription property and set the subscription's ID to the released_subscription property.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def release(
         schedule: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,

--- a/stripe/api_resources/tax/calculation.py
+++ b/stripe/api_resources/tax/calculation.py
@@ -695,6 +695,20 @@ class Calculation(CreateableAPIResource["Calculation"]):
         ...
 
     @overload
+    @staticmethod
+    def list_line_items(
+        calculation: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Calculation.ListLineItemsParams"]
+    ) -> ListObject["CalculationLineItem"]:
+        """
+        Retrieves the line items of a persisted tax calculation as a collection.
+        """
+        ...
+
+    @overload
     def list_line_items(
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/tax/calculation.py
+++ b/stripe/api_resources/tax/calculation.py
@@ -680,21 +680,6 @@ class Calculation(CreateableAPIResource["Calculation"]):
         )
 
     @overload
-    @classmethod
-    def list_line_items(
-        cls,
-        calculation: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Calculation.ListLineItemsParams"]
-    ) -> ListObject["CalculationLineItem"]:
-        """
-        Retrieves the line items of a persisted tax calculation as a collection.
-        """
-        ...
-
-    @overload
     @staticmethod
     def list_line_items(
         calculation: str,

--- a/stripe/api_resources/tax/transaction.py
+++ b/stripe/api_resources/tax/transaction.py
@@ -542,6 +542,20 @@ class Transaction(APIResource["Transaction"]):
         ...
 
     @overload
+    @staticmethod
+    def list_line_items(
+        transaction: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Transaction.ListLineItemsParams"]
+    ) -> ListObject["TransactionLineItem"]:
+        """
+        Retrieves the line items of a committed standalone transaction as a collection.
+        """
+        ...
+
+    @overload
     def list_line_items(
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/tax/transaction.py
+++ b/stripe/api_resources/tax/transaction.py
@@ -527,21 +527,6 @@ class Transaction(APIResource["Transaction"]):
         )
 
     @overload
-    @classmethod
-    def list_line_items(
-        cls,
-        transaction: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Transaction.ListLineItemsParams"]
-    ) -> ListObject["TransactionLineItem"]:
-        """
-        Retrieves the line items of a committed standalone transaction as a collection.
-        """
-        ...
-
-    @overload
     @staticmethod
     def list_line_items(
         transaction: str,

--- a/stripe/api_resources/terminal/configuration.py
+++ b/stripe/api_resources/terminal/configuration.py
@@ -996,6 +996,16 @@ class Configuration(
         ...
 
     @overload
+    @staticmethod
+    def delete(
+        sid: str, **params: Unpack["Configuration.DeleteParams"]
+    ) -> "Configuration":
+        """
+        Deletes a Configuration object.
+        """
+        ...
+
+    @overload
     def delete(
         self, **params: Unpack["Configuration.DeleteParams"]
     ) -> "Configuration":

--- a/stripe/api_resources/terminal/configuration.py
+++ b/stripe/api_resources/terminal/configuration.py
@@ -986,16 +986,6 @@ class Configuration(
         )
 
     @overload
-    @classmethod
-    def delete(
-        cls, sid: str, **params: Unpack["Configuration.DeleteParams"]
-    ) -> "Configuration":
-        """
-        Deletes a Configuration object.
-        """
-        ...
-
-    @overload
     @staticmethod
     def delete(
         sid: str, **params: Unpack["Configuration.DeleteParams"]

--- a/stripe/api_resources/terminal/location.py
+++ b/stripe/api_resources/terminal/location.py
@@ -256,16 +256,6 @@ class Location(
         )
 
     @overload
-    @classmethod
-    def delete(
-        cls, sid: str, **params: Unpack["Location.DeleteParams"]
-    ) -> "Location":
-        """
-        Deletes a Location object.
-        """
-        ...
-
-    @overload
     @staticmethod
     def delete(
         sid: str, **params: Unpack["Location.DeleteParams"]

--- a/stripe/api_resources/terminal/location.py
+++ b/stripe/api_resources/terminal/location.py
@@ -266,6 +266,16 @@ class Location(
         ...
 
     @overload
+    @staticmethod
+    def delete(
+        sid: str, **params: Unpack["Location.DeleteParams"]
+    ) -> "Location":
+        """
+        Deletes a Location object.
+        """
+        ...
+
+    @overload
     def delete(self, **params: Unpack["Location.DeleteParams"]) -> "Location":
         """
         Deletes a Location object.

--- a/stripe/api_resources/terminal/reader.py
+++ b/stripe/api_resources/terminal/reader.py
@@ -581,6 +581,20 @@ class Reader(
         ...
 
     @overload
+    @staticmethod
+    def cancel_action(
+        reader: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Reader.CancelActionParams"]
+    ) -> "Reader":
+        """
+        Cancels the current reader action.
+        """
+        ...
+
+    @overload
     def cancel_action(
         self,
         idempotency_key: Optional[str] = None,
@@ -655,6 +669,14 @@ class Reader(
     def delete(
         cls, sid: str, **params: Unpack["Reader.DeleteParams"]
     ) -> "Reader":
+        """
+        Deletes a Reader object.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def delete(sid: str, **params: Unpack["Reader.DeleteParams"]) -> "Reader":
         """
         Deletes a Reader object.
         """
@@ -763,6 +785,20 @@ class Reader(
         ...
 
     @overload
+    @staticmethod
+    def process_payment_intent(
+        reader: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Reader.ProcessPaymentIntentParams"]
+    ) -> "Reader":
+        """
+        Initiates a payment flow on a Reader.
+        """
+        ...
+
+    @overload
     def process_payment_intent(
         self,
         idempotency_key: Optional[str] = None,
@@ -836,6 +872,20 @@ class Reader(
         ...
 
     @overload
+    @staticmethod
+    def process_setup_intent(
+        reader: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Reader.ProcessSetupIntentParams"]
+    ) -> "Reader":
+        """
+        Initiates a setup intent flow on a Reader.
+        """
+        ...
+
+    @overload
     def process_setup_intent(
         self,
         idempotency_key: Optional[str] = None,
@@ -897,6 +947,20 @@ class Reader(
     @classmethod
     def refund_payment(
         cls,
+        reader: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Reader.RefundPaymentParams"]
+    ) -> "Reader":
+        """
+        Initiates a refund on a Reader
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def refund_payment(
         reader: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
@@ -993,6 +1057,20 @@ class Reader(
         ...
 
     @overload
+    @staticmethod
+    def set_reader_display(
+        reader: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Reader.SetReaderDisplayParams"]
+    ) -> "Reader":
+        """
+        Sets reader display to show cart details.
+        """
+        ...
+
+    @overload
     def set_reader_display(
         self,
         idempotency_key: Optional[str] = None,
@@ -1057,6 +1135,20 @@ class Reader(
         @classmethod
         def present_payment_method(
             cls,
+            reader: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["Reader.PresentPaymentMethodParams"]
+        ) -> "Reader":
+            """
+            Presents a payment method on a simulated reader. Can be used to simulate accepting a payment, saving a card or refunding a transaction.
+            """
+            ...
+
+        @overload
+        @staticmethod
+        def present_payment_method(
             reader: str,
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,

--- a/stripe/api_resources/terminal/reader.py
+++ b/stripe/api_resources/terminal/reader.py
@@ -566,21 +566,6 @@ class Reader(
         )
 
     @overload
-    @classmethod
-    def cancel_action(
-        cls,
-        reader: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Reader.CancelActionParams"]
-    ) -> "Reader":
-        """
-        Cancels the current reader action.
-        """
-        ...
-
-    @overload
     @staticmethod
     def cancel_action(
         reader: str,
@@ -663,16 +648,6 @@ class Reader(
             "Reader",
             cls._static_request("delete", url, params=params),
         )
-
-    @overload
-    @classmethod
-    def delete(
-        cls, sid: str, **params: Unpack["Reader.DeleteParams"]
-    ) -> "Reader":
-        """
-        Deletes a Reader object.
-        """
-        ...
 
     @overload
     @staticmethod
@@ -770,21 +745,6 @@ class Reader(
         )
 
     @overload
-    @classmethod
-    def process_payment_intent(
-        cls,
-        reader: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Reader.ProcessPaymentIntentParams"]
-    ) -> "Reader":
-        """
-        Initiates a payment flow on a Reader.
-        """
-        ...
-
-    @overload
     @staticmethod
     def process_payment_intent(
         reader: str,
@@ -857,21 +817,6 @@ class Reader(
         )
 
     @overload
-    @classmethod
-    def process_setup_intent(
-        cls,
-        reader: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Reader.ProcessSetupIntentParams"]
-    ) -> "Reader":
-        """
-        Initiates a setup intent flow on a Reader.
-        """
-        ...
-
-    @overload
     @staticmethod
     def process_setup_intent(
         reader: str,
@@ -942,21 +887,6 @@ class Reader(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def refund_payment(
-        cls,
-        reader: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Reader.RefundPaymentParams"]
-    ) -> "Reader":
-        """
-        Initiates a refund on a Reader
-        """
-        ...
 
     @overload
     @staticmethod
@@ -1042,21 +972,6 @@ class Reader(
         )
 
     @overload
-    @classmethod
-    def set_reader_display(
-        cls,
-        reader: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Reader.SetReaderDisplayParams"]
-    ) -> "Reader":
-        """
-        Sets reader display to show cart details.
-        """
-        ...
-
-    @overload
     @staticmethod
     def set_reader_display(
         reader: str,
@@ -1130,21 +1045,6 @@ class Reader(
                     params=params,
                 ),
             )
-
-        @overload
-        @classmethod
-        def present_payment_method(
-            cls,
-            reader: str,
-            api_key: Optional[str] = None,
-            stripe_version: Optional[str] = None,
-            stripe_account: Optional[str] = None,
-            **params: Unpack["Reader.PresentPaymentMethodParams"]
-        ) -> "Reader":
-            """
-            Presents a payment method on a simulated reader. Can be used to simulate accepting a payment, saving a card or refunding a transaction.
-            """
-            ...
 
         @overload
         @staticmethod

--- a/stripe/api_resources/test_helpers/test_clock.py
+++ b/stripe/api_resources/test_helpers/test_clock.py
@@ -160,6 +160,20 @@ class TestClock(
         ...
 
     @overload
+    @staticmethod
+    def advance(
+        test_clock: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["TestClock.AdvanceParams"]
+    ) -> "TestClock":
+        """
+        Starts advancing a test clock to a specified time in the future. Advancement is done when status changes to Ready.
+        """
+        ...
+
+    @overload
     def advance(
         self,
         idempotency_key: Optional[str] = None,
@@ -233,6 +247,16 @@ class TestClock(
     @classmethod
     def delete(
         cls, sid: str, **params: Unpack["TestClock.DeleteParams"]
+    ) -> "TestClock":
+        """
+        Deletes a test clock.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def delete(
+        sid: str, **params: Unpack["TestClock.DeleteParams"]
     ) -> "TestClock":
         """
         Deletes a test clock.

--- a/stripe/api_resources/test_helpers/test_clock.py
+++ b/stripe/api_resources/test_helpers/test_clock.py
@@ -145,21 +145,6 @@ class TestClock(
         )
 
     @overload
-    @classmethod
-    def advance(
-        cls,
-        test_clock: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["TestClock.AdvanceParams"]
-    ) -> "TestClock":
-        """
-        Starts advancing a test clock to a specified time in the future. Advancement is done when status changes to Ready.
-        """
-        ...
-
-    @overload
     @staticmethod
     def advance(
         test_clock: str,
@@ -242,16 +227,6 @@ class TestClock(
             "TestClock",
             cls._static_request("delete", url, params=params),
         )
-
-    @overload
-    @classmethod
-    def delete(
-        cls, sid: str, **params: Unpack["TestClock.DeleteParams"]
-    ) -> "TestClock":
-        """
-        Deletes a test clock.
-        """
-        ...
 
     @overload
     @staticmethod

--- a/stripe/api_resources/topup.py
+++ b/stripe/api_resources/topup.py
@@ -276,6 +276,20 @@ class Topup(
         ...
 
     @overload
+    @staticmethod
+    def cancel(
+        topup: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["Topup.CancelParams"]
+    ) -> "Topup":
+        """
+        Cancels a top-up. Only pending top-ups can be canceled.
+        """
+        ...
+
+    @overload
     def cancel(
         self,
         idempotency_key: Optional[str] = None,

--- a/stripe/api_resources/topup.py
+++ b/stripe/api_resources/topup.py
@@ -261,21 +261,6 @@ class Topup(
         )
 
     @overload
-    @classmethod
-    def cancel(
-        cls,
-        topup: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["Topup.CancelParams"]
-    ) -> "Topup":
-        """
-        Cancels a top-up. Only pending top-ups can be canceled.
-        """
-        ...
-
-    @overload
     @staticmethod
     def cancel(
         topup: str,

--- a/stripe/api_resources/treasury/financial_account.py
+++ b/stripe/api_resources/treasury/financial_account.py
@@ -881,21 +881,6 @@ class FinancialAccount(
         )
 
     @overload
-    @classmethod
-    def retrieve_features(
-        cls,
-        financial_account: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["FinancialAccount.RetrieveFeaturesParams"]
-    ) -> "FinancialAccountFeatures":
-        """
-        Retrieves Features information associated with the FinancialAccount.
-        """
-        ...
-
-    @overload
     @staticmethod
     def retrieve_features(
         financial_account: str,
@@ -966,21 +951,6 @@ class FinancialAccount(
                 params=params,
             ),
         )
-
-    @overload
-    @classmethod
-    def update_features(
-        cls,
-        financial_account: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["FinancialAccount.UpdateFeaturesParams"]
-    ) -> "FinancialAccountFeatures":
-        """
-        Updates the Features associated with a FinancialAccount.
-        """
-        ...
 
     @overload
     @staticmethod

--- a/stripe/api_resources/treasury/financial_account.py
+++ b/stripe/api_resources/treasury/financial_account.py
@@ -896,6 +896,20 @@ class FinancialAccount(
         ...
 
     @overload
+    @staticmethod
+    def retrieve_features(
+        financial_account: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["FinancialAccount.RetrieveFeaturesParams"]
+    ) -> "FinancialAccountFeatures":
+        """
+        Retrieves Features information associated with the FinancialAccount.
+        """
+        ...
+
+    @overload
     def retrieve_features(
         self,
         idempotency_key: Optional[str] = None,
@@ -957,6 +971,20 @@ class FinancialAccount(
     @classmethod
     def update_features(
         cls,
+        financial_account: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["FinancialAccount.UpdateFeaturesParams"]
+    ) -> "FinancialAccountFeatures":
+        """
+        Updates the Features associated with a FinancialAccount.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def update_features(
         financial_account: str,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,

--- a/stripe/api_resources/treasury/inbound_transfer.py
+++ b/stripe/api_resources/treasury/inbound_transfer.py
@@ -382,6 +382,20 @@ class InboundTransfer(
         ...
 
     @overload
+    @staticmethod
+    def cancel(
+        inbound_transfer: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["InboundTransfer.CancelParams"]
+    ) -> "InboundTransfer":
+        """
+        Cancels an InboundTransfer.
+        """
+        ...
+
+    @overload
     def cancel(
         self,
         idempotency_key: Optional[str] = None,
@@ -522,6 +536,20 @@ class InboundTransfer(
             ...
 
         @overload
+        @staticmethod
+        def fail(
+            id: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["InboundTransfer.FailParams"]
+        ) -> "InboundTransfer":
+            """
+            Transitions a test mode created InboundTransfer to the failed status. The InboundTransfer must already be in the processing state.
+            """
+            ...
+
+        @overload
         def fail(
             self,
             idempotency_key: Optional[str] = None,
@@ -595,6 +623,20 @@ class InboundTransfer(
             ...
 
         @overload
+        @staticmethod
+        def return_inbound_transfer(
+            id: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"]
+        ) -> "InboundTransfer":
+            """
+            Marks the test mode InboundTransfer object as returned and links the InboundTransfer to a ReceivedDebit. The InboundTransfer must already be in the succeeded state.
+            """
+            ...
+
+        @overload
         def return_inbound_transfer(
             self,
             idempotency_key: Optional[str] = None,
@@ -656,6 +698,20 @@ class InboundTransfer(
         @classmethod
         def succeed(
             cls,
+            id: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["InboundTransfer.SucceedParams"]
+        ) -> "InboundTransfer":
+            """
+            Transitions a test mode created InboundTransfer to the succeeded status. The InboundTransfer must already be in the processing state.
+            """
+            ...
+
+        @overload
+        @staticmethod
+        def succeed(
             id: str,
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,

--- a/stripe/api_resources/treasury/inbound_transfer.py
+++ b/stripe/api_resources/treasury/inbound_transfer.py
@@ -367,21 +367,6 @@ class InboundTransfer(
         )
 
     @overload
-    @classmethod
-    def cancel(
-        cls,
-        inbound_transfer: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["InboundTransfer.CancelParams"]
-    ) -> "InboundTransfer":
-        """
-        Cancels an InboundTransfer.
-        """
-        ...
-
-    @overload
     @staticmethod
     def cancel(
         inbound_transfer: str,
@@ -521,21 +506,6 @@ class InboundTransfer(
             )
 
         @overload
-        @classmethod
-        def fail(
-            cls,
-            id: str,
-            api_key: Optional[str] = None,
-            stripe_version: Optional[str] = None,
-            stripe_account: Optional[str] = None,
-            **params: Unpack["InboundTransfer.FailParams"]
-        ) -> "InboundTransfer":
-            """
-            Transitions a test mode created InboundTransfer to the failed status. The InboundTransfer must already be in the processing state.
-            """
-            ...
-
-        @overload
         @staticmethod
         def fail(
             id: str,
@@ -608,21 +578,6 @@ class InboundTransfer(
             )
 
         @overload
-        @classmethod
-        def return_inbound_transfer(
-            cls,
-            id: str,
-            api_key: Optional[str] = None,
-            stripe_version: Optional[str] = None,
-            stripe_account: Optional[str] = None,
-            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"]
-        ) -> "InboundTransfer":
-            """
-            Marks the test mode InboundTransfer object as returned and links the InboundTransfer to a ReceivedDebit. The InboundTransfer must already be in the succeeded state.
-            """
-            ...
-
-        @overload
         @staticmethod
         def return_inbound_transfer(
             id: str,
@@ -693,21 +648,6 @@ class InboundTransfer(
                     params=params,
                 ),
             )
-
-        @overload
-        @classmethod
-        def succeed(
-            cls,
-            id: str,
-            api_key: Optional[str] = None,
-            stripe_version: Optional[str] = None,
-            stripe_account: Optional[str] = None,
-            **params: Unpack["InboundTransfer.SucceedParams"]
-        ) -> "InboundTransfer":
-            """
-            Transitions a test mode created InboundTransfer to the succeeded status. The InboundTransfer must already be in the processing state.
-            """
-            ...
 
         @overload
         @staticmethod

--- a/stripe/api_resources/treasury/outbound_payment.py
+++ b/stripe/api_resources/treasury/outbound_payment.py
@@ -551,21 +551,6 @@ class OutboundPayment(
         )
 
     @overload
-    @classmethod
-    def cancel(
-        cls,
-        id: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["OutboundPayment.CancelParams"]
-    ) -> "OutboundPayment":
-        """
-        Cancel an OutboundPayment.
-        """
-        ...
-
-    @overload
     @staticmethod
     def cancel(
         id: str,
@@ -705,21 +690,6 @@ class OutboundPayment(
             )
 
         @overload
-        @classmethod
-        def fail(
-            cls,
-            id: str,
-            api_key: Optional[str] = None,
-            stripe_version: Optional[str] = None,
-            stripe_account: Optional[str] = None,
-            **params: Unpack["OutboundPayment.FailParams"]
-        ) -> "OutboundPayment":
-            """
-            Transitions a test mode created OutboundPayment to the failed status. The OutboundPayment must already be in the processing state.
-            """
-            ...
-
-        @overload
         @staticmethod
         def fail(
             id: str,
@@ -792,21 +762,6 @@ class OutboundPayment(
             )
 
         @overload
-        @classmethod
-        def post(
-            cls,
-            id: str,
-            api_key: Optional[str] = None,
-            stripe_version: Optional[str] = None,
-            stripe_account: Optional[str] = None,
-            **params: Unpack["OutboundPayment.PostParams"]
-        ) -> "OutboundPayment":
-            """
-            Transitions a test mode created OutboundPayment to the posted status. The OutboundPayment must already be in the processing state.
-            """
-            ...
-
-        @overload
         @staticmethod
         def post(
             id: str,
@@ -877,21 +832,6 @@ class OutboundPayment(
                     params=params,
                 ),
             )
-
-        @overload
-        @classmethod
-        def return_outbound_payment(
-            cls,
-            id: str,
-            api_key: Optional[str] = None,
-            stripe_version: Optional[str] = None,
-            stripe_account: Optional[str] = None,
-            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"]
-        ) -> "OutboundPayment":
-            """
-            Transitions a test mode created OutboundPayment to the returned status. The OutboundPayment must already be in the processing state.
-            """
-            ...
 
         @overload
         @staticmethod

--- a/stripe/api_resources/treasury/outbound_payment.py
+++ b/stripe/api_resources/treasury/outbound_payment.py
@@ -566,6 +566,20 @@ class OutboundPayment(
         ...
 
     @overload
+    @staticmethod
+    def cancel(
+        id: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["OutboundPayment.CancelParams"]
+    ) -> "OutboundPayment":
+        """
+        Cancel an OutboundPayment.
+        """
+        ...
+
+    @overload
     def cancel(
         self,
         idempotency_key: Optional[str] = None,
@@ -706,6 +720,20 @@ class OutboundPayment(
             ...
 
         @overload
+        @staticmethod
+        def fail(
+            id: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["OutboundPayment.FailParams"]
+        ) -> "OutboundPayment":
+            """
+            Transitions a test mode created OutboundPayment to the failed status. The OutboundPayment must already be in the processing state.
+            """
+            ...
+
+        @overload
         def fail(
             self,
             idempotency_key: Optional[str] = None,
@@ -779,6 +807,20 @@ class OutboundPayment(
             ...
 
         @overload
+        @staticmethod
+        def post(
+            id: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["OutboundPayment.PostParams"]
+        ) -> "OutboundPayment":
+            """
+            Transitions a test mode created OutboundPayment to the posted status. The OutboundPayment must already be in the processing state.
+            """
+            ...
+
+        @overload
         def post(
             self,
             idempotency_key: Optional[str] = None,
@@ -840,6 +882,20 @@ class OutboundPayment(
         @classmethod
         def return_outbound_payment(
             cls,
+            id: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"]
+        ) -> "OutboundPayment":
+            """
+            Transitions a test mode created OutboundPayment to the returned status. The OutboundPayment must already be in the processing state.
+            """
+            ...
+
+        @overload
+        @staticmethod
+        def return_outbound_payment(
             id: str,
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,

--- a/stripe/api_resources/treasury/outbound_transfer.py
+++ b/stripe/api_resources/treasury/outbound_transfer.py
@@ -386,21 +386,6 @@ class OutboundTransfer(
         )
 
     @overload
-    @classmethod
-    def cancel(
-        cls,
-        outbound_transfer: str,
-        api_key: Optional[str] = None,
-        stripe_version: Optional[str] = None,
-        stripe_account: Optional[str] = None,
-        **params: Unpack["OutboundTransfer.CancelParams"]
-    ) -> "OutboundTransfer":
-        """
-        An OutboundTransfer can be canceled if the funds have not yet been paid out.
-        """
-        ...
-
-    @overload
     @staticmethod
     def cancel(
         outbound_transfer: str,
@@ -540,21 +525,6 @@ class OutboundTransfer(
             )
 
         @overload
-        @classmethod
-        def fail(
-            cls,
-            outbound_transfer: str,
-            api_key: Optional[str] = None,
-            stripe_version: Optional[str] = None,
-            stripe_account: Optional[str] = None,
-            **params: Unpack["OutboundTransfer.FailParams"]
-        ) -> "OutboundTransfer":
-            """
-            Transitions a test mode created OutboundTransfer to the failed status. The OutboundTransfer must already be in the processing state.
-            """
-            ...
-
-        @overload
         @staticmethod
         def fail(
             outbound_transfer: str,
@@ -629,21 +599,6 @@ class OutboundTransfer(
             )
 
         @overload
-        @classmethod
-        def post(
-            cls,
-            outbound_transfer: str,
-            api_key: Optional[str] = None,
-            stripe_version: Optional[str] = None,
-            stripe_account: Optional[str] = None,
-            **params: Unpack["OutboundTransfer.PostParams"]
-        ) -> "OutboundTransfer":
-            """
-            Transitions a test mode created OutboundTransfer to the posted status. The OutboundTransfer must already be in the processing state.
-            """
-            ...
-
-        @overload
         @staticmethod
         def post(
             outbound_transfer: str,
@@ -716,21 +671,6 @@ class OutboundTransfer(
                     params=params,
                 ),
             )
-
-        @overload
-        @classmethod
-        def return_outbound_transfer(
-            cls,
-            outbound_transfer: str,
-            api_key: Optional[str] = None,
-            stripe_version: Optional[str] = None,
-            stripe_account: Optional[str] = None,
-            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"]
-        ) -> "OutboundTransfer":
-            """
-            Transitions a test mode created OutboundTransfer to the returned status. The OutboundTransfer must already be in the processing state.
-            """
-            ...
 
         @overload
         @staticmethod

--- a/stripe/api_resources/treasury/outbound_transfer.py
+++ b/stripe/api_resources/treasury/outbound_transfer.py
@@ -401,6 +401,20 @@ class OutboundTransfer(
         ...
 
     @overload
+    @staticmethod
+    def cancel(
+        outbound_transfer: str,
+        api_key: Optional[str] = None,
+        stripe_version: Optional[str] = None,
+        stripe_account: Optional[str] = None,
+        **params: Unpack["OutboundTransfer.CancelParams"]
+    ) -> "OutboundTransfer":
+        """
+        An OutboundTransfer can be canceled if the funds have not yet been paid out.
+        """
+        ...
+
+    @overload
     def cancel(
         self,
         idempotency_key: Optional[str] = None,
@@ -541,6 +555,20 @@ class OutboundTransfer(
             ...
 
         @overload
+        @staticmethod
+        def fail(
+            outbound_transfer: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["OutboundTransfer.FailParams"]
+        ) -> "OutboundTransfer":
+            """
+            Transitions a test mode created OutboundTransfer to the failed status. The OutboundTransfer must already be in the processing state.
+            """
+            ...
+
+        @overload
         def fail(
             self,
             idempotency_key: Optional[str] = None,
@@ -616,6 +644,20 @@ class OutboundTransfer(
             ...
 
         @overload
+        @staticmethod
+        def post(
+            outbound_transfer: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["OutboundTransfer.PostParams"]
+        ) -> "OutboundTransfer":
+            """
+            Transitions a test mode created OutboundTransfer to the posted status. The OutboundTransfer must already be in the processing state.
+            """
+            ...
+
+        @overload
         def post(
             self,
             idempotency_key: Optional[str] = None,
@@ -679,6 +721,20 @@ class OutboundTransfer(
         @classmethod
         def return_outbound_transfer(
             cls,
+            outbound_transfer: str,
+            api_key: Optional[str] = None,
+            stripe_version: Optional[str] = None,
+            stripe_account: Optional[str] = None,
+            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"]
+        ) -> "OutboundTransfer":
+            """
+            Transitions a test mode created OutboundTransfer to the returned status. The OutboundTransfer must already be in the processing state.
+            """
+            ...
+
+        @overload
+        @staticmethod
+        def return_outbound_transfer(
             outbound_transfer: str,
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,

--- a/stripe/api_resources/webhook_endpoint.py
+++ b/stripe/api_resources/webhook_endpoint.py
@@ -441,16 +441,6 @@ class WebhookEndpoint(
         )
 
     @overload
-    @classmethod
-    def delete(
-        cls, sid: str, **params: Unpack["WebhookEndpoint.DeleteParams"]
-    ) -> "WebhookEndpoint":
-        """
-        You can also delete webhook endpoints via the [webhook endpoint management](https://dashboard.stripe.com/account/webhooks) page of the Stripe dashboard.
-        """
-        ...
-
-    @overload
     @staticmethod
     def delete(
         sid: str, **params: Unpack["WebhookEndpoint.DeleteParams"]

--- a/stripe/api_resources/webhook_endpoint.py
+++ b/stripe/api_resources/webhook_endpoint.py
@@ -451,6 +451,16 @@ class WebhookEndpoint(
         ...
 
     @overload
+    @staticmethod
+    def delete(
+        sid: str, **params: Unpack["WebhookEndpoint.DeleteParams"]
+    ) -> "WebhookEndpoint":
+        """
+        You can also delete webhook endpoints via the [webhook endpoint management](https://dashboard.stripe.com/account/webhooks) page of the Stripe dashboard.
+        """
+        ...
+
+    @overload
     def delete(
         self, **params: Unpack["WebhookEndpoint.DeleteParams"]
     ) -> "WebhookEndpoint":


### PR DESCRIPTION
Fixes #1113.

As #1113 reports, the types for our classmethods do not work for MyPy. The problem is our `@class_method_variant` pattern and the fact that we have methods with the same name that double as both class methods and instance methods. 

MyPy doesn't like it when you do not apply `@classmethod` consistently to all overloads of a method. It complains

```
Overload does not consistently use the "@classmethod" decorator on all function signatures.  [misc]
```

I don't mind doing something MyPy doesn't like internally in stripe-python, so long as it gives users types that accurately describe correct usage of the library, but unfortunately in this case MyPy will not generate the overload type that omits `self` or `cls` (unlike how Pyright behaves, incidentally). Here's a simplified example:

```python
class Foo:
    @overload
    def boop(self, id: str) -> None:
        pass

    @overload
    @classmethod
    def boop(cls, id: str) -> None:
        pass

    def boop(*args: Any, **kwargs: Any) -> None:
        pass

reveal_type(Foo.boop)
# MYPY: Revealed type is "Overload(def (self: t.Foo, id: builtins.str), def (cls: Type[t.Foo], id: builtins.str))"
# PYRIGHT: Type of "Foo.boop" is "Overload[(self: Foo, id: str) -> None, (id: str) -> None]"

reveal_type(Foo().boop)
# MYPY: Revealed type is "def (id: builtins.str)"
# PYRIGHT: Type of "Foo().boop" is "Overload[(id: str) -> None, (id: str) -> None]"
```

This PR addresses the problem by adding an additional `@staticmethod` overload. This isn't very satisfying, as `@staticmethod` is for methods that do not actually need a reference to `cls`. On the other hand, because we're only using it on an overload, it doesn't really change the way anything behaves at runtime at all, and it causes `MyPy` to generate an overload typed the way we want, i.e.:

```python
reveal_type(Foo.boop)
# Revealed type is "Overload(def (self: t.Foo, id: builtins.str), def (cls: Type[t.Foo], id: builtins.str), def (id: builtins.str))"
reveal_type(Foo().boop)
# Revealed type is "def (id: builtins.str)"
```
