### PR TITLE
Remove `.lgtm.yml` and `bungcip.better-toml`

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,3 +1,0 @@
-path_classifiers:
-  library:
-    - stripe/six.py

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
   "recommendations": [
     "ms-python.python",
-    "bungcip.better-toml",
     "EditorConfig.editorconfig"
   ]
 }


### PR DESCRIPTION
lgtm.yml is superseded by "github code scanning" which I think is enabled (see lgtm.com)
bungcip.better-toml is archived https://github.com/bungcip/better-toml and currently gives contributors an unwelcome notification when they open up VSCode in the project.