### PR TITLE
Make: move editable install into venv task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,15 @@ PIP?=pip
 PYTHON?=python3
 
 venv: $(VENV_NAME)/bin/activate
+	# In order for pyright to be able to follow imports, we need "editable_mode=compat" to force setuptools to do
+	# an editable install via a .pth file mechanism and not "import hooks". See
+	# the "editable installs" section of https://github.com/microsoft/pyright/blob/main/docs/import-resolution.md#editable-installs
+
+	# This command might fail if we're on python 3.6, as versions of pip that
+	# support python 3.6 don't know about "--config-settings", but in this case
+	# we don't need to pass config-settings anyway because "editable_mode=compat" just
+	# means to perform as these old versions of pip already do.
+	${VENV_NAME}/bin/python -m pip install -e . --config-settings editable_mode=compat || pip install -e .
 
 $(VENV_NAME)/bin/activate: setup.py requirements.txt
 	@test -d $(VENV_NAME) || $(PYTHON) -m venv --clear $(VENV_NAME)
@@ -22,15 +31,6 @@ coveralls: venv
 	@${VENV_NAME}/bin/tox -e coveralls
 
 pyright: venv
-	# In order for pyright to be able to follow imports, we need "editable_mode=compat" to force setuptools to do
-	# an editable install via a .pth file mechanism and not "import hooks". See
-	# the "editable installs" section of https://github.com/microsoft/pyright/blob/main/docs/import-resolution.md#editable-installs
-
-	# This command might fail if we're on python 3.6, as versions of pip that
-	# support python 3.6 don't know about "--config-settings", but in this case
-	# we don't need to pass config-settings anyway because "editable_mode=compat" just
-	# means to perform as these old versions of pip already do.
-	pip install -e . --config-settings editable_mode=compat || pip install -e .
 	@${VENV_NAME}/bin/pyright --version
 	@${VENV_NAME}/bin/pyright $(PYRIGHT_ARGS)
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ venv: $(VENV_NAME)/bin/activate
 	# support python 3.6 don't know about "--config-settings", but in this case
 	# we don't need to pass config-settings anyway because "editable_mode=compat" just
 	# means to perform as these old versions of pip already do.
-	${VENV_NAME}/bin/python -m pip install -e . --config-settings editable_mode=compat || pip install -e .
+	${VENV_NAME}/bin/python -m pip install -e . --config-settings editable_mode=compat || ${VENV_NAME}/bin/python -m pip install -e .
 
 $(VENV_NAME)/bin/activate: setup.py requirements.txt
 	@test -d $(VENV_NAME) || $(PYTHON) -m venv --clear $(VENV_NAME)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,11 @@ reportUnnecessaryCast=true
 reportUnnecessaryComparison=true
 reportUnnecessaryContains=true
 reportUnnecessaryIsInstance=true
+
+[tool.mypy]
+no_site_packages = true
+enable_incomplete_feature=["Unpack"]
+
+[[tool.mypy.overrides]]
+module = "stripe.*"
+ignore_errors = true


### PR DESCRIPTION
This was previously done only in `make pyright` but you should be able to clone the repo, call `Make` and your `venv` should be in a correct state so that if you point your IDE to use `venv/bin/python` type checking and everything will work.