### PR TITLE
Suppress type errors from latest pyright

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 cryptography<40
 tox
 twine
-pyright <= 1.1.334
+pyright
 pytest-cov >= 2.8.1, < 2.11.0
 pytest-mock >= 2.0.0
 pytest-xdist >= 1.31.0

--- a/stripe/api_resources/account.py
+++ b/stripe/api_resources/account.py
@@ -3494,7 +3494,9 @@ class Account(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.CreateParams"]
+        **params: Unpack[
+            "Account.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Account":
         """
         With [Connect](https://stripe.com/docs/connect), you can create Stripe accounts for your users.
@@ -3582,7 +3584,9 @@ class Account(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.ListParams"]
+        **params: Unpack[
+            "Account.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Account"]:
         """
         Returns a list of accounts connected to your platform via [Connect](https://stripe.com/docs/connect). If you're not a platform, the list is empty.
@@ -3611,7 +3615,9 @@ class Account(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.PersonsParams"]
+        **params: Unpack[
+            "Account.PersonsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Person"]:
         """
         Returns a list of people associated with the account's legal entity. The people are returned sorted by creation date, with the most recent people appearing first.
@@ -3637,7 +3643,9 @@ class Account(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.PersonsParams"]
+        **params: Unpack[
+            "Account.PersonsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Person"]:
         """
         Returns a list of people associated with the account's legal entity. The people are returned sorted by creation date, with the most recent people appearing first.
@@ -3648,7 +3656,9 @@ class Account(
     def persons(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Account.PersonsParams"]
+        **params: Unpack[
+            "Account.PersonsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Person"]:
         """
         Returns a list of people associated with the account's legal entity. The people are returned sorted by creation date, with the most recent people appearing first.
@@ -3659,7 +3669,9 @@ class Account(
     def persons(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Account.PersonsParams"]
+        **params: Unpack[
+            "Account.PersonsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Person"]:
         """
         Returns a list of people associated with the account's legal entity. The people are returned sorted by creation date, with the most recent people appearing first.
@@ -3683,7 +3695,9 @@ class Account(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.RejectParams"]
+        **params: Unpack[
+            "Account.RejectParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Account":
         """
         With [Connect](https://stripe.com/docs/connect), you may flag accounts as suspicious.
@@ -3711,7 +3725,9 @@ class Account(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.RejectParams"]
+        **params: Unpack[
+            "Account.RejectParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Account":
         """
         With [Connect](https://stripe.com/docs/connect), you may flag accounts as suspicious.
@@ -3724,7 +3740,9 @@ class Account(
     def reject(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Account.RejectParams"]
+        **params: Unpack[
+            "Account.RejectParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Account":
         """
         With [Connect](https://stripe.com/docs/connect), you may flag accounts as suspicious.
@@ -3737,7 +3755,9 @@ class Account(
     def reject(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Account.RejectParams"]
+        **params: Unpack[
+            "Account.RejectParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Account":
         """
         With [Connect](https://stripe.com/docs/connect), you may flag accounts as suspicious.
@@ -3807,7 +3827,9 @@ class Account(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.RetrieveCapabilityParams"]
+        **params: Unpack[
+            "Account.RetrieveCapabilityParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Capability":
         """
         Retrieves information about the specified Account Capability.
@@ -3835,7 +3857,9 @@ class Account(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.ModifyCapabilityParams"]
+        **params: Unpack[
+            "Account.ModifyCapabilityParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Capability":
         """
         Updates an existing Account Capability. Request or remove a capability by updating its requested parameter.
@@ -3862,7 +3886,9 @@ class Account(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.ListCapabilitiesParams"]
+        **params: Unpack[
+            "Account.ListCapabilitiesParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Capability"]:
         """
         Returns a list of capabilities associated with the account. The capabilities are returned sorted by creation date, with the most recent capability appearing first.
@@ -3888,7 +3914,9 @@ class Account(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.CreateExternalAccountParams"]
+        **params: Unpack[
+            "Account.CreateExternalAccountParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> Union["BankAccount", "Card"]:
         """
         Create an external account for a given account.
@@ -3915,7 +3943,9 @@ class Account(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.RetrieveExternalAccountParams"]
+        **params: Unpack[
+            "Account.RetrieveExternalAccountParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> Union["BankAccount", "Card"]:
         """
         Retrieve a specified external account for a given account.
@@ -3942,7 +3972,9 @@ class Account(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.ModifyExternalAccountParams"]
+        **params: Unpack[
+            "Account.ModifyExternalAccountParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> Union["BankAccount", "Card"]:
         """
         Updates the metadata, account holder name, account holder type of a bank account belonging to a [Custom account](https://stripe.com/docs/connect/custom-accounts), and optionally sets it as the default for its currency. Other bank account details are not editable by design.
@@ -3971,7 +4003,9 @@ class Account(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.DeleteExternalAccountParams"]
+        **params: Unpack[
+            "Account.DeleteExternalAccountParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> Union["BankAccount", "Card"]:
         """
         Delete a specified external account for a given account.
@@ -3997,7 +4031,9 @@ class Account(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.ListExternalAccountsParams"]
+        **params: Unpack[
+            "Account.ListExternalAccountsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject[Union["BankAccount", "Card"]]:
         """
         List external accounts for an account.
@@ -4023,7 +4059,9 @@ class Account(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.CreateLoginLinkParams"]
+        **params: Unpack[
+            "Account.CreateLoginLinkParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "LoginLink":
         """
         Creates a single-use login link for an Express account to access their Stripe dashboard.
@@ -4051,7 +4089,9 @@ class Account(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.CreatePersonParams"]
+        **params: Unpack[
+            "Account.CreatePersonParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Person":
         """
         Creates a new person.
@@ -4078,7 +4118,9 @@ class Account(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.RetrievePersonParams"]
+        **params: Unpack[
+            "Account.RetrievePersonParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Person":
         """
         Retrieves an existing person.
@@ -4106,7 +4148,9 @@ class Account(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.ModifyPersonParams"]
+        **params: Unpack[
+            "Account.ModifyPersonParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Person":
         """
         Updates an existing person.
@@ -4134,7 +4178,9 @@ class Account(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.DeletePersonParams"]
+        **params: Unpack[
+            "Account.DeletePersonParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Person":
         """
         Deletes an existing person's relationship to the account's legal entity. Any person with a relationship for an account can be deleted through the API, except if the person is the account_opener. If your integration is using the executive parameter, you cannot delete the only verified executive on file.
@@ -4161,7 +4207,9 @@ class Account(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.ListPersonsParams"]
+        **params: Unpack[
+            "Account.ListPersonsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Person"]:
         """
         Returns a list of people associated with the account's legal entity. The people are returned sorted by creation date, with the most recent people appearing first.

--- a/stripe/api_resources/account_link.py
+++ b/stripe/api_resources/account_link.py
@@ -67,7 +67,9 @@ class AccountLink(CreateableAPIResource["AccountLink"]):
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["AccountLink.CreateParams"]
+        **params: Unpack[
+            "AccountLink.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "AccountLink":
         """
         Creates an AccountLink object that includes a single-use Stripe URL that the platform can redirect their user to in order to take them through the Connect Onboarding flow.

--- a/stripe/api_resources/account_session.py
+++ b/stripe/api_resources/account_session.py
@@ -99,7 +99,9 @@ class AccountSession(CreateableAPIResource["AccountSession"]):
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["AccountSession.CreateParams"]
+        **params: Unpack[
+            "AccountSession.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "AccountSession":
         """
         Creates a AccountSession object that includes a single-use token that the platform can use on their front-end to grant client-side API access.

--- a/stripe/api_resources/apple_pay_domain.py
+++ b/stripe/api_resources/apple_pay_domain.py
@@ -85,7 +85,9 @@ class ApplePayDomain(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["ApplePayDomain.CreateParams"]
+        **params: Unpack[
+            "ApplePayDomain.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "ApplePayDomain":
         """
         Create an apple pay domain.
@@ -154,7 +156,9 @@ class ApplePayDomain(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["ApplePayDomain.ListParams"]
+        **params: Unpack[
+            "ApplePayDomain.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["ApplePayDomain"]:
         """
         List apple pay domains.

--- a/stripe/api_resources/application_fee.py
+++ b/stripe/api_resources/application_fee.py
@@ -205,7 +205,9 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["ApplicationFee.ListParams"]
+        **params: Unpack[
+            "ApplicationFee.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["ApplicationFee"]:
         """
         Returns a list of application fees you've previously collected. The application fees are returned in sorted order, with the most recent fees appearing first.
@@ -234,7 +236,9 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["ApplicationFee.RefundParams"]
+        **params: Unpack[
+            "ApplicationFee.RefundParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "ApplicationFeeRefund":
         """
         Refunds an application fee that has previously been collected but not yet refunded.
@@ -268,7 +272,9 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["ApplicationFee.RefundParams"]
+        **params: Unpack[
+            "ApplicationFee.RefundParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "ApplicationFeeRefund":
         """
         Refunds an application fee that has previously been collected but not yet refunded.
@@ -287,7 +293,9 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
     def refund(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["ApplicationFee.RefundParams"]
+        **params: Unpack[
+            "ApplicationFee.RefundParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "ApplicationFeeRefund":
         """
         Refunds an application fee that has previously been collected but not yet refunded.
@@ -306,7 +314,9 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
     def refund(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["ApplicationFee.RefundParams"]
+        **params: Unpack[
+            "ApplicationFee.RefundParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "ApplicationFeeRefund":
         """
         Refunds an application fee that has previously been collected but not yet refunded.
@@ -349,7 +359,9 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["ApplicationFee.CreateRefundParams"]
+        **params: Unpack[
+            "ApplicationFee.CreateRefundParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "ApplicationFeeRefund":
         """
         Refunds an application fee that has previously been collected but not yet refunded.
@@ -384,7 +396,9 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["ApplicationFee.RetrieveRefundParams"]
+        **params: Unpack[
+            "ApplicationFee.RetrieveRefundParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "ApplicationFeeRefund":
         """
         By default, you can see the 10 most recent refunds stored directly on the application fee object, but you can also retrieve details about a specific refund stored on the application fee.
@@ -411,7 +425,9 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["ApplicationFee.ModifyRefundParams"]
+        **params: Unpack[
+            "ApplicationFee.ModifyRefundParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "ApplicationFeeRefund":
         """
         Updates the specified application fee refund by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
@@ -439,7 +455,9 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["ApplicationFee.ListRefundsParams"]
+        **params: Unpack[
+            "ApplicationFee.ListRefundsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["ApplicationFeeRefund"]:
         """
         You can see a list of the refunds belonging to a specific application fee. Note that the 10 most recent refunds are always available by default on the application fee object. If you need more than those 10, you can use this API method and the limit and starting_after parameters to page through additional refunds.

--- a/stripe/api_resources/apps/secret.py
+++ b/stripe/api_resources/apps/secret.py
@@ -197,7 +197,9 @@ class Secret(CreateableAPIResource["Secret"], ListableAPIResource["Secret"]):
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Secret.CreateParams"]
+        **params: Unpack[
+            "Secret.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Secret":
         """
         Create or replace a secret in the secret store.
@@ -221,7 +223,9 @@ class Secret(CreateableAPIResource["Secret"], ListableAPIResource["Secret"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Secret.DeleteWhereParams"]
+        **params: Unpack[
+            "Secret.DeleteWhereParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Secret":
         """
         Deletes a secret from the secret store by name and scope.
@@ -244,7 +248,9 @@ class Secret(CreateableAPIResource["Secret"], ListableAPIResource["Secret"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Secret.FindParams"]
+        **params: Unpack[
+            "Secret.FindParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Secret":
         """
         Finds a secret in the secret store by name and scope.
@@ -267,7 +273,9 @@ class Secret(CreateableAPIResource["Secret"], ListableAPIResource["Secret"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Secret.ListParams"]
+        **params: Unpack[
+            "Secret.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Secret"]:
         """
         List all secrets stored on the given scope.

--- a/stripe/api_resources/balance_transaction.py
+++ b/stripe/api_resources/balance_transaction.py
@@ -267,7 +267,9 @@ class BalanceTransaction(ListableAPIResource["BalanceTransaction"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["BalanceTransaction.ListParams"]
+        **params: Unpack[
+            "BalanceTransaction.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["BalanceTransaction"]:
         """
         Returns a list of transactions that have contributed to the Stripe account balance (e.g., charges, transfers, and so forth). The transactions are returned in sorted order, with the most recent transactions appearing first.

--- a/stripe/api_resources/billing_portal/configuration.py
+++ b/stripe/api_resources/billing_portal/configuration.py
@@ -659,7 +659,9 @@ class Configuration(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Configuration.CreateParams"]
+        **params: Unpack[
+            "Configuration.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Configuration":
         """
         Creates a configuration that describes the functionality and behavior of a PortalSession
@@ -683,7 +685,9 @@ class Configuration(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Configuration.ListParams"]
+        **params: Unpack[
+            "Configuration.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Configuration"]:
         """
         Returns a list of configurations that describe the functionality of the customer portal.

--- a/stripe/api_resources/billing_portal/session.py
+++ b/stripe/api_resources/billing_portal/session.py
@@ -451,7 +451,9 @@ class Session(CreateableAPIResource["Session"]):
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Session.CreateParams"]
+        **params: Unpack[
+            "Session.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Session":
         """
         Creates a session of the customer portal.

--- a/stripe/api_resources/charge.py
+++ b/stripe/api_resources/charge.py
@@ -2184,7 +2184,9 @@ class Charge(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Charge.CaptureParams"]
+        **params: Unpack[
+            "Charge.CaptureParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Charge":
         """
         Capture the payment of an existing, uncaptured charge that was created with the capture option set to false.
@@ -2214,7 +2216,9 @@ class Charge(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Charge.CaptureParams"]
+        **params: Unpack[
+            "Charge.CaptureParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Charge":
         """
         Capture the payment of an existing, uncaptured charge that was created with the capture option set to false.
@@ -2229,7 +2233,9 @@ class Charge(
     def capture(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Charge.CaptureParams"]
+        **params: Unpack[
+            "Charge.CaptureParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Charge":
         """
         Capture the payment of an existing, uncaptured charge that was created with the capture option set to false.
@@ -2244,7 +2250,9 @@ class Charge(
     def capture(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Charge.CaptureParams"]
+        **params: Unpack[
+            "Charge.CaptureParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Charge":
         """
         Capture the payment of an existing, uncaptured charge that was created with the capture option set to false.
@@ -2272,7 +2280,9 @@ class Charge(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Charge.CreateParams"]
+        **params: Unpack[
+            "Charge.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Charge":
         """
         Use the [Payment Intents API](https://stripe.com/docs/api/payment_intents) to initiate a new payment instead
@@ -2298,7 +2308,9 @@ class Charge(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Charge.ListParams"]
+        **params: Unpack[
+            "Charge.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Charge"]:
         """
         Returns a list of charges you've previously created. The charges are returned in sorted order, with the most recent charges appearing first.

--- a/stripe/api_resources/checkout/session.py
+++ b/stripe/api_resources/checkout/session.py
@@ -3583,7 +3583,9 @@ class Session(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Session.CreateParams"]
+        **params: Unpack[
+            "Session.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Session":
         """
         Creates a Session object.
@@ -3608,7 +3610,9 @@ class Session(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Session.ExpireParams"]
+        **params: Unpack[
+            "Session.ExpireParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Session":
         """
         A Session can be expired when it is in one of these statuses: open
@@ -3636,7 +3640,9 @@ class Session(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Session.ExpireParams"]
+        **params: Unpack[
+            "Session.ExpireParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Session":
         """
         A Session can be expired when it is in one of these statuses: open
@@ -3649,7 +3655,9 @@ class Session(
     def expire(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Session.ExpireParams"]
+        **params: Unpack[
+            "Session.ExpireParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Session":
         """
         A Session can be expired when it is in one of these statuses: open
@@ -3662,7 +3670,9 @@ class Session(
     def expire(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Session.ExpireParams"]
+        **params: Unpack[
+            "Session.ExpireParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Session":
         """
         A Session can be expired when it is in one of these statuses: open
@@ -3687,7 +3697,9 @@ class Session(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Session.ListParams"]
+        **params: Unpack[
+            "Session.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Session"]:
         """
         Returns a list of Checkout Sessions.
@@ -3716,7 +3728,9 @@ class Session(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Session.ListLineItemsParams"]
+        **params: Unpack[
+            "Session.ListLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["LineItem"]:
         """
         When retrieving a Checkout Session, there is an includable line_items property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.
@@ -3742,7 +3756,9 @@ class Session(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Session.ListLineItemsParams"]
+        **params: Unpack[
+            "Session.ListLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["LineItem"]:
         """
         When retrieving a Checkout Session, there is an includable line_items property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.
@@ -3753,7 +3769,9 @@ class Session(
     def list_line_items(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Session.ListLineItemsParams"]
+        **params: Unpack[
+            "Session.ListLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["LineItem"]:
         """
         When retrieving a Checkout Session, there is an includable line_items property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.
@@ -3764,7 +3782,9 @@ class Session(
     def list_line_items(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Session.ListLineItemsParams"]
+        **params: Unpack[
+            "Session.ListLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["LineItem"]:
         """
         When retrieving a Checkout Session, there is an includable line_items property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.

--- a/stripe/api_resources/country_spec.py
+++ b/stripe/api_resources/country_spec.py
@@ -107,7 +107,9 @@ class CountrySpec(ListableAPIResource["CountrySpec"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["CountrySpec.ListParams"]
+        **params: Unpack[
+            "CountrySpec.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["CountrySpec"]:
         """
         Lists all Country Spec objects available in the API.

--- a/stripe/api_resources/coupon.py
+++ b/stripe/api_resources/coupon.py
@@ -269,7 +269,9 @@ class Coupon(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Coupon.CreateParams"]
+        **params: Unpack[
+            "Coupon.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Coupon":
         """
         You can create coupons easily via the [coupon management](https://dashboard.stripe.com/coupons) page of the Stripe dashboard. Coupon creation is also accessible via the API if you need to create coupons on the fly.
@@ -336,7 +338,9 @@ class Coupon(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Coupon.ListParams"]
+        **params: Unpack[
+            "Coupon.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Coupon"]:
         """
         Returns a list of your coupons.

--- a/stripe/api_resources/credit_note.py
+++ b/stripe/api_resources/credit_note.py
@@ -668,7 +668,9 @@ class CreditNote(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["CreditNote.CreateParams"]
+        **params: Unpack[
+            "CreditNote.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "CreditNote":
         """
         Issue a credit note to adjust the amount of a finalized invoice. For a status=open invoice, a credit note reduces
@@ -705,7 +707,9 @@ class CreditNote(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["CreditNote.ListParams"]
+        **params: Unpack[
+            "CreditNote.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["CreditNote"]:
         """
         Returns a list of credit notes.
@@ -746,7 +750,9 @@ class CreditNote(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["CreditNote.PreviewParams"]
+        **params: Unpack[
+            "CreditNote.PreviewParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "CreditNote":
         """
         Get a preview of a credit note without creating it.
@@ -769,7 +775,9 @@ class CreditNote(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["CreditNote.PreviewLinesParams"]
+        **params: Unpack[
+            "CreditNote.PreviewLinesParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["CreditNoteLineItem"]:
         """
         When retrieving a credit note preview, you'll get a lines property containing the first handful of those items. This URL you can retrieve the full (paginated) list of line items.
@@ -804,7 +812,9 @@ class CreditNote(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["CreditNote.VoidCreditNoteParams"]
+        **params: Unpack[
+            "CreditNote.VoidCreditNoteParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "CreditNote":
         """
         Marks a credit note as void. Learn more about [voiding credit notes](https://stripe.com/docs/billing/invoices/credit-notes#voiding).
@@ -828,7 +838,9 @@ class CreditNote(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["CreditNote.VoidCreditNoteParams"]
+        **params: Unpack[
+            "CreditNote.VoidCreditNoteParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "CreditNote":
         """
         Marks a credit note as void. Learn more about [voiding credit notes](https://stripe.com/docs/billing/invoices/credit-notes#voiding).
@@ -839,7 +851,9 @@ class CreditNote(
     def void_credit_note(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["CreditNote.VoidCreditNoteParams"]
+        **params: Unpack[
+            "CreditNote.VoidCreditNoteParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "CreditNote":
         """
         Marks a credit note as void. Learn more about [voiding credit notes](https://stripe.com/docs/billing/invoices/credit-notes#voiding).
@@ -850,7 +864,9 @@ class CreditNote(
     def void_credit_note(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["CreditNote.VoidCreditNoteParams"]
+        **params: Unpack[
+            "CreditNote.VoidCreditNoteParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "CreditNote":
         """
         Marks a credit note as void. Learn more about [voiding credit notes](https://stripe.com/docs/billing/invoices/credit-notes#voiding).
@@ -874,7 +890,9 @@ class CreditNote(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["CreditNote.ListLinesParams"]
+        **params: Unpack[
+            "CreditNote.ListLinesParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["CreditNoteLineItem"]:
         """
         When retrieving a credit note, you'll get a lines property containing the the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.

--- a/stripe/api_resources/credit_note_line_item.py
+++ b/stripe/api_resources/credit_note_line_item.py
@@ -163,7 +163,9 @@ class CreditNoteLineItem(ListableAPIResource["CreditNoteLineItem"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["CreditNoteLineItem.ListParams"]
+        **params: Unpack[
+            "CreditNoteLineItem.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["CreditNoteLineItem"]:
         """
         When retrieving a credit note, you'll get a lines property containing the the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.

--- a/stripe/api_resources/customer.py
+++ b/stripe/api_resources/customer.py
@@ -1394,7 +1394,9 @@ class Customer(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.CreateParams"]
+        **params: Unpack[
+            "Customer.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Customer":
         """
         Creates a new customer object.
@@ -1419,7 +1421,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.CreateFundingInstructionsParams"]
+        **params: Unpack[
+            "Customer.CreateFundingInstructionsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "FundingInstructions":
         """
         Retrieve funding instructions for a customer cash balance. If funding instructions do not yet exist for the customer, new
@@ -1447,7 +1451,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.CreateFundingInstructionsParams"]
+        **params: Unpack[
+            "Customer.CreateFundingInstructionsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "FundingInstructions":
         """
         Retrieve funding instructions for a customer cash balance. If funding instructions do not yet exist for the customer, new
@@ -1460,7 +1466,9 @@ class Customer(
     def create_funding_instructions(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Customer.CreateFundingInstructionsParams"]
+        **params: Unpack[
+            "Customer.CreateFundingInstructionsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "FundingInstructions":
         """
         Retrieve funding instructions for a customer cash balance. If funding instructions do not yet exist for the customer, new
@@ -1473,7 +1481,9 @@ class Customer(
     def create_funding_instructions(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Customer.CreateFundingInstructionsParams"]
+        **params: Unpack[
+            "Customer.CreateFundingInstructionsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "FundingInstructions":
         """
         Retrieve funding instructions for a customer cash balance. If funding instructions do not yet exist for the customer, new
@@ -1542,7 +1552,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.DeleteDiscountParams"]
+        **params: Unpack[
+            "Customer.DeleteDiscountParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Discount":
         """
         Removes the currently applied discount on a customer.
@@ -1568,7 +1580,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.DeleteDiscountParams"]
+        **params: Unpack[
+            "Customer.DeleteDiscountParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Discount":
         """
         Removes the currently applied discount on a customer.
@@ -1579,7 +1593,9 @@ class Customer(
     def delete_discount(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Customer.DeleteDiscountParams"]
+        **params: Unpack[
+            "Customer.DeleteDiscountParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Discount":
         """
         Removes the currently applied discount on a customer.
@@ -1590,7 +1606,9 @@ class Customer(
     def delete_discount(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Customer.DeleteDiscountParams"]
+        **params: Unpack[
+            "Customer.DeleteDiscountParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Discount":
         """
         Removes the currently applied discount on a customer.
@@ -1613,7 +1631,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.ListParams"]
+        **params: Unpack[
+            "Customer.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Customer"]:
         """
         Returns a list of your customers. The customers are returned sorted by creation date, with the most recent customers appearing first.
@@ -1642,7 +1662,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.ListPaymentMethodsParams"]
+        **params: Unpack[
+            "Customer.ListPaymentMethodsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["PaymentMethod"]:
         """
         Returns a list of PaymentMethods for a given Customer
@@ -1668,7 +1690,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.ListPaymentMethodsParams"]
+        **params: Unpack[
+            "Customer.ListPaymentMethodsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["PaymentMethod"]:
         """
         Returns a list of PaymentMethods for a given Customer
@@ -1679,7 +1703,9 @@ class Customer(
     def list_payment_methods(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Customer.ListPaymentMethodsParams"]
+        **params: Unpack[
+            "Customer.ListPaymentMethodsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["PaymentMethod"]:
         """
         Returns a list of PaymentMethods for a given Customer
@@ -1690,7 +1716,9 @@ class Customer(
     def list_payment_methods(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Customer.ListPaymentMethodsParams"]
+        **params: Unpack[
+            "Customer.ListPaymentMethodsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["PaymentMethod"]:
         """
         Returns a list of PaymentMethods for a given Customer
@@ -1741,7 +1769,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.RetrievePaymentMethodParams"]
+        **params: Unpack[
+            "Customer.RetrievePaymentMethodParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentMethod":
         """
         Retrieves a PaymentMethod object for a given Customer.
@@ -1769,7 +1799,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.RetrievePaymentMethodParams"]
+        **params: Unpack[
+            "Customer.RetrievePaymentMethodParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentMethod":
         """
         Retrieves a PaymentMethod object for a given Customer.
@@ -1781,7 +1813,9 @@ class Customer(
         self,
         payment_method: str,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Customer.RetrievePaymentMethodParams"]
+        **params: Unpack[
+            "Customer.RetrievePaymentMethodParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentMethod":
         """
         Retrieves a PaymentMethod object for a given Customer.
@@ -1793,7 +1827,9 @@ class Customer(
         self,
         payment_method: str,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Customer.RetrievePaymentMethodParams"]
+        **params: Unpack[
+            "Customer.RetrievePaymentMethodParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentMethod":
         """
         Retrieves a PaymentMethod object for a given Customer.
@@ -1836,7 +1872,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.CreateBalanceTransactionParams"]
+        **params: Unpack[
+            "Customer.CreateBalanceTransactionParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "CustomerBalanceTransaction":
         """
         Creates an immutable transaction that updates the customer's credit [balance](https://stripe.com/docs/billing/customer/balance).
@@ -1863,7 +1901,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.RetrieveBalanceTransactionParams"]
+        **params: Unpack[
+            "Customer.RetrieveBalanceTransactionParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "CustomerBalanceTransaction":
         """
         Retrieves a specific customer balance transaction that updated the customer's [balances](https://stripe.com/docs/billing/customer/balance).
@@ -1891,7 +1931,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.ModifyBalanceTransactionParams"]
+        **params: Unpack[
+            "Customer.ModifyBalanceTransactionParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "CustomerBalanceTransaction":
         """
         Most credit balance transaction fields are immutable, but you may update its description and metadata.
@@ -1918,7 +1960,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.ListBalanceTransactionsParams"]
+        **params: Unpack[
+            "Customer.ListBalanceTransactionsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["CustomerBalanceTransaction"]:
         """
         Returns a list of transactions that updated the customer's [balances](https://stripe.com/docs/billing/customer/balance).
@@ -1945,7 +1989,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.RetrieveCashBalanceTransactionParams"]
+        **params: Unpack[
+            "Customer.RetrieveCashBalanceTransactionParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "CustomerCashBalanceTransaction":
         """
         Retrieves a specific cash balance transaction, which updated the customer's [cash balance](https://stripe.com/docs/payments/customer-balance).
@@ -1972,7 +2018,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.ListCashBalanceTransactionsParams"]
+        **params: Unpack[
+            "Customer.ListCashBalanceTransactionsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["CustomerCashBalanceTransaction"]:
         """
         Returns a list of transactions that modified the customer's [cash balance](https://stripe.com/docs/payments/customer-balance).
@@ -1998,7 +2046,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.CreateSourceParams"]
+        **params: Unpack[
+            "Customer.CreateSourceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> Union["Account", "BankAccount", "Card", "Source"]:
         """
         When you create a new credit card, you must specify a customer or recipient on which to create it.
@@ -2029,7 +2079,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.RetrieveSourceParams"]
+        **params: Unpack[
+            "Customer.RetrieveSourceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> Union["Account", "BankAccount", "Card", "Source"]:
         """
         Retrieve a specified source for a given customer.
@@ -2057,7 +2109,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.ModifySourceParams"]
+        **params: Unpack[
+            "Customer.ModifySourceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> Union["Account", "BankAccount", "Card", "Source"]:
         """
         Update a specified source for a given customer.
@@ -2085,7 +2139,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.DeleteSourceParams"]
+        **params: Unpack[
+            "Customer.DeleteSourceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> Union["Account", "BankAccount", "Card", "Source"]:
         """
         Delete a specified source for a given customer.
@@ -2112,7 +2168,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.ListSourcesParams"]
+        **params: Unpack[
+            "Customer.ListSourcesParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject[Union["Account", "BankAccount", "Card", "Source"]]:
         """
         List sources for a specified customer.
@@ -2138,7 +2196,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.CreateTaxIdParams"]
+        **params: Unpack[
+            "Customer.CreateTaxIdParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "TaxId":
         """
         Creates a new tax_id object for a customer.
@@ -2165,7 +2225,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.RetrieveTaxIdParams"]
+        **params: Unpack[
+            "Customer.RetrieveTaxIdParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "TaxId":
         """
         Retrieves the tax_id object with the given identifier.
@@ -2193,7 +2255,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.DeleteTaxIdParams"]
+        **params: Unpack[
+            "Customer.DeleteTaxIdParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "TaxId":
         """
         Deletes an existing tax_id object.
@@ -2220,7 +2284,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.ListTaxIdsParams"]
+        **params: Unpack[
+            "Customer.ListTaxIdsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["TaxId"]:
         """
         Returns a list of tax IDs for a customer.
@@ -2246,7 +2312,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.ModifyCashBalanceParams"]
+        **params: Unpack[
+            "Customer.ModifyCashBalanceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "CashBalance":
         """
         Changes the settings on a customer's cash balance.
@@ -2272,7 +2340,9 @@ class Customer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Customer.RetrieveCashBalanceParams"]
+        **params: Unpack[
+            "Customer.RetrieveCashBalanceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "CashBalance":
         """
         Retrieves a customer's cash balance.
@@ -2301,7 +2371,9 @@ class Customer(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Customer.FundCashBalanceParams"]
+            **params: Unpack[
+                "Customer.FundCashBalanceParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "CustomerCashBalanceTransaction":
             """
             Create an incoming testmode bank transfer
@@ -2327,7 +2399,9 @@ class Customer(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Customer.FundCashBalanceParams"]
+            **params: Unpack[
+                "Customer.FundCashBalanceParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "CustomerCashBalanceTransaction":
             """
             Create an incoming testmode bank transfer
@@ -2338,7 +2412,9 @@ class Customer(
         def fund_cash_balance(
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Customer.FundCashBalanceParams"]
+            **params: Unpack[
+                "Customer.FundCashBalanceParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "CustomerCashBalanceTransaction":
             """
             Create an incoming testmode bank transfer
@@ -2349,7 +2425,9 @@ class Customer(
         def fund_cash_balance(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Customer.FundCashBalanceParams"]
+            **params: Unpack[
+                "Customer.FundCashBalanceParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "CustomerCashBalanceTransaction":
             """
             Create an incoming testmode bank transfer

--- a/stripe/api_resources/customer_cash_balance_transaction.py
+++ b/stripe/api_resources/customer_cash_balance_transaction.py
@@ -223,7 +223,9 @@ class CustomerCashBalanceTransaction(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["CustomerCashBalanceTransaction.ListParams"]
+        **params: Unpack[
+            "CustomerCashBalanceTransaction.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["CustomerCashBalanceTransaction"]:
         """
         Returns a list of transactions that modified the customer's [cash balance](https://stripe.com/docs/payments/customer-balance).

--- a/stripe/api_resources/dispute.py
+++ b/stripe/api_resources/dispute.py
@@ -451,7 +451,9 @@ class Dispute(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Dispute.CloseParams"]
+        **params: Unpack[
+            "Dispute.CloseParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Dispute":
         """
         Closing the dispute for a charge indicates that you do not have any evidence to submit and are essentially dismissing the dispute, acknowledging it as lost.
@@ -479,7 +481,9 @@ class Dispute(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Dispute.CloseParams"]
+        **params: Unpack[
+            "Dispute.CloseParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Dispute":
         """
         Closing the dispute for a charge indicates that you do not have any evidence to submit and are essentially dismissing the dispute, acknowledging it as lost.
@@ -492,7 +496,9 @@ class Dispute(
     def close(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Dispute.CloseParams"]
+        **params: Unpack[
+            "Dispute.CloseParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Dispute":
         """
         Closing the dispute for a charge indicates that you do not have any evidence to submit and are essentially dismissing the dispute, acknowledging it as lost.
@@ -505,7 +511,9 @@ class Dispute(
     def close(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Dispute.CloseParams"]
+        **params: Unpack[
+            "Dispute.CloseParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Dispute":
         """
         Closing the dispute for a charge indicates that you do not have any evidence to submit and are essentially dismissing the dispute, acknowledging it as lost.
@@ -530,7 +538,9 @@ class Dispute(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Dispute.ListParams"]
+        **params: Unpack[
+            "Dispute.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Dispute"]:
         """
         Returns a list of your disputes.

--- a/stripe/api_resources/event.py
+++ b/stripe/api_resources/event.py
@@ -397,7 +397,9 @@ class Event(ListableAPIResource["Event"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Event.ListParams"]
+        **params: Unpack[
+            "Event.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Event"]:
         """
         List events, going back up to 30 days. Each event data is rendered according to Stripe API version at its creation time, specified in [event object](https://stripe.com/docs/api/events/object) api_version attribute (not according to your current Stripe API version or Stripe-Version header).

--- a/stripe/api_resources/exchange_rate.py
+++ b/stripe/api_resources/exchange_rate.py
@@ -83,7 +83,9 @@ class ExchangeRate(ListableAPIResource["ExchangeRate"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["ExchangeRate.ListParams"]
+        **params: Unpack[
+            "ExchangeRate.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["ExchangeRate"]:
         """
         Returns a list of objects that contain the rates at which foreign currencies are converted to one another. Only shows the currencies for which Stripe supports.

--- a/stripe/api_resources/file.py
+++ b/stripe/api_resources/file.py
@@ -148,7 +148,9 @@ class File(ListableAPIResource["File"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["File.ListParams"]
+        **params: Unpack[
+            "File.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["File"]:
         """
         Returns a list of the files that your account has access to. Stripe sorts and returns the files by their creation dates, placing the most recently created files at the top.

--- a/stripe/api_resources/file_link.py
+++ b/stripe/api_resources/file_link.py
@@ -163,7 +163,9 @@ class FileLink(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["FileLink.CreateParams"]
+        **params: Unpack[
+            "FileLink.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "FileLink":
         """
         Creates a new file link object.
@@ -187,7 +189,9 @@ class FileLink(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["FileLink.ListParams"]
+        **params: Unpack[
+            "FileLink.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["FileLink"]:
         """
         Returns a list of file links.

--- a/stripe/api_resources/financial_connections/account.py
+++ b/stripe/api_resources/financial_connections/account.py
@@ -293,7 +293,9 @@ class Account(ListableAPIResource["Account"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.DisconnectParams"]
+        **params: Unpack[
+            "Account.DisconnectParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Account":
         """
         Disables your access to a Financial Connections Account. You will no longer be able to access data associated with the account (e.g. balances, transactions).
@@ -319,7 +321,9 @@ class Account(ListableAPIResource["Account"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.DisconnectParams"]
+        **params: Unpack[
+            "Account.DisconnectParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Account":
         """
         Disables your access to a Financial Connections Account. You will no longer be able to access data associated with the account (e.g. balances, transactions).
@@ -330,7 +334,9 @@ class Account(ListableAPIResource["Account"]):
     def disconnect(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Account.DisconnectParams"]
+        **params: Unpack[
+            "Account.DisconnectParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Account":
         """
         Disables your access to a Financial Connections Account. You will no longer be able to access data associated with the account (e.g. balances, transactions).
@@ -341,7 +347,9 @@ class Account(ListableAPIResource["Account"]):
     def disconnect(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Account.DisconnectParams"]
+        **params: Unpack[
+            "Account.DisconnectParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Account":
         """
         Disables your access to a Financial Connections Account. You will no longer be able to access data associated with the account (e.g. balances, transactions).
@@ -364,7 +372,9 @@ class Account(ListableAPIResource["Account"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.ListParams"]
+        **params: Unpack[
+            "Account.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Account"]:
         """
         Returns a list of Financial Connections Account objects.
@@ -393,7 +403,9 @@ class Account(ListableAPIResource["Account"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.ListOwnersParams"]
+        **params: Unpack[
+            "Account.ListOwnersParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["AccountOwner"]:
         """
         Lists all owners for a given Account
@@ -419,7 +431,9 @@ class Account(ListableAPIResource["Account"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.ListOwnersParams"]
+        **params: Unpack[
+            "Account.ListOwnersParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["AccountOwner"]:
         """
         Lists all owners for a given Account
@@ -430,7 +444,9 @@ class Account(ListableAPIResource["Account"]):
     def list_owners(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Account.ListOwnersParams"]
+        **params: Unpack[
+            "Account.ListOwnersParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["AccountOwner"]:
         """
         Lists all owners for a given Account
@@ -441,7 +457,9 @@ class Account(ListableAPIResource["Account"]):
     def list_owners(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Account.ListOwnersParams"]
+        **params: Unpack[
+            "Account.ListOwnersParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["AccountOwner"]:
         """
         Lists all owners for a given Account
@@ -465,7 +483,9 @@ class Account(ListableAPIResource["Account"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.RefreshAccountParams"]
+        **params: Unpack[
+            "Account.RefreshAccountParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Account":
         """
         Refreshes the data associated with a Financial Connections Account.
@@ -491,7 +511,9 @@ class Account(ListableAPIResource["Account"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Account.RefreshAccountParams"]
+        **params: Unpack[
+            "Account.RefreshAccountParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Account":
         """
         Refreshes the data associated with a Financial Connections Account.
@@ -502,7 +524,9 @@ class Account(ListableAPIResource["Account"]):
     def refresh_account(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Account.RefreshAccountParams"]
+        **params: Unpack[
+            "Account.RefreshAccountParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Account":
         """
         Refreshes the data associated with a Financial Connections Account.
@@ -513,7 +537,9 @@ class Account(ListableAPIResource["Account"]):
     def refresh_account(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Account.RefreshAccountParams"]
+        **params: Unpack[
+            "Account.RefreshAccountParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Account":
         """
         Refreshes the data associated with a Financial Connections Account.

--- a/stripe/api_resources/financial_connections/session.py
+++ b/stripe/api_resources/financial_connections/session.py
@@ -158,7 +158,9 @@ class Session(CreateableAPIResource["Session"]):
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Session.CreateParams"]
+        **params: Unpack[
+            "Session.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Session":
         """
         To launch the Financial Connections authorization flow, create a Session. The session's client_secret can be used to launch the flow using Stripe.js.

--- a/stripe/api_resources/identity/verification_report.py
+++ b/stripe/api_resources/identity/verification_report.py
@@ -396,7 +396,9 @@ class VerificationReport(ListableAPIResource["VerificationReport"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["VerificationReport.ListParams"]
+        **params: Unpack[
+            "VerificationReport.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["VerificationReport"]:
         """
         List all verification reports.

--- a/stripe/api_resources/identity/verification_session.py
+++ b/stripe/api_resources/identity/verification_session.py
@@ -402,7 +402,9 @@ class VerificationSession(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["VerificationSession.CancelParams"]
+        **params: Unpack[
+            "VerificationSession.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "VerificationSession":
         """
         A VerificationSession object can be canceled when it is in requires_input [status](https://stripe.com/docs/identity/how-sessions-work).
@@ -430,7 +432,9 @@ class VerificationSession(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["VerificationSession.CancelParams"]
+        **params: Unpack[
+            "VerificationSession.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "VerificationSession":
         """
         A VerificationSession object can be canceled when it is in requires_input [status](https://stripe.com/docs/identity/how-sessions-work).
@@ -443,7 +447,9 @@ class VerificationSession(
     def cancel(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["VerificationSession.CancelParams"]
+        **params: Unpack[
+            "VerificationSession.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "VerificationSession":
         """
         A VerificationSession object can be canceled when it is in requires_input [status](https://stripe.com/docs/identity/how-sessions-work).
@@ -456,7 +462,9 @@ class VerificationSession(
     def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["VerificationSession.CancelParams"]
+        **params: Unpack[
+            "VerificationSession.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "VerificationSession":
         """
         A VerificationSession object can be canceled when it is in requires_input [status](https://stripe.com/docs/identity/how-sessions-work).
@@ -482,7 +490,9 @@ class VerificationSession(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["VerificationSession.CreateParams"]
+        **params: Unpack[
+            "VerificationSession.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "VerificationSession":
         """
         Creates a VerificationSession object.
@@ -512,7 +522,9 @@ class VerificationSession(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["VerificationSession.ListParams"]
+        **params: Unpack[
+            "VerificationSession.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["VerificationSession"]:
         """
         Returns a list of VerificationSessions
@@ -557,7 +569,9 @@ class VerificationSession(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["VerificationSession.RedactParams"]
+        **params: Unpack[
+            "VerificationSession.RedactParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "VerificationSession":
         """
         Redact a VerificationSession to remove all collected information from Stripe. This will redact
@@ -601,7 +615,9 @@ class VerificationSession(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["VerificationSession.RedactParams"]
+        **params: Unpack[
+            "VerificationSession.RedactParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "VerificationSession":
         """
         Redact a VerificationSession to remove all collected information from Stripe. This will redact
@@ -630,7 +646,9 @@ class VerificationSession(
     def redact(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["VerificationSession.RedactParams"]
+        **params: Unpack[
+            "VerificationSession.RedactParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "VerificationSession":
         """
         Redact a VerificationSession to remove all collected information from Stripe. This will redact
@@ -659,7 +677,9 @@ class VerificationSession(
     def redact(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["VerificationSession.RedactParams"]
+        **params: Unpack[
+            "VerificationSession.RedactParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "VerificationSession":
         """
         Redact a VerificationSession to remove all collected information from Stripe. This will redact

--- a/stripe/api_resources/invoice.py
+++ b/stripe/api_resources/invoice.py
@@ -3596,7 +3596,9 @@ class Invoice(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Invoice.CreateParams"]
+        **params: Unpack[
+            "Invoice.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Invoice":
         """
         This endpoint creates a draft invoice for a given customer. The invoice remains a draft until you [finalize the invoice, which allows you to [pay](#pay_invoice) or <a href="#send_invoice">send](https://stripe.com/docs/api#finalize_invoice) the invoice to your customers.
@@ -3664,7 +3666,9 @@ class Invoice(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Invoice.FinalizeInvoiceParams"]
+        **params: Unpack[
+            "Invoice.FinalizeInvoiceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Invoice":
         """
         Stripe automatically finalizes drafts before sending and attempting payment on invoices. However, if you'd like to finalize a draft invoice manually, you can do so using this method.
@@ -3690,7 +3694,9 @@ class Invoice(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Invoice.FinalizeInvoiceParams"]
+        **params: Unpack[
+            "Invoice.FinalizeInvoiceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Invoice":
         """
         Stripe automatically finalizes drafts before sending and attempting payment on invoices. However, if you'd like to finalize a draft invoice manually, you can do so using this method.
@@ -3701,7 +3707,9 @@ class Invoice(
     def finalize_invoice(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Invoice.FinalizeInvoiceParams"]
+        **params: Unpack[
+            "Invoice.FinalizeInvoiceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Invoice":
         """
         Stripe automatically finalizes drafts before sending and attempting payment on invoices. However, if you'd like to finalize a draft invoice manually, you can do so using this method.
@@ -3712,7 +3720,9 @@ class Invoice(
     def finalize_invoice(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Invoice.FinalizeInvoiceParams"]
+        **params: Unpack[
+            "Invoice.FinalizeInvoiceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Invoice":
         """
         Stripe automatically finalizes drafts before sending and attempting payment on invoices. However, if you'd like to finalize a draft invoice manually, you can do so using this method.
@@ -3735,7 +3745,9 @@ class Invoice(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Invoice.ListParams"]
+        **params: Unpack[
+            "Invoice.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Invoice"]:
         """
         You can list all invoices, or list the invoices for a specific customer. The invoices are returned sorted by creation date, with the most recently created invoices appearing first.
@@ -3764,7 +3776,9 @@ class Invoice(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Invoice.MarkUncollectibleParams"]
+        **params: Unpack[
+            "Invoice.MarkUncollectibleParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Invoice":
         """
         Marking an invoice as uncollectible is useful for keeping track of bad debts that can be written off for accounting purposes.
@@ -3790,7 +3804,9 @@ class Invoice(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Invoice.MarkUncollectibleParams"]
+        **params: Unpack[
+            "Invoice.MarkUncollectibleParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Invoice":
         """
         Marking an invoice as uncollectible is useful for keeping track of bad debts that can be written off for accounting purposes.
@@ -3801,7 +3817,9 @@ class Invoice(
     def mark_uncollectible(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Invoice.MarkUncollectibleParams"]
+        **params: Unpack[
+            "Invoice.MarkUncollectibleParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Invoice":
         """
         Marking an invoice as uncollectible is useful for keeping track of bad debts that can be written off for accounting purposes.
@@ -3812,7 +3830,9 @@ class Invoice(
     def mark_uncollectible(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Invoice.MarkUncollectibleParams"]
+        **params: Unpack[
+            "Invoice.MarkUncollectibleParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Invoice":
         """
         Marking an invoice as uncollectible is useful for keeping track of bad debts that can be written off for accounting purposes.
@@ -3854,7 +3874,9 @@ class Invoice(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Invoice.PayParams"]
+        **params: Unpack[
+            "Invoice.PayParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Invoice":
         """
         Stripe automatically creates and then attempts to collect payment on invoices for customers on subscriptions according to your [subscriptions settings](https://dashboard.stripe.com/account/billing/automatic). However, if you'd like to attempt payment on an invoice out of the normal collection schedule or for some other reason, you can do so.
@@ -3880,7 +3902,9 @@ class Invoice(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Invoice.PayParams"]
+        **params: Unpack[
+            "Invoice.PayParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Invoice":
         """
         Stripe automatically creates and then attempts to collect payment on invoices for customers on subscriptions according to your [subscriptions settings](https://dashboard.stripe.com/account/billing/automatic). However, if you'd like to attempt payment on an invoice out of the normal collection schedule or for some other reason, you can do so.
@@ -3891,7 +3915,9 @@ class Invoice(
     def pay(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Invoice.PayParams"]
+        **params: Unpack[
+            "Invoice.PayParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Invoice":
         """
         Stripe automatically creates and then attempts to collect payment on invoices for customers on subscriptions according to your [subscriptions settings](https://dashboard.stripe.com/account/billing/automatic). However, if you'd like to attempt payment on an invoice out of the normal collection schedule or for some other reason, you can do so.
@@ -3902,7 +3928,9 @@ class Invoice(
     def pay(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Invoice.PayParams"]
+        **params: Unpack[
+            "Invoice.PayParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Invoice":
         """
         Stripe automatically creates and then attempts to collect payment on invoices for customers on subscriptions according to your [subscriptions settings](https://dashboard.stripe.com/account/billing/automatic). However, if you'd like to attempt payment on an invoice out of the normal collection schedule or for some other reason, you can do so.
@@ -3937,7 +3965,9 @@ class Invoice(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Invoice.SendInvoiceParams"]
+        **params: Unpack[
+            "Invoice.SendInvoiceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Invoice":
         """
         Stripe will automatically send invoices to customers according to your [subscriptions settings](https://dashboard.stripe.com/account/billing/automatic). However, if you'd like to manually send an invoice to your customer out of the normal schedule, you can do so. When sending invoices that have already been paid, there will be no reference to the payment in the email.
@@ -3965,7 +3995,9 @@ class Invoice(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Invoice.SendInvoiceParams"]
+        **params: Unpack[
+            "Invoice.SendInvoiceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Invoice":
         """
         Stripe will automatically send invoices to customers according to your [subscriptions settings](https://dashboard.stripe.com/account/billing/automatic). However, if you'd like to manually send an invoice to your customer out of the normal schedule, you can do so. When sending invoices that have already been paid, there will be no reference to the payment in the email.
@@ -3978,7 +4010,9 @@ class Invoice(
     def send_invoice(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Invoice.SendInvoiceParams"]
+        **params: Unpack[
+            "Invoice.SendInvoiceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Invoice":
         """
         Stripe will automatically send invoices to customers according to your [subscriptions settings](https://dashboard.stripe.com/account/billing/automatic). However, if you'd like to manually send an invoice to your customer out of the normal schedule, you can do so. When sending invoices that have already been paid, there will be no reference to the payment in the email.
@@ -3991,7 +4025,9 @@ class Invoice(
     def send_invoice(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Invoice.SendInvoiceParams"]
+        **params: Unpack[
+            "Invoice.SendInvoiceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Invoice":
         """
         Stripe will automatically send invoices to customers according to your [subscriptions settings](https://dashboard.stripe.com/account/billing/automatic). However, if you'd like to manually send an invoice to your customer out of the normal schedule, you can do so. When sending invoices that have already been paid, there will be no reference to the payment in the email.
@@ -4016,7 +4052,9 @@ class Invoice(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Invoice.UpcomingParams"]
+        **params: Unpack[
+            "Invoice.UpcomingParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Invoice":
         """
         At any time, you can preview the upcoming invoice for a customer. This will show you all the charges that are pending, including subscription renewal charges, invoice item charges, etc. It will also show you any discounts that are applicable to the invoice.
@@ -4043,7 +4081,9 @@ class Invoice(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Invoice.UpcomingLinesParams"]
+        **params: Unpack[
+            "Invoice.UpcomingLinesParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["InvoiceLineItem"]:
         """
         When retrieving an upcoming invoice, you'll get a lines property containing the total count of line items and the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.
@@ -4067,7 +4107,9 @@ class Invoice(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Invoice.VoidInvoiceParams"]
+        **params: Unpack[
+            "Invoice.VoidInvoiceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Invoice":
         """
         Mark a finalized invoice as void. This cannot be undone. Voiding an invoice is similar to [deletion](https://stripe.com/docs/api#delete_invoice), however it only applies to finalized invoices and maintains a papertrail where the invoice can still be found.
@@ -4093,7 +4135,9 @@ class Invoice(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Invoice.VoidInvoiceParams"]
+        **params: Unpack[
+            "Invoice.VoidInvoiceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Invoice":
         """
         Mark a finalized invoice as void. This cannot be undone. Voiding an invoice is similar to [deletion](https://stripe.com/docs/api#delete_invoice), however it only applies to finalized invoices and maintains a papertrail where the invoice can still be found.
@@ -4104,7 +4148,9 @@ class Invoice(
     def void_invoice(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Invoice.VoidInvoiceParams"]
+        **params: Unpack[
+            "Invoice.VoidInvoiceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Invoice":
         """
         Mark a finalized invoice as void. This cannot be undone. Voiding an invoice is similar to [deletion](https://stripe.com/docs/api#delete_invoice), however it only applies to finalized invoices and maintains a papertrail where the invoice can still be found.
@@ -4115,7 +4161,9 @@ class Invoice(
     def void_invoice(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Invoice.VoidInvoiceParams"]
+        **params: Unpack[
+            "Invoice.VoidInvoiceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Invoice":
         """
         Mark a finalized invoice as void. This cannot be undone. Voiding an invoice is similar to [deletion](https://stripe.com/docs/api#delete_invoice), however it only applies to finalized invoices and maintains a papertrail where the invoice can still be found.

--- a/stripe/api_resources/invoice_item.py
+++ b/stripe/api_resources/invoice_item.py
@@ -461,7 +461,9 @@ class InvoiceItem(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["InvoiceItem.CreateParams"]
+        **params: Unpack[
+            "InvoiceItem.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "InvoiceItem":
         """
         Creates an item to be added to a draft invoice (up to 250 items per invoice). If no invoice is specified, the item will be on the next invoice created for the customer specified.
@@ -530,7 +532,9 @@ class InvoiceItem(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["InvoiceItem.ListParams"]
+        **params: Unpack[
+            "InvoiceItem.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["InvoiceItem"]:
         """
         Returns a list of your invoice items. Invoice items are returned sorted by creation date, with the most recently created invoice items appearing first.

--- a/stripe/api_resources/issuing/authorization.py
+++ b/stripe/api_resources/issuing/authorization.py
@@ -805,7 +805,9 @@ class Authorization(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Authorization.ApproveParams"]
+        **params: Unpack[
+            "Authorization.ApproveParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Authorization":
         """
         [Deprecated] Approves a pending Issuing Authorization object. This request should be made within the timeout window of the [real-time authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations) flow.
@@ -832,7 +834,9 @@ class Authorization(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Authorization.ApproveParams"]
+        **params: Unpack[
+            "Authorization.ApproveParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Authorization":
         """
         [Deprecated] Approves a pending Issuing Authorization object. This request should be made within the timeout window of the [real-time authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations) flow.
@@ -844,7 +848,9 @@ class Authorization(
     def approve(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Authorization.ApproveParams"]
+        **params: Unpack[
+            "Authorization.ApproveParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Authorization":
         """
         [Deprecated] Approves a pending Issuing Authorization object. This request should be made within the timeout window of the [real-time authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations) flow.
@@ -856,7 +862,9 @@ class Authorization(
     def approve(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Authorization.ApproveParams"]
+        **params: Unpack[
+            "Authorization.ApproveParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Authorization":
         """
         [Deprecated] Approves a pending Issuing Authorization object. This request should be made within the timeout window of the [real-time authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations) flow.
@@ -881,7 +889,9 @@ class Authorization(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Authorization.DeclineParams"]
+        **params: Unpack[
+            "Authorization.DeclineParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Authorization":
         """
         [Deprecated] Declines a pending Issuing Authorization object. This request should be made within the timeout window of the [real time authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations) flow.
@@ -908,7 +918,9 @@ class Authorization(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Authorization.DeclineParams"]
+        **params: Unpack[
+            "Authorization.DeclineParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Authorization":
         """
         [Deprecated] Declines a pending Issuing Authorization object. This request should be made within the timeout window of the [real time authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations) flow.
@@ -920,7 +932,9 @@ class Authorization(
     def decline(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Authorization.DeclineParams"]
+        **params: Unpack[
+            "Authorization.DeclineParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Authorization":
         """
         [Deprecated] Declines a pending Issuing Authorization object. This request should be made within the timeout window of the [real time authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations) flow.
@@ -932,7 +946,9 @@ class Authorization(
     def decline(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Authorization.DeclineParams"]
+        **params: Unpack[
+            "Authorization.DeclineParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Authorization":
         """
         [Deprecated] Declines a pending Issuing Authorization object. This request should be made within the timeout window of the [real time authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations) flow.
@@ -956,7 +972,9 @@ class Authorization(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Authorization.ListParams"]
+        **params: Unpack[
+            "Authorization.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Authorization"]:
         """
         Returns a list of Issuing Authorization objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
@@ -1012,7 +1030,9 @@ class Authorization(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Authorization.CaptureParams"]
+            **params: Unpack[
+                "Authorization.CaptureParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Authorization":
             """
             Capture a test-mode authorization.
@@ -1038,7 +1058,9 @@ class Authorization(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Authorization.CaptureParams"]
+            **params: Unpack[
+                "Authorization.CaptureParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Authorization":
             """
             Capture a test-mode authorization.
@@ -1049,7 +1071,9 @@ class Authorization(
         def capture(
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Authorization.CaptureParams"]
+            **params: Unpack[
+                "Authorization.CaptureParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Authorization":
             """
             Capture a test-mode authorization.
@@ -1060,7 +1084,9 @@ class Authorization(
         def capture(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Authorization.CaptureParams"]
+            **params: Unpack[
+                "Authorization.CaptureParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Authorization":
             """
             Capture a test-mode authorization.
@@ -1083,7 +1109,9 @@ class Authorization(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Authorization.CreateParams"]
+            **params: Unpack[
+                "Authorization.CreateParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Authorization":
             """
             Create a test-mode authorization.
@@ -1107,7 +1135,9 @@ class Authorization(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Authorization.ExpireParams"]
+            **params: Unpack[
+                "Authorization.ExpireParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Authorization":
             """
             Expire a test-mode Authorization.
@@ -1133,7 +1163,9 @@ class Authorization(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Authorization.ExpireParams"]
+            **params: Unpack[
+                "Authorization.ExpireParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Authorization":
             """
             Expire a test-mode Authorization.
@@ -1144,7 +1176,9 @@ class Authorization(
         def expire(
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Authorization.ExpireParams"]
+            **params: Unpack[
+                "Authorization.ExpireParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Authorization":
             """
             Expire a test-mode Authorization.
@@ -1155,7 +1189,9 @@ class Authorization(
         def expire(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Authorization.ExpireParams"]
+            **params: Unpack[
+                "Authorization.ExpireParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Authorization":
             """
             Expire a test-mode Authorization.
@@ -1179,7 +1215,9 @@ class Authorization(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Authorization.IncrementParams"]
+            **params: Unpack[
+                "Authorization.IncrementParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Authorization":
             """
             Increment a test-mode Authorization.
@@ -1205,7 +1243,9 @@ class Authorization(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Authorization.IncrementParams"]
+            **params: Unpack[
+                "Authorization.IncrementParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Authorization":
             """
             Increment a test-mode Authorization.
@@ -1216,7 +1256,9 @@ class Authorization(
         def increment(
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Authorization.IncrementParams"]
+            **params: Unpack[
+                "Authorization.IncrementParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Authorization":
             """
             Increment a test-mode Authorization.
@@ -1227,7 +1269,9 @@ class Authorization(
         def increment(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Authorization.IncrementParams"]
+            **params: Unpack[
+                "Authorization.IncrementParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Authorization":
             """
             Increment a test-mode Authorization.
@@ -1251,7 +1295,9 @@ class Authorization(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Authorization.ReverseParams"]
+            **params: Unpack[
+                "Authorization.ReverseParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Authorization":
             """
             Reverse a test-mode Authorization.
@@ -1277,7 +1323,9 @@ class Authorization(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Authorization.ReverseParams"]
+            **params: Unpack[
+                "Authorization.ReverseParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Authorization":
             """
             Reverse a test-mode Authorization.
@@ -1288,7 +1336,9 @@ class Authorization(
         def reverse(
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Authorization.ReverseParams"]
+            **params: Unpack[
+                "Authorization.ReverseParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Authorization":
             """
             Reverse a test-mode Authorization.
@@ -1299,7 +1349,9 @@ class Authorization(
         def reverse(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Authorization.ReverseParams"]
+            **params: Unpack[
+                "Authorization.ReverseParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Authorization":
             """
             Reverse a test-mode Authorization.

--- a/stripe/api_resources/issuing/card.py
+++ b/stripe/api_resources/issuing/card.py
@@ -1530,7 +1530,9 @@ class Card(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Card.CreateParams"]
+        **params: Unpack[
+            "Card.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Card":
         """
         Creates an Issuing Card object.
@@ -1554,7 +1556,9 @@ class Card(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Card.ListParams"]
+        **params: Unpack[
+            "Card.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Card"]:
         """
         Returns a list of Issuing Card objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
@@ -1608,7 +1612,9 @@ class Card(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Card.DeliverCardParams"]
+            **params: Unpack[
+                "Card.DeliverCardParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Card":
             """
             Updates the shipping status of the specified Issuing Card object to delivered.
@@ -1634,7 +1640,9 @@ class Card(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Card.DeliverCardParams"]
+            **params: Unpack[
+                "Card.DeliverCardParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Card":
             """
             Updates the shipping status of the specified Issuing Card object to delivered.
@@ -1645,7 +1653,9 @@ class Card(
         def deliver_card(
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Card.DeliverCardParams"]
+            **params: Unpack[
+                "Card.DeliverCardParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Card":
             """
             Updates the shipping status of the specified Issuing Card object to delivered.
@@ -1656,7 +1666,9 @@ class Card(
         def deliver_card(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Card.DeliverCardParams"]
+            **params: Unpack[
+                "Card.DeliverCardParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Card":
             """
             Updates the shipping status of the specified Issuing Card object to delivered.
@@ -1680,7 +1692,9 @@ class Card(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Card.FailCardParams"]
+            **params: Unpack[
+                "Card.FailCardParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Card":
             """
             Updates the shipping status of the specified Issuing Card object to failure.
@@ -1706,7 +1720,9 @@ class Card(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Card.FailCardParams"]
+            **params: Unpack[
+                "Card.FailCardParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Card":
             """
             Updates the shipping status of the specified Issuing Card object to failure.
@@ -1717,7 +1733,9 @@ class Card(
         def fail_card(
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Card.FailCardParams"]
+            **params: Unpack[
+                "Card.FailCardParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Card":
             """
             Updates the shipping status of the specified Issuing Card object to failure.
@@ -1728,7 +1746,9 @@ class Card(
         def fail_card(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Card.FailCardParams"]
+            **params: Unpack[
+                "Card.FailCardParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Card":
             """
             Updates the shipping status of the specified Issuing Card object to failure.
@@ -1752,7 +1772,9 @@ class Card(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Card.ReturnCardParams"]
+            **params: Unpack[
+                "Card.ReturnCardParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Card":
             """
             Updates the shipping status of the specified Issuing Card object to returned.
@@ -1778,7 +1800,9 @@ class Card(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Card.ReturnCardParams"]
+            **params: Unpack[
+                "Card.ReturnCardParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Card":
             """
             Updates the shipping status of the specified Issuing Card object to returned.
@@ -1789,7 +1813,9 @@ class Card(
         def return_card(
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Card.ReturnCardParams"]
+            **params: Unpack[
+                "Card.ReturnCardParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Card":
             """
             Updates the shipping status of the specified Issuing Card object to returned.
@@ -1800,7 +1826,9 @@ class Card(
         def return_card(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Card.ReturnCardParams"]
+            **params: Unpack[
+                "Card.ReturnCardParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Card":
             """
             Updates the shipping status of the specified Issuing Card object to returned.
@@ -1824,7 +1852,9 @@ class Card(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Card.ShipCardParams"]
+            **params: Unpack[
+                "Card.ShipCardParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Card":
             """
             Updates the shipping status of the specified Issuing Card object to shipped.
@@ -1850,7 +1880,9 @@ class Card(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Card.ShipCardParams"]
+            **params: Unpack[
+                "Card.ShipCardParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Card":
             """
             Updates the shipping status of the specified Issuing Card object to shipped.
@@ -1861,7 +1893,9 @@ class Card(
         def ship_card(
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Card.ShipCardParams"]
+            **params: Unpack[
+                "Card.ShipCardParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Card":
             """
             Updates the shipping status of the specified Issuing Card object to shipped.
@@ -1872,7 +1906,9 @@ class Card(
         def ship_card(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Card.ShipCardParams"]
+            **params: Unpack[
+                "Card.ShipCardParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Card":
             """
             Updates the shipping status of the specified Issuing Card object to shipped.

--- a/stripe/api_resources/issuing/cardholder.py
+++ b/stripe/api_resources/issuing/cardholder.py
@@ -1685,7 +1685,9 @@ class Cardholder(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Cardholder.CreateParams"]
+        **params: Unpack[
+            "Cardholder.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Cardholder":
         """
         Creates a new Issuing Cardholder object that can be issued cards.
@@ -1709,7 +1711,9 @@ class Cardholder(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Cardholder.ListParams"]
+        **params: Unpack[
+            "Cardholder.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Cardholder"]:
         """
         Returns a list of Issuing Cardholder objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.

--- a/stripe/api_resources/issuing/dispute.py
+++ b/stripe/api_resources/issuing/dispute.py
@@ -865,7 +865,9 @@ class Dispute(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Dispute.CreateParams"]
+        **params: Unpack[
+            "Dispute.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Dispute":
         """
         Creates an Issuing Dispute object. Individual pieces of evidence within the evidence object are optional at this point. Stripe only validates that required evidence is present during submission. Refer to [Dispute reasons and evidence](https://stripe.com/docs/issuing/purchases/disputes#dispute-reasons-and-evidence) for more details about evidence requirements.
@@ -889,7 +891,9 @@ class Dispute(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Dispute.ListParams"]
+        **params: Unpack[
+            "Dispute.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Dispute"]:
         """
         Returns a list of Issuing Dispute objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
@@ -942,7 +946,9 @@ class Dispute(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Dispute.SubmitParams"]
+        **params: Unpack[
+            "Dispute.SubmitParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Dispute":
         """
         Submits an Issuing Dispute to the card network. Stripe validates that all evidence fields required for the dispute's reason are present. For more details, see [Dispute reasons and evidence](https://stripe.com/docs/issuing/purchases/disputes#dispute-reasons-and-evidence).
@@ -968,7 +974,9 @@ class Dispute(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Dispute.SubmitParams"]
+        **params: Unpack[
+            "Dispute.SubmitParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Dispute":
         """
         Submits an Issuing Dispute to the card network. Stripe validates that all evidence fields required for the dispute's reason are present. For more details, see [Dispute reasons and evidence](https://stripe.com/docs/issuing/purchases/disputes#dispute-reasons-and-evidence).
@@ -979,7 +987,9 @@ class Dispute(
     def submit(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Dispute.SubmitParams"]
+        **params: Unpack[
+            "Dispute.SubmitParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Dispute":
         """
         Submits an Issuing Dispute to the card network. Stripe validates that all evidence fields required for the dispute's reason are present. For more details, see [Dispute reasons and evidence](https://stripe.com/docs/issuing/purchases/disputes#dispute-reasons-and-evidence).
@@ -990,7 +1000,9 @@ class Dispute(
     def submit(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Dispute.SubmitParams"]
+        **params: Unpack[
+            "Dispute.SubmitParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Dispute":
         """
         Submits an Issuing Dispute to the card network. Stripe validates that all evidence fields required for the dispute's reason are present. For more details, see [Dispute reasons and evidence](https://stripe.com/docs/issuing/purchases/disputes#dispute-reasons-and-evidence).

--- a/stripe/api_resources/issuing/token.py
+++ b/stripe/api_resources/issuing/token.py
@@ -316,7 +316,9 @@ class Token(ListableAPIResource["Token"], UpdateableAPIResource["Token"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Token.ListParams"]
+        **params: Unpack[
+            "Token.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Token"]:
         """
         Lists all Issuing Token objects for a given card.

--- a/stripe/api_resources/issuing/transaction.py
+++ b/stripe/api_resources/issuing/transaction.py
@@ -774,7 +774,9 @@ class Transaction(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Transaction.ListParams"]
+        **params: Unpack[
+            "Transaction.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Transaction"]:
         """
         Returns a list of Issuing Transaction objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
@@ -829,7 +831,9 @@ class Transaction(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Transaction.CreateForceCaptureParams"]
+            **params: Unpack[
+                "Transaction.CreateForceCaptureParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Transaction":
             """
             Allows the user to capture an arbitrary amount, also known as a forced capture.
@@ -852,7 +856,9 @@ class Transaction(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Transaction.CreateUnlinkedRefundParams"]
+            **params: Unpack[
+                "Transaction.CreateUnlinkedRefundParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Transaction":
             """
             Allows the user to refund an arbitrary amount, also known as a unlinked refund.
@@ -876,7 +882,9 @@ class Transaction(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Transaction.RefundParams"]
+            **params: Unpack[
+                "Transaction.RefundParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Transaction":
             """
             Refund a test-mode Transaction.
@@ -902,7 +910,9 @@ class Transaction(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Transaction.RefundParams"]
+            **params: Unpack[
+                "Transaction.RefundParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Transaction":
             """
             Refund a test-mode Transaction.
@@ -913,7 +923,9 @@ class Transaction(
         def refund(
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Transaction.RefundParams"]
+            **params: Unpack[
+                "Transaction.RefundParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Transaction":
             """
             Refund a test-mode Transaction.
@@ -924,7 +936,9 @@ class Transaction(
         def refund(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Transaction.RefundParams"]
+            **params: Unpack[
+                "Transaction.RefundParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Transaction":
             """
             Refund a test-mode Transaction.

--- a/stripe/api_resources/list_object.py
+++ b/stripe/api_resources/list_object.py
@@ -192,8 +192,11 @@ class ListObject(StripeObject, Generic[T]):
             stripe_account=stripe_account,
             **params_with_filters,
         )
+        # Sanity check that this is a list object.
         assert isinstance(result, ListObject)
-        return result
+        # We have to cast to assert that this the types *inside* the list object
+        # are the types indicated by "self"
+        return cast(Self, result)
 
     def previous_page(
         self,
@@ -225,5 +228,8 @@ class ListObject(StripeObject, Generic[T]):
             stripe_account=stripe_account,
             **params_with_filters,
         )
+        # Sanity check that this is a list object.
         assert isinstance(result, ListObject)
-        return result
+        # We have to cast to assert that this the types *inside* the list object
+        # are the types indicated by "self"
+        return cast(Self, result)

--- a/stripe/api_resources/payment_intent.py
+++ b/stripe/api_resources/payment_intent.py
@@ -7456,7 +7456,9 @@ class PaymentIntent(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentIntent.ApplyCustomerBalanceParams"]
+        **params: Unpack[
+            "PaymentIntent.ApplyCustomerBalanceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         Manually reconcile the remaining amount for a customer_balance PaymentIntent.
@@ -7482,7 +7484,9 @@ class PaymentIntent(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentIntent.ApplyCustomerBalanceParams"]
+        **params: Unpack[
+            "PaymentIntent.ApplyCustomerBalanceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         Manually reconcile the remaining amount for a customer_balance PaymentIntent.
@@ -7493,7 +7497,9 @@ class PaymentIntent(
     def apply_customer_balance(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["PaymentIntent.ApplyCustomerBalanceParams"]
+        **params: Unpack[
+            "PaymentIntent.ApplyCustomerBalanceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         Manually reconcile the remaining amount for a customer_balance PaymentIntent.
@@ -7504,7 +7510,9 @@ class PaymentIntent(
     def apply_customer_balance(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["PaymentIntent.ApplyCustomerBalanceParams"]
+        **params: Unpack[
+            "PaymentIntent.ApplyCustomerBalanceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         Manually reconcile the remaining amount for a customer_balance PaymentIntent.
@@ -7528,7 +7536,9 @@ class PaymentIntent(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentIntent.CancelParams"]
+        **params: Unpack[
+            "PaymentIntent.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         You can cancel a PaymentIntent object when it's in one of these statuses: requires_payment_method, requires_capture, requires_confirmation, requires_action or, [in rare cases](https://stripe.com/docs/payments/intents), processing.
@@ -7558,7 +7568,9 @@ class PaymentIntent(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentIntent.CancelParams"]
+        **params: Unpack[
+            "PaymentIntent.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         You can cancel a PaymentIntent object when it's in one of these statuses: requires_payment_method, requires_capture, requires_confirmation, requires_action or, [in rare cases](https://stripe.com/docs/payments/intents), processing.
@@ -7573,7 +7585,9 @@ class PaymentIntent(
     def cancel(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["PaymentIntent.CancelParams"]
+        **params: Unpack[
+            "PaymentIntent.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         You can cancel a PaymentIntent object when it's in one of these statuses: requires_payment_method, requires_capture, requires_confirmation, requires_action or, [in rare cases](https://stripe.com/docs/payments/intents), processing.
@@ -7588,7 +7602,9 @@ class PaymentIntent(
     def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["PaymentIntent.CancelParams"]
+        **params: Unpack[
+            "PaymentIntent.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         You can cancel a PaymentIntent object when it's in one of these statuses: requires_payment_method, requires_capture, requires_confirmation, requires_action or, [in rare cases](https://stripe.com/docs/payments/intents), processing.
@@ -7616,7 +7632,9 @@ class PaymentIntent(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentIntent.CaptureParams"]
+        **params: Unpack[
+            "PaymentIntent.CaptureParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         Capture the funds of an existing uncaptured PaymentIntent when its status is requires_capture.
@@ -7646,7 +7664,9 @@ class PaymentIntent(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentIntent.CaptureParams"]
+        **params: Unpack[
+            "PaymentIntent.CaptureParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         Capture the funds of an existing uncaptured PaymentIntent when its status is requires_capture.
@@ -7661,7 +7681,9 @@ class PaymentIntent(
     def capture(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["PaymentIntent.CaptureParams"]
+        **params: Unpack[
+            "PaymentIntent.CaptureParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         Capture the funds of an existing uncaptured PaymentIntent when its status is requires_capture.
@@ -7676,7 +7698,9 @@ class PaymentIntent(
     def capture(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["PaymentIntent.CaptureParams"]
+        **params: Unpack[
+            "PaymentIntent.CaptureParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         Capture the funds of an existing uncaptured PaymentIntent when its status is requires_capture.
@@ -7704,7 +7728,9 @@ class PaymentIntent(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentIntent.ConfirmParams"]
+        **params: Unpack[
+            "PaymentIntent.ConfirmParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         Confirm that your customer intends to pay with current or provided
@@ -7752,7 +7778,9 @@ class PaymentIntent(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentIntent.ConfirmParams"]
+        **params: Unpack[
+            "PaymentIntent.ConfirmParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         Confirm that your customer intends to pay with current or provided
@@ -7785,7 +7813,9 @@ class PaymentIntent(
     def confirm(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["PaymentIntent.ConfirmParams"]
+        **params: Unpack[
+            "PaymentIntent.ConfirmParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         Confirm that your customer intends to pay with current or provided
@@ -7818,7 +7848,9 @@ class PaymentIntent(
     def confirm(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["PaymentIntent.ConfirmParams"]
+        **params: Unpack[
+            "PaymentIntent.ConfirmParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         Confirm that your customer intends to pay with current or provided
@@ -7864,7 +7896,9 @@ class PaymentIntent(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentIntent.CreateParams"]
+        **params: Unpack[
+            "PaymentIntent.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         Creates a PaymentIntent object.
@@ -7898,7 +7932,9 @@ class PaymentIntent(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentIntent.IncrementAuthorizationParams"]
+        **params: Unpack[
+            "PaymentIntent.IncrementAuthorizationParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         Perform an incremental authorization on an eligible
@@ -7947,7 +7983,9 @@ class PaymentIntent(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentIntent.IncrementAuthorizationParams"]
+        **params: Unpack[
+            "PaymentIntent.IncrementAuthorizationParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         Perform an incremental authorization on an eligible
@@ -7981,7 +8019,9 @@ class PaymentIntent(
     def increment_authorization(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["PaymentIntent.IncrementAuthorizationParams"]
+        **params: Unpack[
+            "PaymentIntent.IncrementAuthorizationParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         Perform an incremental authorization on an eligible
@@ -8015,7 +8055,9 @@ class PaymentIntent(
     def increment_authorization(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["PaymentIntent.IncrementAuthorizationParams"]
+        **params: Unpack[
+            "PaymentIntent.IncrementAuthorizationParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         Perform an incremental authorization on an eligible
@@ -8061,7 +8103,9 @@ class PaymentIntent(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentIntent.ListParams"]
+        **params: Unpack[
+            "PaymentIntent.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["PaymentIntent"]:
         """
         Returns a list of PaymentIntents.
@@ -8124,7 +8168,9 @@ class PaymentIntent(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentIntent.VerifyMicrodepositsParams"]
+        **params: Unpack[
+            "PaymentIntent.VerifyMicrodepositsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         Verifies microdeposits on a PaymentIntent object.
@@ -8150,7 +8196,9 @@ class PaymentIntent(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentIntent.VerifyMicrodepositsParams"]
+        **params: Unpack[
+            "PaymentIntent.VerifyMicrodepositsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         Verifies microdeposits on a PaymentIntent object.
@@ -8161,7 +8209,9 @@ class PaymentIntent(
     def verify_microdeposits(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["PaymentIntent.VerifyMicrodepositsParams"]
+        **params: Unpack[
+            "PaymentIntent.VerifyMicrodepositsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         Verifies microdeposits on a PaymentIntent object.
@@ -8172,7 +8222,9 @@ class PaymentIntent(
     def verify_microdeposits(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["PaymentIntent.VerifyMicrodepositsParams"]
+        **params: Unpack[
+            "PaymentIntent.VerifyMicrodepositsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentIntent":
         """
         Verifies microdeposits on a PaymentIntent object.

--- a/stripe/api_resources/payment_link.py
+++ b/stripe/api_resources/payment_link.py
@@ -2103,7 +2103,9 @@ class PaymentLink(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentLink.CreateParams"]
+        **params: Unpack[
+            "PaymentLink.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentLink":
         """
         Creates a payment link.
@@ -2127,7 +2129,9 @@ class PaymentLink(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentLink.ListParams"]
+        **params: Unpack[
+            "PaymentLink.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["PaymentLink"]:
         """
         Returns a list of your payment links.
@@ -2156,7 +2160,9 @@ class PaymentLink(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentLink.ListLineItemsParams"]
+        **params: Unpack[
+            "PaymentLink.ListLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["LineItem"]:
         """
         When retrieving a payment link, there is an includable line_items property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.
@@ -2182,7 +2188,9 @@ class PaymentLink(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentLink.ListLineItemsParams"]
+        **params: Unpack[
+            "PaymentLink.ListLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["LineItem"]:
         """
         When retrieving a payment link, there is an includable line_items property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.
@@ -2193,7 +2201,9 @@ class PaymentLink(
     def list_line_items(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["PaymentLink.ListLineItemsParams"]
+        **params: Unpack[
+            "PaymentLink.ListLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["LineItem"]:
         """
         When retrieving a payment link, there is an includable line_items property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.
@@ -2204,7 +2214,9 @@ class PaymentLink(
     def list_line_items(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["PaymentLink.ListLineItemsParams"]
+        **params: Unpack[
+            "PaymentLink.ListLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["LineItem"]:
         """
         When retrieving a payment link, there is an includable line_items property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.

--- a/stripe/api_resources/payment_method.py
+++ b/stripe/api_resources/payment_method.py
@@ -1708,7 +1708,9 @@ class PaymentMethod(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentMethod.AttachParams"]
+        **params: Unpack[
+            "PaymentMethod.AttachParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentMethod":
         """
         Attaches a PaymentMethod object to a Customer.
@@ -1746,7 +1748,9 @@ class PaymentMethod(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentMethod.AttachParams"]
+        **params: Unpack[
+            "PaymentMethod.AttachParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentMethod":
         """
         Attaches a PaymentMethod object to a Customer.
@@ -1769,7 +1773,9 @@ class PaymentMethod(
     def attach(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["PaymentMethod.AttachParams"]
+        **params: Unpack[
+            "PaymentMethod.AttachParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentMethod":
         """
         Attaches a PaymentMethod object to a Customer.
@@ -1792,7 +1798,9 @@ class PaymentMethod(
     def attach(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["PaymentMethod.AttachParams"]
+        **params: Unpack[
+            "PaymentMethod.AttachParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentMethod":
         """
         Attaches a PaymentMethod object to a Customer.
@@ -1828,7 +1836,9 @@ class PaymentMethod(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentMethod.CreateParams"]
+        **params: Unpack[
+            "PaymentMethod.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentMethod":
         """
         Creates a PaymentMethod object. Read the [Stripe.js reference](https://stripe.com/docs/stripe-js/reference#stripe-create-payment-method) to learn how to create PaymentMethods via Stripe.js.
@@ -1855,7 +1865,9 @@ class PaymentMethod(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentMethod.DetachParams"]
+        **params: Unpack[
+            "PaymentMethod.DetachParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentMethod":
         """
         Detaches a PaymentMethod object from a Customer. After a PaymentMethod is detached, it can no longer be used for a payment or re-attached to a Customer.
@@ -1881,7 +1893,9 @@ class PaymentMethod(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentMethod.DetachParams"]
+        **params: Unpack[
+            "PaymentMethod.DetachParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentMethod":
         """
         Detaches a PaymentMethod object from a Customer. After a PaymentMethod is detached, it can no longer be used for a payment or re-attached to a Customer.
@@ -1892,7 +1906,9 @@ class PaymentMethod(
     def detach(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["PaymentMethod.DetachParams"]
+        **params: Unpack[
+            "PaymentMethod.DetachParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentMethod":
         """
         Detaches a PaymentMethod object from a Customer. After a PaymentMethod is detached, it can no longer be used for a payment or re-attached to a Customer.
@@ -1903,7 +1919,9 @@ class PaymentMethod(
     def detach(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["PaymentMethod.DetachParams"]
+        **params: Unpack[
+            "PaymentMethod.DetachParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentMethod":
         """
         Detaches a PaymentMethod object from a Customer. After a PaymentMethod is detached, it can no longer be used for a payment or re-attached to a Customer.
@@ -1926,7 +1944,9 @@ class PaymentMethod(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentMethod.ListParams"]
+        **params: Unpack[
+            "PaymentMethod.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["PaymentMethod"]:
         """
         Returns a list of PaymentMethods for Treasury flows. If you want to list the PaymentMethods attached to a Customer for payments, you should use the [List a Customer's PaymentMethods](https://stripe.com/docs/api/payment_methods/customer_list) API instead.

--- a/stripe/api_resources/payment_method_configuration.py
+++ b/stripe/api_resources/payment_method_configuration.py
@@ -2266,7 +2266,9 @@ class PaymentMethodConfiguration(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentMethodConfiguration.CreateParams"]
+        **params: Unpack[
+            "PaymentMethodConfiguration.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentMethodConfiguration":
         """
         Creates a payment method configuration
@@ -2290,7 +2292,9 @@ class PaymentMethodConfiguration(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentMethodConfiguration.ListParams"]
+        **params: Unpack[
+            "PaymentMethodConfiguration.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["PaymentMethodConfiguration"]:
         """
         List payment method configurations

--- a/stripe/api_resources/payment_method_domain.py
+++ b/stripe/api_resources/payment_method_domain.py
@@ -211,7 +211,9 @@ class PaymentMethodDomain(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentMethodDomain.CreateParams"]
+        **params: Unpack[
+            "PaymentMethodDomain.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentMethodDomain":
         """
         Creates a payment method domain.
@@ -235,7 +237,9 @@ class PaymentMethodDomain(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentMethodDomain.ListParams"]
+        **params: Unpack[
+            "PaymentMethodDomain.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["PaymentMethodDomain"]:
         """
         Lists the details of existing payment method domains.
@@ -288,7 +292,9 @@ class PaymentMethodDomain(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentMethodDomain.ValidateParams"]
+        **params: Unpack[
+            "PaymentMethodDomain.ValidateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentMethodDomain":
         """
         Some payment methods such as Apple Pay require additional steps to verify a domain. If the requirements weren't satisfied when the domain was created, the payment method will be inactive on the domain.
@@ -321,7 +327,9 @@ class PaymentMethodDomain(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PaymentMethodDomain.ValidateParams"]
+        **params: Unpack[
+            "PaymentMethodDomain.ValidateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentMethodDomain":
         """
         Some payment methods such as Apple Pay require additional steps to verify a domain. If the requirements weren't satisfied when the domain was created, the payment method will be inactive on the domain.
@@ -337,7 +345,9 @@ class PaymentMethodDomain(
     def validate(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["PaymentMethodDomain.ValidateParams"]
+        **params: Unpack[
+            "PaymentMethodDomain.ValidateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentMethodDomain":
         """
         Some payment methods such as Apple Pay require additional steps to verify a domain. If the requirements weren't satisfied when the domain was created, the payment method will be inactive on the domain.
@@ -353,7 +363,9 @@ class PaymentMethodDomain(
     def validate(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["PaymentMethodDomain.ValidateParams"]
+        **params: Unpack[
+            "PaymentMethodDomain.ValidateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PaymentMethodDomain":
         """
         Some payment methods such as Apple Pay require additional steps to verify a domain. If the requirements weren't satisfied when the domain was created, the payment method will be inactive on the domain.

--- a/stripe/api_resources/payout.py
+++ b/stripe/api_resources/payout.py
@@ -283,7 +283,9 @@ class Payout(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Payout.CancelParams"]
+        **params: Unpack[
+            "Payout.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Payout":
         """
         You can cancel a previously created payout if it hasn't been paid out yet. Stripe refunds the funds to your available balance. You can't cancel automatic Stripe payouts.
@@ -309,7 +311,9 @@ class Payout(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Payout.CancelParams"]
+        **params: Unpack[
+            "Payout.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Payout":
         """
         You can cancel a previously created payout if it hasn't been paid out yet. Stripe refunds the funds to your available balance. You can't cancel automatic Stripe payouts.
@@ -320,7 +324,9 @@ class Payout(
     def cancel(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Payout.CancelParams"]
+        **params: Unpack[
+            "Payout.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Payout":
         """
         You can cancel a previously created payout if it hasn't been paid out yet. Stripe refunds the funds to your available balance. You can't cancel automatic Stripe payouts.
@@ -331,7 +337,9 @@ class Payout(
     def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Payout.CancelParams"]
+        **params: Unpack[
+            "Payout.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Payout":
         """
         You can cancel a previously created payout if it hasn't been paid out yet. Stripe refunds the funds to your available balance. You can't cancel automatic Stripe payouts.
@@ -355,7 +363,9 @@ class Payout(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Payout.CreateParams"]
+        **params: Unpack[
+            "Payout.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Payout":
         """
         To send funds to your own bank account, create a new payout object. Your [Stripe balance](https://stripe.com/docs/api#balance) must cover the payout amount. If it doesn't, you receive an “Insufficient Funds” error.
@@ -383,7 +393,9 @@ class Payout(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Payout.ListParams"]
+        **params: Unpack[
+            "Payout.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Payout"]:
         """
         Returns a list of existing payouts sent to third-party bank accounts or payouts that Stripe sent to you. The payouts return in sorted order, with the most recently created payouts appearing first.
@@ -436,7 +448,9 @@ class Payout(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Payout.ReverseParams"]
+        **params: Unpack[
+            "Payout.ReverseParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Payout":
         """
         Reverses a payout by debiting the destination bank account. At this time, you can only reverse payouts for connected accounts to US bank accounts. If the payout is in the pending status, use /v1/payouts/:id/cancel instead.
@@ -464,7 +478,9 @@ class Payout(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Payout.ReverseParams"]
+        **params: Unpack[
+            "Payout.ReverseParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Payout":
         """
         Reverses a payout by debiting the destination bank account. At this time, you can only reverse payouts for connected accounts to US bank accounts. If the payout is in the pending status, use /v1/payouts/:id/cancel instead.
@@ -477,7 +493,9 @@ class Payout(
     def reverse(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Payout.ReverseParams"]
+        **params: Unpack[
+            "Payout.ReverseParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Payout":
         """
         Reverses a payout by debiting the destination bank account. At this time, you can only reverse payouts for connected accounts to US bank accounts. If the payout is in the pending status, use /v1/payouts/:id/cancel instead.
@@ -490,7 +508,9 @@ class Payout(
     def reverse(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Payout.ReverseParams"]
+        **params: Unpack[
+            "Payout.ReverseParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Payout":
         """
         Reverses a payout by debiting the destination bank account. At this time, you can only reverse payouts for connected accounts to US bank accounts. If the payout is in the pending status, use /v1/payouts/:id/cancel instead.

--- a/stripe/api_resources/plan.py
+++ b/stripe/api_resources/plan.py
@@ -392,7 +392,9 @@ class Plan(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Plan.CreateParams"]
+        **params: Unpack[
+            "Plan.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Plan":
         """
         You can now model subscriptions more flexibly using the [Prices API](https://stripe.com/docs/api#prices). It replaces the Plans API and is backwards compatible to simplify your migration.
@@ -457,7 +459,9 @@ class Plan(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Plan.ListParams"]
+        **params: Unpack[
+            "Plan.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Plan"]:
         """
         Returns a list of your plans.

--- a/stripe/api_resources/price.py
+++ b/stripe/api_resources/price.py
@@ -734,7 +734,9 @@ class Price(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Price.CreateParams"]
+        **params: Unpack[
+            "Price.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Price":
         """
         Creates a new price for an existing product. The price can be recurring or one-time.
@@ -758,7 +760,9 @@ class Price(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Price.ListParams"]
+        **params: Unpack[
+            "Price.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Price"]:
         """
         Returns a list of your prices.

--- a/stripe/api_resources/product.py
+++ b/stripe/api_resources/product.py
@@ -556,7 +556,9 @@ class Product(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Product.CreateParams"]
+        **params: Unpack[
+            "Product.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Product":
         """
         Creates a new product object.
@@ -623,7 +625,9 @@ class Product(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Product.ListParams"]
+        **params: Unpack[
+            "Product.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Product"]:
         """
         Returns a list of your products. The products are returned sorted by creation date, with the most recently created products appearing first.

--- a/stripe/api_resources/promotion_code.py
+++ b/stripe/api_resources/promotion_code.py
@@ -281,7 +281,9 @@ class PromotionCode(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PromotionCode.CreateParams"]
+        **params: Unpack[
+            "PromotionCode.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "PromotionCode":
         """
         A promotion code points to a coupon. You can optionally restrict the code to a specific customer, redemption limit, and expiration date.
@@ -305,7 +307,9 @@ class PromotionCode(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["PromotionCode.ListParams"]
+        **params: Unpack[
+            "PromotionCode.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["PromotionCode"]:
         """
         Returns a list of your promotion codes.

--- a/stripe/api_resources/quote.py
+++ b/stripe/api_resources/quote.py
@@ -1044,7 +1044,9 @@ class Quote(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Quote.AcceptParams"]
+        **params: Unpack[
+            "Quote.AcceptParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Quote":
         """
         Accepts the specified quote.
@@ -1070,7 +1072,9 @@ class Quote(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Quote.AcceptParams"]
+        **params: Unpack[
+            "Quote.AcceptParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Quote":
         """
         Accepts the specified quote.
@@ -1081,7 +1085,9 @@ class Quote(
     def accept(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Quote.AcceptParams"]
+        **params: Unpack[
+            "Quote.AcceptParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Quote":
         """
         Accepts the specified quote.
@@ -1092,7 +1098,9 @@ class Quote(
     def accept(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Quote.AcceptParams"]
+        **params: Unpack[
+            "Quote.AcceptParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Quote":
         """
         Accepts the specified quote.
@@ -1116,7 +1124,9 @@ class Quote(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Quote.CancelParams"]
+        **params: Unpack[
+            "Quote.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Quote":
         """
         Cancels the quote.
@@ -1142,7 +1152,9 @@ class Quote(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Quote.CancelParams"]
+        **params: Unpack[
+            "Quote.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Quote":
         """
         Cancels the quote.
@@ -1153,7 +1165,9 @@ class Quote(
     def cancel(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Quote.CancelParams"]
+        **params: Unpack[
+            "Quote.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Quote":
         """
         Cancels the quote.
@@ -1164,7 +1178,9 @@ class Quote(
     def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Quote.CancelParams"]
+        **params: Unpack[
+            "Quote.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Quote":
         """
         Cancels the quote.
@@ -1188,7 +1204,9 @@ class Quote(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Quote.CreateParams"]
+        **params: Unpack[
+            "Quote.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Quote":
         """
         A quote models prices and services for a customer. Default options for header, description, footer, and expires_at can be set in the dashboard via the [quote template](https://dashboard.stripe.com/settings/billing/quote).
@@ -1213,7 +1231,9 @@ class Quote(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Quote.FinalizeQuoteParams"]
+        **params: Unpack[
+            "Quote.FinalizeQuoteParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Quote":
         """
         Finalizes the quote.
@@ -1239,7 +1259,9 @@ class Quote(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Quote.FinalizeQuoteParams"]
+        **params: Unpack[
+            "Quote.FinalizeQuoteParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Quote":
         """
         Finalizes the quote.
@@ -1250,7 +1272,9 @@ class Quote(
     def finalize_quote(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Quote.FinalizeQuoteParams"]
+        **params: Unpack[
+            "Quote.FinalizeQuoteParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Quote":
         """
         Finalizes the quote.
@@ -1261,7 +1285,9 @@ class Quote(
     def finalize_quote(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Quote.FinalizeQuoteParams"]
+        **params: Unpack[
+            "Quote.FinalizeQuoteParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Quote":
         """
         Finalizes the quote.
@@ -1284,7 +1310,9 @@ class Quote(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Quote.ListParams"]
+        **params: Unpack[
+            "Quote.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Quote"]:
         """
         Returns a list of your quotes.
@@ -1313,7 +1341,9 @@ class Quote(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Quote.ListComputedUpfrontLineItemsParams"]
+        **params: Unpack[
+            "Quote.ListComputedUpfrontLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["LineItem"]:
         """
         When retrieving a quote, there is an includable [computed.upfront.line_items](https://stripe.com/docs/api/quotes/object#quote_object-computed-upfront-line_items) property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of upfront line items.
@@ -1339,7 +1369,9 @@ class Quote(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Quote.ListComputedUpfrontLineItemsParams"]
+        **params: Unpack[
+            "Quote.ListComputedUpfrontLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["LineItem"]:
         """
         When retrieving a quote, there is an includable [computed.upfront.line_items](https://stripe.com/docs/api/quotes/object#quote_object-computed-upfront-line_items) property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of upfront line items.
@@ -1350,7 +1382,9 @@ class Quote(
     def list_computed_upfront_line_items(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Quote.ListComputedUpfrontLineItemsParams"]
+        **params: Unpack[
+            "Quote.ListComputedUpfrontLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["LineItem"]:
         """
         When retrieving a quote, there is an includable [computed.upfront.line_items](https://stripe.com/docs/api/quotes/object#quote_object-computed-upfront-line_items) property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of upfront line items.
@@ -1361,7 +1395,9 @@ class Quote(
     def list_computed_upfront_line_items(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Quote.ListComputedUpfrontLineItemsParams"]
+        **params: Unpack[
+            "Quote.ListComputedUpfrontLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["LineItem"]:
         """
         When retrieving a quote, there is an includable [computed.upfront.line_items](https://stripe.com/docs/api/quotes/object#quote_object-computed-upfront-line_items) property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of upfront line items.
@@ -1385,7 +1421,9 @@ class Quote(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Quote.ListLineItemsParams"]
+        **params: Unpack[
+            "Quote.ListLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["LineItem"]:
         """
         When retrieving a quote, there is an includable line_items property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.
@@ -1411,7 +1449,9 @@ class Quote(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Quote.ListLineItemsParams"]
+        **params: Unpack[
+            "Quote.ListLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["LineItem"]:
         """
         When retrieving a quote, there is an includable line_items property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.
@@ -1422,7 +1462,9 @@ class Quote(
     def list_line_items(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Quote.ListLineItemsParams"]
+        **params: Unpack[
+            "Quote.ListLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["LineItem"]:
         """
         When retrieving a quote, there is an includable line_items property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.
@@ -1433,7 +1475,9 @@ class Quote(
     def list_line_items(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Quote.ListLineItemsParams"]
+        **params: Unpack[
+            "Quote.ListLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["LineItem"]:
         """
         When retrieving a quote, there is an includable line_items property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.

--- a/stripe/api_resources/radar/early_fraud_warning.py
+++ b/stripe/api_resources/radar/early_fraud_warning.py
@@ -96,7 +96,9 @@ class EarlyFraudWarning(ListableAPIResource["EarlyFraudWarning"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["EarlyFraudWarning.ListParams"]
+        **params: Unpack[
+            "EarlyFraudWarning.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["EarlyFraudWarning"]:
         """
         Returns a list of early fraud warnings.

--- a/stripe/api_resources/radar/value_list.py
+++ b/stripe/api_resources/radar/value_list.py
@@ -197,7 +197,9 @@ class ValueList(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["ValueList.CreateParams"]
+        **params: Unpack[
+            "ValueList.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "ValueList":
         """
         Creates a new ValueList object, which can then be referenced in rules.
@@ -266,7 +268,9 @@ class ValueList(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["ValueList.ListParams"]
+        **params: Unpack[
+            "ValueList.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["ValueList"]:
         """
         Returns a list of ValueList objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.

--- a/stripe/api_resources/radar/value_list_item.py
+++ b/stripe/api_resources/radar/value_list_item.py
@@ -143,7 +143,9 @@ class ValueListItem(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["ValueListItem.CreateParams"]
+        **params: Unpack[
+            "ValueListItem.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "ValueListItem":
         """
         Creates a new ValueListItem object, which is added to the specified parent value list.
@@ -212,7 +214,9 @@ class ValueListItem(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["ValueListItem.ListParams"]
+        **params: Unpack[
+            "ValueListItem.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["ValueListItem"]:
         """
         Returns a list of ValueListItem objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.

--- a/stripe/api_resources/refund.py
+++ b/stripe/api_resources/refund.py
@@ -256,7 +256,9 @@ class Refund(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Refund.CancelParams"]
+        **params: Unpack[
+            "Refund.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Refund":
         """
         Cancels a refund with a status of requires_action.
@@ -284,7 +286,9 @@ class Refund(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Refund.CancelParams"]
+        **params: Unpack[
+            "Refund.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Refund":
         """
         Cancels a refund with a status of requires_action.
@@ -297,7 +301,9 @@ class Refund(
     def cancel(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Refund.CancelParams"]
+        **params: Unpack[
+            "Refund.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Refund":
         """
         Cancels a refund with a status of requires_action.
@@ -310,7 +316,9 @@ class Refund(
     def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Refund.CancelParams"]
+        **params: Unpack[
+            "Refund.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Refund":
         """
         Cancels a refund with a status of requires_action.
@@ -336,7 +344,9 @@ class Refund(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Refund.CreateParams"]
+        **params: Unpack[
+            "Refund.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Refund":
         """
         When you create a new refund, you must specify a Charge or a PaymentIntent object on which to create it.
@@ -370,7 +380,9 @@ class Refund(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Refund.ListParams"]
+        **params: Unpack[
+            "Refund.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Refund"]:
         """
         You can see a list of the refunds belonging to a specific charge. Note that the 10 most recent refunds are always available by default on the charge object. If you need more than those 10, you can use this API method and the limit and starting_after parameters to page through additional refunds.
@@ -428,7 +440,9 @@ class Refund(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Refund.ExpireParams"]
+            **params: Unpack[
+                "Refund.ExpireParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Refund":
             """
             Expire a refund with a status of requires_action.
@@ -454,7 +468,9 @@ class Refund(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Refund.ExpireParams"]
+            **params: Unpack[
+                "Refund.ExpireParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Refund":
             """
             Expire a refund with a status of requires_action.
@@ -465,7 +481,9 @@ class Refund(
         def expire(
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Refund.ExpireParams"]
+            **params: Unpack[
+                "Refund.ExpireParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Refund":
             """
             Expire a refund with a status of requires_action.
@@ -476,7 +494,9 @@ class Refund(
         def expire(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Refund.ExpireParams"]
+            **params: Unpack[
+                "Refund.ExpireParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Refund":
             """
             Expire a refund with a status of requires_action.

--- a/stripe/api_resources/reporting/report_run.py
+++ b/stripe/api_resources/reporting/report_run.py
@@ -220,7 +220,9 @@ class ReportRun(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["ReportRun.CreateParams"]
+        **params: Unpack[
+            "ReportRun.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "ReportRun":
         """
         Creates a new object and begin running the report. (Certain report types require a [live-mode API key](https://stripe.com/docs/keys#test-live-modes).)
@@ -244,7 +246,9 @@ class ReportRun(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["ReportRun.ListParams"]
+        **params: Unpack[
+            "ReportRun.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["ReportRun"]:
         """
         Returns a list of Report Runs, with the most recent appearing first.

--- a/stripe/api_resources/reporting/report_type.py
+++ b/stripe/api_resources/reporting/report_type.py
@@ -79,7 +79,9 @@ class ReportType(ListableAPIResource["ReportType"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["ReportType.ListParams"]
+        **params: Unpack[
+            "ReportType.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["ReportType"]:
         """
         Returns a full list of Report Types.

--- a/stripe/api_resources/review.py
+++ b/stripe/api_resources/review.py
@@ -190,7 +190,9 @@ class Review(ListableAPIResource["Review"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Review.ApproveParams"]
+        **params: Unpack[
+            "Review.ApproveParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Review":
         """
         Approves a Review object, closing it and removing it from the list of reviews.
@@ -216,7 +218,9 @@ class Review(ListableAPIResource["Review"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Review.ApproveParams"]
+        **params: Unpack[
+            "Review.ApproveParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Review":
         """
         Approves a Review object, closing it and removing it from the list of reviews.
@@ -227,7 +231,9 @@ class Review(ListableAPIResource["Review"]):
     def approve(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Review.ApproveParams"]
+        **params: Unpack[
+            "Review.ApproveParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Review":
         """
         Approves a Review object, closing it and removing it from the list of reviews.
@@ -238,7 +244,9 @@ class Review(ListableAPIResource["Review"]):
     def approve(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Review.ApproveParams"]
+        **params: Unpack[
+            "Review.ApproveParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Review":
         """
         Approves a Review object, closing it and removing it from the list of reviews.
@@ -261,7 +269,9 @@ class Review(ListableAPIResource["Review"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Review.ListParams"]
+        **params: Unpack[
+            "Review.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Review"]:
         """
         Returns a list of Review objects that have open set to true. The objects are sorted in descending order by creation date, with the most recently created object appearing first.

--- a/stripe/api_resources/search_result_object.py
+++ b/stripe/api_resources/search_result_object.py
@@ -120,5 +120,8 @@ class SearchResultObject(StripeObject, Generic[T]):
             stripe_account=stripe_account,
             **params_with_filters,
         )
+        # Sanity check that the object returned should be a SearchResultObject
         assert isinstance(result, SearchResultObject)
-        return result
+        # We still have to assert that the items *inside* the search result
+        # object are the types indicated by "Self"
+        return cast(Self, result)

--- a/stripe/api_resources/setup_attempt.py
+++ b/stripe/api_resources/setup_attempt.py
@@ -757,7 +757,9 @@ class SetupAttempt(ListableAPIResource["SetupAttempt"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["SetupAttempt.ListParams"]
+        **params: Unpack[
+            "SetupAttempt.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["SetupAttempt"]:
         """
         Returns a list of SetupAttempts that associate with a provided SetupIntent.

--- a/stripe/api_resources/setup_intent.py
+++ b/stripe/api_resources/setup_intent.py
@@ -3296,7 +3296,9 @@ class SetupIntent(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["SetupIntent.CancelParams"]
+        **params: Unpack[
+            "SetupIntent.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "SetupIntent":
         """
         You can cancel a SetupIntent object when it's in one of these statuses: requires_payment_method, requires_confirmation, or requires_action.
@@ -3324,7 +3326,9 @@ class SetupIntent(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["SetupIntent.CancelParams"]
+        **params: Unpack[
+            "SetupIntent.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "SetupIntent":
         """
         You can cancel a SetupIntent object when it's in one of these statuses: requires_payment_method, requires_confirmation, or requires_action.
@@ -3337,7 +3341,9 @@ class SetupIntent(
     def cancel(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["SetupIntent.CancelParams"]
+        **params: Unpack[
+            "SetupIntent.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "SetupIntent":
         """
         You can cancel a SetupIntent object when it's in one of these statuses: requires_payment_method, requires_confirmation, or requires_action.
@@ -3350,7 +3356,9 @@ class SetupIntent(
     def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["SetupIntent.CancelParams"]
+        **params: Unpack[
+            "SetupIntent.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "SetupIntent":
         """
         You can cancel a SetupIntent object when it's in one of these statuses: requires_payment_method, requires_confirmation, or requires_action.
@@ -3376,7 +3384,9 @@ class SetupIntent(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["SetupIntent.ConfirmParams"]
+        **params: Unpack[
+            "SetupIntent.ConfirmParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "SetupIntent":
         """
         Confirm that your customer intends to set up the current or
@@ -3415,7 +3425,9 @@ class SetupIntent(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["SetupIntent.ConfirmParams"]
+        **params: Unpack[
+            "SetupIntent.ConfirmParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "SetupIntent":
         """
         Confirm that your customer intends to set up the current or
@@ -3439,7 +3451,9 @@ class SetupIntent(
     def confirm(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["SetupIntent.ConfirmParams"]
+        **params: Unpack[
+            "SetupIntent.ConfirmParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "SetupIntent":
         """
         Confirm that your customer intends to set up the current or
@@ -3463,7 +3477,9 @@ class SetupIntent(
     def confirm(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["SetupIntent.ConfirmParams"]
+        **params: Unpack[
+            "SetupIntent.ConfirmParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "SetupIntent":
         """
         Confirm that your customer intends to set up the current or
@@ -3500,7 +3516,9 @@ class SetupIntent(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["SetupIntent.CreateParams"]
+        **params: Unpack[
+            "SetupIntent.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "SetupIntent":
         """
         Creates a SetupIntent object.
@@ -3527,7 +3545,9 @@ class SetupIntent(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["SetupIntent.ListParams"]
+        **params: Unpack[
+            "SetupIntent.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["SetupIntent"]:
         """
         Returns a list of SetupIntents.
@@ -3584,7 +3604,9 @@ class SetupIntent(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["SetupIntent.VerifyMicrodepositsParams"]
+        **params: Unpack[
+            "SetupIntent.VerifyMicrodepositsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "SetupIntent":
         """
         Verifies microdeposits on a SetupIntent object.
@@ -3610,7 +3632,9 @@ class SetupIntent(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["SetupIntent.VerifyMicrodepositsParams"]
+        **params: Unpack[
+            "SetupIntent.VerifyMicrodepositsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "SetupIntent":
         """
         Verifies microdeposits on a SetupIntent object.
@@ -3621,7 +3645,9 @@ class SetupIntent(
     def verify_microdeposits(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["SetupIntent.VerifyMicrodepositsParams"]
+        **params: Unpack[
+            "SetupIntent.VerifyMicrodepositsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "SetupIntent":
         """
         Verifies microdeposits on a SetupIntent object.
@@ -3632,7 +3658,9 @@ class SetupIntent(
     def verify_microdeposits(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["SetupIntent.VerifyMicrodepositsParams"]
+        **params: Unpack[
+            "SetupIntent.VerifyMicrodepositsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "SetupIntent":
         """
         Verifies microdeposits on a SetupIntent object.

--- a/stripe/api_resources/shipping_rate.py
+++ b/stripe/api_resources/shipping_rate.py
@@ -345,7 +345,9 @@ class ShippingRate(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["ShippingRate.CreateParams"]
+        **params: Unpack[
+            "ShippingRate.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "ShippingRate":
         """
         Creates a new shipping rate object.
@@ -369,7 +371,9 @@ class ShippingRate(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["ShippingRate.ListParams"]
+        **params: Unpack[
+            "ShippingRate.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["ShippingRate"]:
         """
         Returns a list of your shipping rates.

--- a/stripe/api_resources/sigma/scheduled_query_run.py
+++ b/stripe/api_resources/sigma/scheduled_query_run.py
@@ -103,7 +103,9 @@ class ScheduledQueryRun(ListableAPIResource["ScheduledQueryRun"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["ScheduledQueryRun.ListParams"]
+        **params: Unpack[
+            "ScheduledQueryRun.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["ScheduledQueryRun"]:
         """
         Returns a list of scheduled query runs.

--- a/stripe/api_resources/source.py
+++ b/stripe/api_resources/source.py
@@ -1125,7 +1125,9 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Source.CreateParams"]
+        **params: Unpack[
+            "Source.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Source":
         """
         Creates a new source object.
@@ -1150,7 +1152,9 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Source.ListSourceTransactionsParams"]
+        **params: Unpack[
+            "Source.ListSourceTransactionsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["SourceTransaction"]:
         """
         List source transactions for a given source.
@@ -1176,7 +1180,9 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Source.ListSourceTransactionsParams"]
+        **params: Unpack[
+            "Source.ListSourceTransactionsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["SourceTransaction"]:
         """
         List source transactions for a given source.
@@ -1187,7 +1193,9 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
     def list_source_transactions(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Source.ListSourceTransactionsParams"]
+        **params: Unpack[
+            "Source.ListSourceTransactionsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["SourceTransaction"]:
         """
         List source transactions for a given source.
@@ -1198,7 +1206,9 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
     def list_source_transactions(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Source.ListSourceTransactionsParams"]
+        **params: Unpack[
+            "Source.ListSourceTransactionsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["SourceTransaction"]:
         """
         List source transactions for a given source.
@@ -1248,7 +1258,9 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Source.VerifyParams"]
+        **params: Unpack[
+            "Source.VerifyParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Source":
         """
         Verify a given source.
@@ -1274,7 +1286,9 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Source.VerifyParams"]
+        **params: Unpack[
+            "Source.VerifyParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Source":
         """
         Verify a given source.
@@ -1285,7 +1299,9 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
     def verify(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Source.VerifyParams"]
+        **params: Unpack[
+            "Source.VerifyParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Source":
         """
         Verify a given source.
@@ -1296,7 +1312,9 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
     def verify(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Source.VerifyParams"]
+        **params: Unpack[
+            "Source.VerifyParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Source":
         """
         Verify a given source.

--- a/stripe/api_resources/subscription.py
+++ b/stripe/api_resources/subscription.py
@@ -1842,7 +1842,9 @@ class Subscription(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Subscription.CancelParams"]
+        **params: Unpack[
+            "Subscription.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Subscription":
         """
         Cancels a customer's subscription immediately. The customer will not be charged again for the subscription.
@@ -1874,7 +1876,9 @@ class Subscription(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Subscription.CancelParams"]
+        **params: Unpack[
+            "Subscription.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Subscription":
         """
         Cancels a customer's subscription immediately. The customer will not be charged again for the subscription.
@@ -1889,7 +1893,9 @@ class Subscription(
     def cancel(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Subscription.CancelParams"]
+        **params: Unpack[
+            "Subscription.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Subscription":
         """
         Cancels a customer's subscription immediately. The customer will not be charged again for the subscription.
@@ -1904,7 +1910,9 @@ class Subscription(
     def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Subscription.CancelParams"]
+        **params: Unpack[
+            "Subscription.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Subscription":
         """
         Cancels a customer's subscription immediately. The customer will not be charged again for the subscription.
@@ -1932,7 +1940,9 @@ class Subscription(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Subscription.CreateParams"]
+        **params: Unpack[
+            "Subscription.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Subscription":
         """
         Creates a new subscription on an existing customer. Each customer can have up to 500 active or scheduled subscriptions.
@@ -1963,7 +1973,9 @@ class Subscription(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Subscription.DeleteDiscountParams"]
+        **params: Unpack[
+            "Subscription.DeleteDiscountParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Discount":
         """
         Removes the currently applied discount on a subscription.
@@ -1991,7 +2003,9 @@ class Subscription(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Subscription.DeleteDiscountParams"]
+        **params: Unpack[
+            "Subscription.DeleteDiscountParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Discount":
         """
         Removes the currently applied discount on a subscription.
@@ -2002,7 +2016,9 @@ class Subscription(
     def delete_discount(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Subscription.DeleteDiscountParams"]
+        **params: Unpack[
+            "Subscription.DeleteDiscountParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Discount":
         """
         Removes the currently applied discount on a subscription.
@@ -2013,7 +2029,9 @@ class Subscription(
     def delete_discount(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Subscription.DeleteDiscountParams"]
+        **params: Unpack[
+            "Subscription.DeleteDiscountParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Discount":
         """
         Removes the currently applied discount on a subscription.
@@ -2036,7 +2054,9 @@ class Subscription(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Subscription.ListParams"]
+        **params: Unpack[
+            "Subscription.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Subscription"]:
         """
         By default, returns a list of subscriptions that have not been canceled. In order to list canceled subscriptions, specify status=canceled.
@@ -2098,7 +2118,9 @@ class Subscription(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Subscription.ResumeParams"]
+        **params: Unpack[
+            "Subscription.ResumeParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Subscription":
         """
         Initiates resumption of a paused subscription, optionally resetting the billing cycle anchor and creating prorations. If a resumption invoice is generated, it must be paid or marked uncollectible before the subscription will be unpaused. If payment succeeds the subscription will become active, and if payment fails the subscription will be past_due. The resumption invoice will void automatically if not paid by the expiration date.
@@ -2124,7 +2146,9 @@ class Subscription(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Subscription.ResumeParams"]
+        **params: Unpack[
+            "Subscription.ResumeParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Subscription":
         """
         Initiates resumption of a paused subscription, optionally resetting the billing cycle anchor and creating prorations. If a resumption invoice is generated, it must be paid or marked uncollectible before the subscription will be unpaused. If payment succeeds the subscription will become active, and if payment fails the subscription will be past_due. The resumption invoice will void automatically if not paid by the expiration date.
@@ -2135,7 +2159,9 @@ class Subscription(
     def resume(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Subscription.ResumeParams"]
+        **params: Unpack[
+            "Subscription.ResumeParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Subscription":
         """
         Initiates resumption of a paused subscription, optionally resetting the billing cycle anchor and creating prorations. If a resumption invoice is generated, it must be paid or marked uncollectible before the subscription will be unpaused. If payment succeeds the subscription will become active, and if payment fails the subscription will be past_due. The resumption invoice will void automatically if not paid by the expiration date.
@@ -2146,7 +2172,9 @@ class Subscription(
     def resume(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Subscription.ResumeParams"]
+        **params: Unpack[
+            "Subscription.ResumeParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Subscription":
         """
         Initiates resumption of a paused subscription, optionally resetting the billing cycle anchor and creating prorations. If a resumption invoice is generated, it must be paid or marked uncollectible before the subscription will be unpaused. If payment succeeds the subscription will become active, and if payment fails the subscription will be past_due. The resumption invoice will void automatically if not paid by the expiration date.

--- a/stripe/api_resources/subscription_item.py
+++ b/stripe/api_resources/subscription_item.py
@@ -409,7 +409,9 @@ class SubscriptionItem(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["SubscriptionItem.CreateParams"]
+        **params: Unpack[
+            "SubscriptionItem.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "SubscriptionItem":
         """
         Adds a new item to an existing subscription. No existing items will be changed or replaced.
@@ -478,7 +480,9 @@ class SubscriptionItem(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["SubscriptionItem.ListParams"]
+        **params: Unpack[
+            "SubscriptionItem.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["SubscriptionItem"]:
         """
         Returns a list of your subscription items for a given subscription.
@@ -531,7 +535,9 @@ class SubscriptionItem(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["SubscriptionItem.CreateUsageRecordParams"]
+        **params: Unpack[
+            "SubscriptionItem.CreateUsageRecordParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "UsageRecord":
         """
         Creates a usage record for a specified subscription item and date, and fills it with a quantity.
@@ -563,7 +569,9 @@ class SubscriptionItem(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["SubscriptionItem.ListUsageRecordSummariesParams"]
+        **params: Unpack[
+            "SubscriptionItem.ListUsageRecordSummariesParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["UsageRecordSummary"]:
         """
         For the specified subscription item, returns a list of summary objects. Each object in the list provides usage information that's been summarized from multiple usage records and over a subscription billing period (e.g., 15 usage records in the month of September).

--- a/stripe/api_resources/subscription_schedule.py
+++ b/stripe/api_resources/subscription_schedule.py
@@ -1297,7 +1297,9 @@ class SubscriptionSchedule(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["SubscriptionSchedule.CancelParams"]
+        **params: Unpack[
+            "SubscriptionSchedule.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "SubscriptionSchedule":
         """
         Cancels a subscription schedule and its associated subscription immediately (if the subscription schedule has an active subscription). A subscription schedule can only be canceled if its status is not_started or active.
@@ -1323,7 +1325,9 @@ class SubscriptionSchedule(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["SubscriptionSchedule.CancelParams"]
+        **params: Unpack[
+            "SubscriptionSchedule.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "SubscriptionSchedule":
         """
         Cancels a subscription schedule and its associated subscription immediately (if the subscription schedule has an active subscription). A subscription schedule can only be canceled if its status is not_started or active.
@@ -1334,7 +1338,9 @@ class SubscriptionSchedule(
     def cancel(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["SubscriptionSchedule.CancelParams"]
+        **params: Unpack[
+            "SubscriptionSchedule.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "SubscriptionSchedule":
         """
         Cancels a subscription schedule and its associated subscription immediately (if the subscription schedule has an active subscription). A subscription schedule can only be canceled if its status is not_started or active.
@@ -1345,7 +1351,9 @@ class SubscriptionSchedule(
     def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["SubscriptionSchedule.CancelParams"]
+        **params: Unpack[
+            "SubscriptionSchedule.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "SubscriptionSchedule":
         """
         Cancels a subscription schedule and its associated subscription immediately (if the subscription schedule has an active subscription). A subscription schedule can only be canceled if its status is not_started or active.
@@ -1369,7 +1377,9 @@ class SubscriptionSchedule(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["SubscriptionSchedule.CreateParams"]
+        **params: Unpack[
+            "SubscriptionSchedule.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "SubscriptionSchedule":
         """
         Creates a new subscription schedule object. Each customer can have up to 500 active or scheduled subscriptions.
@@ -1393,7 +1403,9 @@ class SubscriptionSchedule(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["SubscriptionSchedule.ListParams"]
+        **params: Unpack[
+            "SubscriptionSchedule.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["SubscriptionSchedule"]:
         """
         Retrieves the list of your subscription schedules.
@@ -1435,7 +1447,9 @@ class SubscriptionSchedule(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["SubscriptionSchedule.ReleaseParams"]
+        **params: Unpack[
+            "SubscriptionSchedule.ReleaseParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "SubscriptionSchedule":
         """
         Releases the subscription schedule immediately, which will stop scheduling of its phases, but leave any existing subscription in place. A schedule can only be released if its status is not_started or active. If the subscription schedule is currently associated with a subscription, releasing it will remove its subscription property and set the subscription's ID to the released_subscription property.
@@ -1461,7 +1475,9 @@ class SubscriptionSchedule(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["SubscriptionSchedule.ReleaseParams"]
+        **params: Unpack[
+            "SubscriptionSchedule.ReleaseParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "SubscriptionSchedule":
         """
         Releases the subscription schedule immediately, which will stop scheduling of its phases, but leave any existing subscription in place. A schedule can only be released if its status is not_started or active. If the subscription schedule is currently associated with a subscription, releasing it will remove its subscription property and set the subscription's ID to the released_subscription property.
@@ -1472,7 +1488,9 @@ class SubscriptionSchedule(
     def release(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["SubscriptionSchedule.ReleaseParams"]
+        **params: Unpack[
+            "SubscriptionSchedule.ReleaseParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "SubscriptionSchedule":
         """
         Releases the subscription schedule immediately, which will stop scheduling of its phases, but leave any existing subscription in place. A schedule can only be released if its status is not_started or active. If the subscription schedule is currently associated with a subscription, releasing it will remove its subscription property and set the subscription's ID to the released_subscription property.
@@ -1483,7 +1501,9 @@ class SubscriptionSchedule(
     def release(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["SubscriptionSchedule.ReleaseParams"]
+        **params: Unpack[
+            "SubscriptionSchedule.ReleaseParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "SubscriptionSchedule":
         """
         Releases the subscription schedule immediately, which will stop scheduling of its phases, but leave any existing subscription in place. A schedule can only be released if its status is not_started or active. If the subscription schedule is currently associated with a subscription, releasing it will remove its subscription property and set the subscription's ID to the released_subscription property.

--- a/stripe/api_resources/tax/calculation.py
+++ b/stripe/api_resources/tax/calculation.py
@@ -633,7 +633,9 @@ class Calculation(CreateableAPIResource["Calculation"]):
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Calculation.CreateParams"]
+        **params: Unpack[
+            "Calculation.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Calculation":
         """
         Calculates tax based on input and returns a Tax Calculation object.
@@ -658,7 +660,9 @@ class Calculation(CreateableAPIResource["Calculation"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Calculation.ListLineItemsParams"]
+        **params: Unpack[
+            "Calculation.ListLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["CalculationLineItem"]:
         """
         Retrieves the line items of a persisted tax calculation as a collection.
@@ -684,7 +688,9 @@ class Calculation(CreateableAPIResource["Calculation"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Calculation.ListLineItemsParams"]
+        **params: Unpack[
+            "Calculation.ListLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["CalculationLineItem"]:
         """
         Retrieves the line items of a persisted tax calculation as a collection.
@@ -695,7 +701,9 @@ class Calculation(CreateableAPIResource["Calculation"]):
     def list_line_items(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Calculation.ListLineItemsParams"]
+        **params: Unpack[
+            "Calculation.ListLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["CalculationLineItem"]:
         """
         Retrieves the line items of a persisted tax calculation as a collection.
@@ -706,7 +714,9 @@ class Calculation(CreateableAPIResource["Calculation"]):
     def list_line_items(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Calculation.ListLineItemsParams"]
+        **params: Unpack[
+            "Calculation.ListLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["CalculationLineItem"]:
         """
         Retrieves the line items of a persisted tax calculation as a collection.

--- a/stripe/api_resources/tax/registration.py
+++ b/stripe/api_resources/tax/registration.py
@@ -1642,7 +1642,9 @@ class Registration(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Registration.CreateParams"]
+        **params: Unpack[
+            "Registration.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Registration":
         """
         Creates a new Tax Registration object.
@@ -1666,7 +1668,9 @@ class Registration(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Registration.ListParams"]
+        **params: Unpack[
+            "Registration.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Registration"]:
         """
         Returns a list of Tax Registration objects.

--- a/stripe/api_resources/tax/transaction.py
+++ b/stripe/api_resources/tax/transaction.py
@@ -460,7 +460,9 @@ class Transaction(APIResource["Transaction"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Transaction.CreateFromCalculationParams"]
+        **params: Unpack[
+            "Transaction.CreateFromCalculationParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Transaction":
         """
         Creates a Tax Transaction from a calculation.
@@ -483,7 +485,9 @@ class Transaction(APIResource["Transaction"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Transaction.CreateReversalParams"]
+        **params: Unpack[
+            "Transaction.CreateReversalParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Transaction":
         """
         Partially or fully reverses a previously created Transaction.
@@ -507,7 +511,9 @@ class Transaction(APIResource["Transaction"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Transaction.ListLineItemsParams"]
+        **params: Unpack[
+            "Transaction.ListLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["TransactionLineItem"]:
         """
         Retrieves the line items of a committed standalone transaction as a collection.
@@ -533,7 +539,9 @@ class Transaction(APIResource["Transaction"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Transaction.ListLineItemsParams"]
+        **params: Unpack[
+            "Transaction.ListLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["TransactionLineItem"]:
         """
         Retrieves the line items of a committed standalone transaction as a collection.
@@ -544,7 +552,9 @@ class Transaction(APIResource["Transaction"]):
     def list_line_items(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Transaction.ListLineItemsParams"]
+        **params: Unpack[
+            "Transaction.ListLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["TransactionLineItem"]:
         """
         Retrieves the line items of a committed standalone transaction as a collection.
@@ -555,7 +565,9 @@ class Transaction(APIResource["Transaction"]):
     def list_line_items(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Transaction.ListLineItemsParams"]
+        **params: Unpack[
+            "Transaction.ListLineItemsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["TransactionLineItem"]:
         """
         Retrieves the line items of a committed standalone transaction as a collection.

--- a/stripe/api_resources/tax_code.py
+++ b/stripe/api_resources/tax_code.py
@@ -62,7 +62,9 @@ class TaxCode(ListableAPIResource["TaxCode"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["TaxCode.ListParams"]
+        **params: Unpack[
+            "TaxCode.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["TaxCode"]:
         """
         A list of [all tax codes available](https://stripe.com/docs/tax/tax-categories) to add to Products in order to allow specific tax calculations.

--- a/stripe/api_resources/tax_rate.py
+++ b/stripe/api_resources/tax_rate.py
@@ -260,7 +260,9 @@ class TaxRate(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["TaxRate.CreateParams"]
+        **params: Unpack[
+            "TaxRate.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "TaxRate":
         """
         Creates a new tax rate.
@@ -284,7 +286,9 @@ class TaxRate(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["TaxRate.ListParams"]
+        **params: Unpack[
+            "TaxRate.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["TaxRate"]:
         """
         Returns a list of your tax rates. Tax rates are returned sorted by creation date, with the most recently created tax rates appearing first.

--- a/stripe/api_resources/terminal/configuration.py
+++ b/stripe/api_resources/terminal/configuration.py
@@ -954,7 +954,9 @@ class Configuration(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Configuration.CreateParams"]
+        **params: Unpack[
+            "Configuration.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Configuration":
         """
         Creates a new Configuration object.
@@ -1023,7 +1025,9 @@ class Configuration(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Configuration.ListParams"]
+        **params: Unpack[
+            "Configuration.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Configuration"]:
         """
         Returns a list of Configuration objects.

--- a/stripe/api_resources/terminal/connection_token.py
+++ b/stripe/api_resources/terminal/connection_token.py
@@ -48,7 +48,9 @@ class ConnectionToken(CreateableAPIResource["ConnectionToken"]):
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["ConnectionToken.CreateParams"]
+        **params: Unpack[
+            "ConnectionToken.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "ConnectionToken":
         """
         To connect to a reader the Stripe Terminal SDK needs to retrieve a short-lived connection token from Stripe, proxied through your server. On your backend, add an endpoint that creates and returns a connection token.

--- a/stripe/api_resources/terminal/location.py
+++ b/stripe/api_resources/terminal/location.py
@@ -223,7 +223,9 @@ class Location(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Location.CreateParams"]
+        **params: Unpack[
+            "Location.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Location":
         """
         Creates a new Location object.
@@ -291,7 +293,9 @@ class Location(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Location.ListParams"]
+        **params: Unpack[
+            "Location.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Location"]:
         """
         Returns a list of Location objects.

--- a/stripe/api_resources/terminal/reader.py
+++ b/stripe/api_resources/terminal/reader.py
@@ -544,7 +544,9 @@ class Reader(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Reader.CancelActionParams"]
+        **params: Unpack[
+            "Reader.CancelActionParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reader":
         """
         Cancels the current reader action.
@@ -570,7 +572,9 @@ class Reader(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Reader.CancelActionParams"]
+        **params: Unpack[
+            "Reader.CancelActionParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reader":
         """
         Cancels the current reader action.
@@ -581,7 +585,9 @@ class Reader(
     def cancel_action(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Reader.CancelActionParams"]
+        **params: Unpack[
+            "Reader.CancelActionParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reader":
         """
         Cancels the current reader action.
@@ -592,7 +598,9 @@ class Reader(
     def cancel_action(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Reader.CancelActionParams"]
+        **params: Unpack[
+            "Reader.CancelActionParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reader":
         """
         Cancels the current reader action.
@@ -616,7 +624,9 @@ class Reader(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Reader.CreateParams"]
+        **params: Unpack[
+            "Reader.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reader":
         """
         Creates a new Reader object.
@@ -681,7 +691,9 @@ class Reader(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Reader.ListParams"]
+        **params: Unpack[
+            "Reader.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Reader"]:
         """
         Returns a list of Reader objects.
@@ -723,7 +735,9 @@ class Reader(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Reader.ProcessPaymentIntentParams"]
+        **params: Unpack[
+            "Reader.ProcessPaymentIntentParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reader":
         """
         Initiates a payment flow on a Reader.
@@ -749,7 +763,9 @@ class Reader(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Reader.ProcessPaymentIntentParams"]
+        **params: Unpack[
+            "Reader.ProcessPaymentIntentParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reader":
         """
         Initiates a payment flow on a Reader.
@@ -760,7 +776,9 @@ class Reader(
     def process_payment_intent(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Reader.ProcessPaymentIntentParams"]
+        **params: Unpack[
+            "Reader.ProcessPaymentIntentParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reader":
         """
         Initiates a payment flow on a Reader.
@@ -771,7 +789,9 @@ class Reader(
     def process_payment_intent(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Reader.ProcessPaymentIntentParams"]
+        **params: Unpack[
+            "Reader.ProcessPaymentIntentParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reader":
         """
         Initiates a payment flow on a Reader.
@@ -795,7 +815,9 @@ class Reader(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Reader.ProcessSetupIntentParams"]
+        **params: Unpack[
+            "Reader.ProcessSetupIntentParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reader":
         """
         Initiates a setup intent flow on a Reader.
@@ -821,7 +843,9 @@ class Reader(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Reader.ProcessSetupIntentParams"]
+        **params: Unpack[
+            "Reader.ProcessSetupIntentParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reader":
         """
         Initiates a setup intent flow on a Reader.
@@ -832,7 +856,9 @@ class Reader(
     def process_setup_intent(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Reader.ProcessSetupIntentParams"]
+        **params: Unpack[
+            "Reader.ProcessSetupIntentParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reader":
         """
         Initiates a setup intent flow on a Reader.
@@ -843,7 +869,9 @@ class Reader(
     def process_setup_intent(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Reader.ProcessSetupIntentParams"]
+        **params: Unpack[
+            "Reader.ProcessSetupIntentParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reader":
         """
         Initiates a setup intent flow on a Reader.
@@ -867,7 +895,9 @@ class Reader(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Reader.RefundPaymentParams"]
+        **params: Unpack[
+            "Reader.RefundPaymentParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reader":
         """
         Initiates a refund on a Reader
@@ -893,7 +923,9 @@ class Reader(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Reader.RefundPaymentParams"]
+        **params: Unpack[
+            "Reader.RefundPaymentParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reader":
         """
         Initiates a refund on a Reader
@@ -904,7 +936,9 @@ class Reader(
     def refund_payment(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Reader.RefundPaymentParams"]
+        **params: Unpack[
+            "Reader.RefundPaymentParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reader":
         """
         Initiates a refund on a Reader
@@ -915,7 +949,9 @@ class Reader(
     def refund_payment(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Reader.RefundPaymentParams"]
+        **params: Unpack[
+            "Reader.RefundPaymentParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reader":
         """
         Initiates a refund on a Reader
@@ -950,7 +986,9 @@ class Reader(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Reader.SetReaderDisplayParams"]
+        **params: Unpack[
+            "Reader.SetReaderDisplayParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reader":
         """
         Sets reader display to show cart details.
@@ -976,7 +1014,9 @@ class Reader(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Reader.SetReaderDisplayParams"]
+        **params: Unpack[
+            "Reader.SetReaderDisplayParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reader":
         """
         Sets reader display to show cart details.
@@ -987,7 +1027,9 @@ class Reader(
     def set_reader_display(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Reader.SetReaderDisplayParams"]
+        **params: Unpack[
+            "Reader.SetReaderDisplayParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reader":
         """
         Sets reader display to show cart details.
@@ -998,7 +1040,9 @@ class Reader(
     def set_reader_display(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Reader.SetReaderDisplayParams"]
+        **params: Unpack[
+            "Reader.SetReaderDisplayParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reader":
         """
         Sets reader display to show cart details.
@@ -1025,7 +1069,9 @@ class Reader(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Reader.PresentPaymentMethodParams"]
+            **params: Unpack[
+                "Reader.PresentPaymentMethodParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Reader":
             """
             Presents a payment method on a simulated reader. Can be used to simulate accepting a payment, saving a card or refunding a transaction.
@@ -1051,7 +1097,9 @@ class Reader(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["Reader.PresentPaymentMethodParams"]
+            **params: Unpack[
+                "Reader.PresentPaymentMethodParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Reader":
             """
             Presents a payment method on a simulated reader. Can be used to simulate accepting a payment, saving a card or refunding a transaction.
@@ -1062,7 +1110,9 @@ class Reader(
         def present_payment_method(
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Reader.PresentPaymentMethodParams"]
+            **params: Unpack[
+                "Reader.PresentPaymentMethodParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Reader":
             """
             Presents a payment method on a simulated reader. Can be used to simulate accepting a payment, saving a card or refunding a transaction.
@@ -1073,7 +1123,9 @@ class Reader(
         def present_payment_method(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["Reader.PresentPaymentMethodParams"]
+            **params: Unpack[
+                "Reader.PresentPaymentMethodParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "Reader":
             """
             Presents a payment method on a simulated reader. Can be used to simulate accepting a payment, saving a card or refunding a transaction.

--- a/stripe/api_resources/test_helpers/test_clock.py
+++ b/stripe/api_resources/test_helpers/test_clock.py
@@ -125,7 +125,9 @@ class TestClock(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["TestClock.AdvanceParams"]
+        **params: Unpack[
+            "TestClock.AdvanceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "TestClock":
         """
         Starts advancing a test clock to a specified time in the future. Advancement is done when status changes to Ready.
@@ -151,7 +153,9 @@ class TestClock(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["TestClock.AdvanceParams"]
+        **params: Unpack[
+            "TestClock.AdvanceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "TestClock":
         """
         Starts advancing a test clock to a specified time in the future. Advancement is done when status changes to Ready.
@@ -162,7 +166,9 @@ class TestClock(
     def advance(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["TestClock.AdvanceParams"]
+        **params: Unpack[
+            "TestClock.AdvanceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "TestClock":
         """
         Starts advancing a test clock to a specified time in the future. Advancement is done when status changes to Ready.
@@ -173,7 +179,9 @@ class TestClock(
     def advance(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["TestClock.AdvanceParams"]
+        **params: Unpack[
+            "TestClock.AdvanceParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "TestClock":
         """
         Starts advancing a test clock to a specified time in the future. Advancement is done when status changes to Ready.
@@ -197,7 +205,9 @@ class TestClock(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["TestClock.CreateParams"]
+        **params: Unpack[
+            "TestClock.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "TestClock":
         """
         Creates a new test clock that can be attached to new customers and quotes.
@@ -266,7 +276,9 @@ class TestClock(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["TestClock.ListParams"]
+        **params: Unpack[
+            "TestClock.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["TestClock"]:
         """
         Returns a list of your test clocks.

--- a/stripe/api_resources/token.py
+++ b/stripe/api_resources/token.py
@@ -1081,7 +1081,9 @@ class Token(CreateableAPIResource["Token"]):
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Token.CreateParams"]
+        **params: Unpack[
+            "Token.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Token":
         """
         Creates a single-use token that represents a bank account's details.

--- a/stripe/api_resources/topup.py
+++ b/stripe/api_resources/topup.py
@@ -241,7 +241,9 @@ class Topup(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Topup.CancelParams"]
+        **params: Unpack[
+            "Topup.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Topup":
         """
         Cancels a top-up. Only pending top-ups can be canceled.
@@ -267,7 +269,9 @@ class Topup(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Topup.CancelParams"]
+        **params: Unpack[
+            "Topup.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Topup":
         """
         Cancels a top-up. Only pending top-ups can be canceled.
@@ -278,7 +282,9 @@ class Topup(
     def cancel(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Topup.CancelParams"]
+        **params: Unpack[
+            "Topup.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Topup":
         """
         Cancels a top-up. Only pending top-ups can be canceled.
@@ -289,7 +295,9 @@ class Topup(
     def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["Topup.CancelParams"]
+        **params: Unpack[
+            "Topup.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Topup":
         """
         Cancels a top-up. Only pending top-ups can be canceled.
@@ -313,7 +321,9 @@ class Topup(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Topup.CreateParams"]
+        **params: Unpack[
+            "Topup.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Topup":
         """
         Top up the balance of an account
@@ -337,7 +347,9 @@ class Topup(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Topup.ListParams"]
+        **params: Unpack[
+            "Topup.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Topup"]:
         """
         Returns a list of top-ups.

--- a/stripe/api_resources/transfer.py
+++ b/stripe/api_resources/transfer.py
@@ -284,7 +284,9 @@ class Transfer(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Transfer.CreateParams"]
+        **params: Unpack[
+            "Transfer.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Transfer":
         """
         To send funds from your Stripe account to a connected account, you create a new transfer object. Your [Stripe balance](https://stripe.com/docs/api#balance) must be able to cover the transfer amount, or you'll receive an “Insufficient Funds” error.
@@ -308,7 +310,9 @@ class Transfer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Transfer.ListParams"]
+        **params: Unpack[
+            "Transfer.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Transfer"]:
         """
         Returns a list of existing transfers sent to connected accounts. The transfers are returned in sorted order, with the most recently created transfers appearing first.
@@ -363,7 +367,9 @@ class Transfer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Transfer.CreateReversalParams"]
+        **params: Unpack[
+            "Transfer.CreateReversalParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reversal":
         """
         When you create a new reversal, you must specify a transfer to create it on.
@@ -392,7 +398,9 @@ class Transfer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Transfer.RetrieveReversalParams"]
+        **params: Unpack[
+            "Transfer.RetrieveReversalParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reversal":
         """
         By default, you can see the 10 most recent reversals stored directly on the transfer object, but you can also retrieve details about a specific reversal stored on the transfer.
@@ -420,7 +428,9 @@ class Transfer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Transfer.ModifyReversalParams"]
+        **params: Unpack[
+            "Transfer.ModifyReversalParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "Reversal":
         """
         Updates the specified reversal by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
@@ -449,7 +459,9 @@ class Transfer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Transfer.ListReversalsParams"]
+        **params: Unpack[
+            "Transfer.ListReversalsParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Reversal"]:
         """
         You can see a list of the reversals belonging to a specific transfer. Note that the 10 most recent reversals are always available by default on the transfer object. If you need more than those 10, you can use this API method and the limit and starting_after parameters to page through additional reversals.

--- a/stripe/api_resources/treasury/credit_reversal.py
+++ b/stripe/api_resources/treasury/credit_reversal.py
@@ -146,7 +146,9 @@ class CreditReversal(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["CreditReversal.CreateParams"]
+        **params: Unpack[
+            "CreditReversal.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "CreditReversal":
         """
         Reverses a ReceivedCredit and creates a CreditReversal object.
@@ -170,7 +172,9 @@ class CreditReversal(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["CreditReversal.ListParams"]
+        **params: Unpack[
+            "CreditReversal.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["CreditReversal"]:
         """
         Returns a list of CreditReversals.

--- a/stripe/api_resources/treasury/debit_reversal.py
+++ b/stripe/api_resources/treasury/debit_reversal.py
@@ -162,7 +162,9 @@ class DebitReversal(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["DebitReversal.CreateParams"]
+        **params: Unpack[
+            "DebitReversal.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "DebitReversal":
         """
         Reverses a ReceivedDebit and creates a DebitReversal object.
@@ -186,7 +188,9 @@ class DebitReversal(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["DebitReversal.ListParams"]
+        **params: Unpack[
+            "DebitReversal.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["DebitReversal"]:
         """
         Returns a list of DebitReversals.

--- a/stripe/api_resources/treasury/financial_account.py
+++ b/stripe/api_resources/treasury/financial_account.py
@@ -780,7 +780,9 @@ class FinancialAccount(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["FinancialAccount.CreateParams"]
+        **params: Unpack[
+            "FinancialAccount.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "FinancialAccount":
         """
         Creates a new FinancialAccount. For now, each connected account can only have one FinancialAccount.
@@ -804,7 +806,9 @@ class FinancialAccount(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["FinancialAccount.ListParams"]
+        **params: Unpack[
+            "FinancialAccount.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["FinancialAccount"]:
         """
         Returns a list of FinancialAccounts.
@@ -857,7 +861,9 @@ class FinancialAccount(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["FinancialAccount.RetrieveFeaturesParams"]
+        **params: Unpack[
+            "FinancialAccount.RetrieveFeaturesParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "FinancialAccountFeatures":
         """
         Retrieves Features information associated with the FinancialAccount.
@@ -883,7 +889,9 @@ class FinancialAccount(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["FinancialAccount.RetrieveFeaturesParams"]
+        **params: Unpack[
+            "FinancialAccount.RetrieveFeaturesParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "FinancialAccountFeatures":
         """
         Retrieves Features information associated with the FinancialAccount.
@@ -894,7 +902,9 @@ class FinancialAccount(
     def retrieve_features(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["FinancialAccount.RetrieveFeaturesParams"]
+        **params: Unpack[
+            "FinancialAccount.RetrieveFeaturesParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "FinancialAccountFeatures":
         """
         Retrieves Features information associated with the FinancialAccount.
@@ -905,7 +915,9 @@ class FinancialAccount(
     def retrieve_features(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["FinancialAccount.RetrieveFeaturesParams"]
+        **params: Unpack[
+            "FinancialAccount.RetrieveFeaturesParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "FinancialAccountFeatures":
         """
         Retrieves Features information associated with the FinancialAccount.
@@ -929,7 +941,9 @@ class FinancialAccount(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["FinancialAccount.UpdateFeaturesParams"]
+        **params: Unpack[
+            "FinancialAccount.UpdateFeaturesParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "FinancialAccountFeatures":
         """
         Updates the Features associated with a FinancialAccount.
@@ -955,7 +969,9 @@ class FinancialAccount(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["FinancialAccount.UpdateFeaturesParams"]
+        **params: Unpack[
+            "FinancialAccount.UpdateFeaturesParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "FinancialAccountFeatures":
         """
         Updates the Features associated with a FinancialAccount.
@@ -966,7 +982,9 @@ class FinancialAccount(
     def update_features(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["FinancialAccount.UpdateFeaturesParams"]
+        **params: Unpack[
+            "FinancialAccount.UpdateFeaturesParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "FinancialAccountFeatures":
         """
         Updates the Features associated with a FinancialAccount.
@@ -977,7 +995,9 @@ class FinancialAccount(
     def update_features(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["FinancialAccount.UpdateFeaturesParams"]
+        **params: Unpack[
+            "FinancialAccount.UpdateFeaturesParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "FinancialAccountFeatures":
         """
         Updates the Features associated with a FinancialAccount.

--- a/stripe/api_resources/treasury/inbound_transfer.py
+++ b/stripe/api_resources/treasury/inbound_transfer.py
@@ -347,7 +347,9 @@ class InboundTransfer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["InboundTransfer.CancelParams"]
+        **params: Unpack[
+            "InboundTransfer.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "InboundTransfer":
         """
         Cancels an InboundTransfer.
@@ -373,7 +375,9 @@ class InboundTransfer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["InboundTransfer.CancelParams"]
+        **params: Unpack[
+            "InboundTransfer.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "InboundTransfer":
         """
         Cancels an InboundTransfer.
@@ -384,7 +388,9 @@ class InboundTransfer(
     def cancel(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["InboundTransfer.CancelParams"]
+        **params: Unpack[
+            "InboundTransfer.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "InboundTransfer":
         """
         Cancels an InboundTransfer.
@@ -395,7 +401,9 @@ class InboundTransfer(
     def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["InboundTransfer.CancelParams"]
+        **params: Unpack[
+            "InboundTransfer.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "InboundTransfer":
         """
         Cancels an InboundTransfer.
@@ -419,7 +427,9 @@ class InboundTransfer(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["InboundTransfer.CreateParams"]
+        **params: Unpack[
+            "InboundTransfer.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "InboundTransfer":
         """
         Creates an InboundTransfer.
@@ -443,7 +453,9 @@ class InboundTransfer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["InboundTransfer.ListParams"]
+        **params: Unpack[
+            "InboundTransfer.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["InboundTransfer"]:
         """
         Returns a list of InboundTransfers sent from the specified FinancialAccount.
@@ -486,7 +498,9 @@ class InboundTransfer(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["InboundTransfer.FailParams"]
+            **params: Unpack[
+                "InboundTransfer.FailParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "InboundTransfer":
             """
             Transitions a test mode created InboundTransfer to the failed status. The InboundTransfer must already be in the processing state.
@@ -512,7 +526,9 @@ class InboundTransfer(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["InboundTransfer.FailParams"]
+            **params: Unpack[
+                "InboundTransfer.FailParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "InboundTransfer":
             """
             Transitions a test mode created InboundTransfer to the failed status. The InboundTransfer must already be in the processing state.
@@ -523,7 +539,9 @@ class InboundTransfer(
         def fail(
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["InboundTransfer.FailParams"]
+            **params: Unpack[
+                "InboundTransfer.FailParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "InboundTransfer":
             """
             Transitions a test mode created InboundTransfer to the failed status. The InboundTransfer must already be in the processing state.
@@ -534,7 +552,9 @@ class InboundTransfer(
         def fail(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["InboundTransfer.FailParams"]
+            **params: Unpack[
+                "InboundTransfer.FailParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "InboundTransfer":
             """
             Transitions a test mode created InboundTransfer to the failed status. The InboundTransfer must already be in the processing state.
@@ -558,7 +578,9 @@ class InboundTransfer(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"]
+            **params: Unpack[
+                "InboundTransfer.ReturnInboundTransferParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "InboundTransfer":
             """
             Marks the test mode InboundTransfer object as returned and links the InboundTransfer to a ReceivedDebit. The InboundTransfer must already be in the succeeded state.
@@ -584,7 +606,9 @@ class InboundTransfer(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"]
+            **params: Unpack[
+                "InboundTransfer.ReturnInboundTransferParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "InboundTransfer":
             """
             Marks the test mode InboundTransfer object as returned and links the InboundTransfer to a ReceivedDebit. The InboundTransfer must already be in the succeeded state.
@@ -595,7 +619,9 @@ class InboundTransfer(
         def return_inbound_transfer(
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"]
+            **params: Unpack[
+                "InboundTransfer.ReturnInboundTransferParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "InboundTransfer":
             """
             Marks the test mode InboundTransfer object as returned and links the InboundTransfer to a ReceivedDebit. The InboundTransfer must already be in the succeeded state.
@@ -606,7 +632,9 @@ class InboundTransfer(
         def return_inbound_transfer(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"]
+            **params: Unpack[
+                "InboundTransfer.ReturnInboundTransferParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "InboundTransfer":
             """
             Marks the test mode InboundTransfer object as returned and links the InboundTransfer to a ReceivedDebit. The InboundTransfer must already be in the succeeded state.
@@ -630,7 +658,9 @@ class InboundTransfer(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["InboundTransfer.SucceedParams"]
+            **params: Unpack[
+                "InboundTransfer.SucceedParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "InboundTransfer":
             """
             Transitions a test mode created InboundTransfer to the succeeded status. The InboundTransfer must already be in the processing state.
@@ -656,7 +686,9 @@ class InboundTransfer(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["InboundTransfer.SucceedParams"]
+            **params: Unpack[
+                "InboundTransfer.SucceedParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "InboundTransfer":
             """
             Transitions a test mode created InboundTransfer to the succeeded status. The InboundTransfer must already be in the processing state.
@@ -667,7 +699,9 @@ class InboundTransfer(
         def succeed(
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["InboundTransfer.SucceedParams"]
+            **params: Unpack[
+                "InboundTransfer.SucceedParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "InboundTransfer":
             """
             Transitions a test mode created InboundTransfer to the succeeded status. The InboundTransfer must already be in the processing state.
@@ -678,7 +712,9 @@ class InboundTransfer(
         def succeed(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["InboundTransfer.SucceedParams"]
+            **params: Unpack[
+                "InboundTransfer.SucceedParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "InboundTransfer":
             """
             Transitions a test mode created InboundTransfer to the succeeded status. The InboundTransfer must already be in the processing state.

--- a/stripe/api_resources/treasury/outbound_payment.py
+++ b/stripe/api_resources/treasury/outbound_payment.py
@@ -531,7 +531,9 @@ class OutboundPayment(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["OutboundPayment.CancelParams"]
+        **params: Unpack[
+            "OutboundPayment.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "OutboundPayment":
         """
         Cancel an OutboundPayment.
@@ -557,7 +559,9 @@ class OutboundPayment(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["OutboundPayment.CancelParams"]
+        **params: Unpack[
+            "OutboundPayment.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "OutboundPayment":
         """
         Cancel an OutboundPayment.
@@ -568,7 +572,9 @@ class OutboundPayment(
     def cancel(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["OutboundPayment.CancelParams"]
+        **params: Unpack[
+            "OutboundPayment.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "OutboundPayment":
         """
         Cancel an OutboundPayment.
@@ -579,7 +585,9 @@ class OutboundPayment(
     def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["OutboundPayment.CancelParams"]
+        **params: Unpack[
+            "OutboundPayment.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "OutboundPayment":
         """
         Cancel an OutboundPayment.
@@ -603,7 +611,9 @@ class OutboundPayment(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["OutboundPayment.CreateParams"]
+        **params: Unpack[
+            "OutboundPayment.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "OutboundPayment":
         """
         Creates an OutboundPayment.
@@ -627,7 +637,9 @@ class OutboundPayment(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["OutboundPayment.ListParams"]
+        **params: Unpack[
+            "OutboundPayment.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["OutboundPayment"]:
         """
         Returns a list of OutboundPayments sent from the specified FinancialAccount.
@@ -670,7 +682,9 @@ class OutboundPayment(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["OutboundPayment.FailParams"]
+            **params: Unpack[
+                "OutboundPayment.FailParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundPayment":
             """
             Transitions a test mode created OutboundPayment to the failed status. The OutboundPayment must already be in the processing state.
@@ -696,7 +710,9 @@ class OutboundPayment(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["OutboundPayment.FailParams"]
+            **params: Unpack[
+                "OutboundPayment.FailParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundPayment":
             """
             Transitions a test mode created OutboundPayment to the failed status. The OutboundPayment must already be in the processing state.
@@ -707,7 +723,9 @@ class OutboundPayment(
         def fail(
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["OutboundPayment.FailParams"]
+            **params: Unpack[
+                "OutboundPayment.FailParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundPayment":
             """
             Transitions a test mode created OutboundPayment to the failed status. The OutboundPayment must already be in the processing state.
@@ -718,7 +736,9 @@ class OutboundPayment(
         def fail(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["OutboundPayment.FailParams"]
+            **params: Unpack[
+                "OutboundPayment.FailParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundPayment":
             """
             Transitions a test mode created OutboundPayment to the failed status. The OutboundPayment must already be in the processing state.
@@ -742,7 +762,9 @@ class OutboundPayment(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["OutboundPayment.PostParams"]
+            **params: Unpack[
+                "OutboundPayment.PostParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundPayment":
             """
             Transitions a test mode created OutboundPayment to the posted status. The OutboundPayment must already be in the processing state.
@@ -768,7 +790,9 @@ class OutboundPayment(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["OutboundPayment.PostParams"]
+            **params: Unpack[
+                "OutboundPayment.PostParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundPayment":
             """
             Transitions a test mode created OutboundPayment to the posted status. The OutboundPayment must already be in the processing state.
@@ -779,7 +803,9 @@ class OutboundPayment(
         def post(
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["OutboundPayment.PostParams"]
+            **params: Unpack[
+                "OutboundPayment.PostParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundPayment":
             """
             Transitions a test mode created OutboundPayment to the posted status. The OutboundPayment must already be in the processing state.
@@ -790,7 +816,9 @@ class OutboundPayment(
         def post(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["OutboundPayment.PostParams"]
+            **params: Unpack[
+                "OutboundPayment.PostParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundPayment":
             """
             Transitions a test mode created OutboundPayment to the posted status. The OutboundPayment must already be in the processing state.
@@ -814,7 +842,9 @@ class OutboundPayment(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"]
+            **params: Unpack[
+                "OutboundPayment.ReturnOutboundPaymentParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundPayment":
             """
             Transitions a test mode created OutboundPayment to the returned status. The OutboundPayment must already be in the processing state.
@@ -840,7 +870,9 @@ class OutboundPayment(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"]
+            **params: Unpack[
+                "OutboundPayment.ReturnOutboundPaymentParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundPayment":
             """
             Transitions a test mode created OutboundPayment to the returned status. The OutboundPayment must already be in the processing state.
@@ -851,7 +883,9 @@ class OutboundPayment(
         def return_outbound_payment(
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"]
+            **params: Unpack[
+                "OutboundPayment.ReturnOutboundPaymentParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundPayment":
             """
             Transitions a test mode created OutboundPayment to the returned status. The OutboundPayment must already be in the processing state.
@@ -862,7 +896,9 @@ class OutboundPayment(
         def return_outbound_payment(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"]
+            **params: Unpack[
+                "OutboundPayment.ReturnOutboundPaymentParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundPayment":
             """
             Transitions a test mode created OutboundPayment to the returned status. The OutboundPayment must already be in the processing state.

--- a/stripe/api_resources/treasury/outbound_transfer.py
+++ b/stripe/api_resources/treasury/outbound_transfer.py
@@ -366,7 +366,9 @@ class OutboundTransfer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["OutboundTransfer.CancelParams"]
+        **params: Unpack[
+            "OutboundTransfer.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "OutboundTransfer":
         """
         An OutboundTransfer can be canceled if the funds have not yet been paid out.
@@ -392,7 +394,9 @@ class OutboundTransfer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["OutboundTransfer.CancelParams"]
+        **params: Unpack[
+            "OutboundTransfer.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "OutboundTransfer":
         """
         An OutboundTransfer can be canceled if the funds have not yet been paid out.
@@ -403,7 +407,9 @@ class OutboundTransfer(
     def cancel(
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["OutboundTransfer.CancelParams"]
+        **params: Unpack[
+            "OutboundTransfer.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "OutboundTransfer":
         """
         An OutboundTransfer can be canceled if the funds have not yet been paid out.
@@ -414,7 +420,9 @@ class OutboundTransfer(
     def cancel(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         idempotency_key: Optional[str] = None,
-        **params: Unpack["OutboundTransfer.CancelParams"]
+        **params: Unpack[
+            "OutboundTransfer.CancelParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "OutboundTransfer":
         """
         An OutboundTransfer can be canceled if the funds have not yet been paid out.
@@ -438,7 +446,9 @@ class OutboundTransfer(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["OutboundTransfer.CreateParams"]
+        **params: Unpack[
+            "OutboundTransfer.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "OutboundTransfer":
         """
         Creates an OutboundTransfer.
@@ -462,7 +472,9 @@ class OutboundTransfer(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["OutboundTransfer.ListParams"]
+        **params: Unpack[
+            "OutboundTransfer.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["OutboundTransfer"]:
         """
         Returns a list of OutboundTransfers sent from the specified FinancialAccount.
@@ -505,7 +517,9 @@ class OutboundTransfer(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["OutboundTransfer.FailParams"]
+            **params: Unpack[
+                "OutboundTransfer.FailParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the failed status. The OutboundTransfer must already be in the processing state.
@@ -531,7 +545,9 @@ class OutboundTransfer(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["OutboundTransfer.FailParams"]
+            **params: Unpack[
+                "OutboundTransfer.FailParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the failed status. The OutboundTransfer must already be in the processing state.
@@ -542,7 +558,9 @@ class OutboundTransfer(
         def fail(
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["OutboundTransfer.FailParams"]
+            **params: Unpack[
+                "OutboundTransfer.FailParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the failed status. The OutboundTransfer must already be in the processing state.
@@ -553,7 +571,9 @@ class OutboundTransfer(
         def fail(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["OutboundTransfer.FailParams"]
+            **params: Unpack[
+                "OutboundTransfer.FailParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the failed status. The OutboundTransfer must already be in the processing state.
@@ -579,7 +599,9 @@ class OutboundTransfer(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["OutboundTransfer.PostParams"]
+            **params: Unpack[
+                "OutboundTransfer.PostParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the posted status. The OutboundTransfer must already be in the processing state.
@@ -605,7 +627,9 @@ class OutboundTransfer(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["OutboundTransfer.PostParams"]
+            **params: Unpack[
+                "OutboundTransfer.PostParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the posted status. The OutboundTransfer must already be in the processing state.
@@ -616,7 +640,9 @@ class OutboundTransfer(
         def post(
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["OutboundTransfer.PostParams"]
+            **params: Unpack[
+                "OutboundTransfer.PostParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the posted status. The OutboundTransfer must already be in the processing state.
@@ -627,7 +653,9 @@ class OutboundTransfer(
         def post(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["OutboundTransfer.PostParams"]
+            **params: Unpack[
+                "OutboundTransfer.PostParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the posted status. The OutboundTransfer must already be in the processing state.
@@ -653,7 +681,9 @@ class OutboundTransfer(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"]
+            **params: Unpack[
+                "OutboundTransfer.ReturnOutboundTransferParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the returned status. The OutboundTransfer must already be in the processing state.
@@ -679,7 +709,9 @@ class OutboundTransfer(
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"]
+            **params: Unpack[
+                "OutboundTransfer.ReturnOutboundTransferParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the returned status. The OutboundTransfer must already be in the processing state.
@@ -690,7 +722,9 @@ class OutboundTransfer(
         def return_outbound_transfer(
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"]
+            **params: Unpack[
+                "OutboundTransfer.ReturnOutboundTransferParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the returned status. The OutboundTransfer must already be in the processing state.
@@ -701,7 +735,9 @@ class OutboundTransfer(
         def return_outbound_transfer(  # pyright: ignore[reportGeneralTypeIssues]
             self,
             idempotency_key: Optional[str] = None,
-            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"]
+            **params: Unpack[
+                "OutboundTransfer.ReturnOutboundTransferParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the returned status. The OutboundTransfer must already be in the processing state.

--- a/stripe/api_resources/treasury/received_credit.py
+++ b/stripe/api_resources/treasury/received_credit.py
@@ -371,7 +371,9 @@ class ReceivedCredit(ListableAPIResource["ReceivedCredit"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["ReceivedCredit.ListParams"]
+        **params: Unpack[
+            "ReceivedCredit.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["ReceivedCredit"]:
         """
         Returns a list of ReceivedCredits.
@@ -413,7 +415,9 @@ class ReceivedCredit(ListableAPIResource["ReceivedCredit"]):
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["ReceivedCredit.CreateParams"]
+            **params: Unpack[
+                "ReceivedCredit.CreateParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "ReceivedCredit":
             """
             Use this endpoint to simulate a test mode ReceivedCredit initiated by a third party. In live mode, you can't directly create ReceivedCredits initiated by third parties.

--- a/stripe/api_resources/treasury/received_debit.py
+++ b/stripe/api_resources/treasury/received_debit.py
@@ -320,7 +320,9 @@ class ReceivedDebit(ListableAPIResource["ReceivedDebit"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["ReceivedDebit.ListParams"]
+        **params: Unpack[
+            "ReceivedDebit.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["ReceivedDebit"]:
         """
         Returns a list of ReceivedDebits.
@@ -362,7 +364,9 @@ class ReceivedDebit(ListableAPIResource["ReceivedDebit"]):
             api_key: Optional[str] = None,
             stripe_version: Optional[str] = None,
             stripe_account: Optional[str] = None,
-            **params: Unpack["ReceivedDebit.CreateParams"]
+            **params: Unpack[
+                "ReceivedDebit.CreateParams"
+            ]  # pyright: ignore[reportGeneralTypeIssues]
         ) -> "ReceivedDebit":
             """
             Use this endpoint to simulate a test mode ReceivedDebit initiated by a third party. In live mode, you can't directly create ReceivedDebits initiated by third parties.

--- a/stripe/api_resources/treasury/transaction.py
+++ b/stripe/api_resources/treasury/transaction.py
@@ -281,7 +281,9 @@ class Transaction(ListableAPIResource["Transaction"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["Transaction.ListParams"]
+        **params: Unpack[
+            "Transaction.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["Transaction"]:
         """
         Retrieves a list of Transaction objects.

--- a/stripe/api_resources/treasury/transaction_entry.py
+++ b/stripe/api_resources/treasury/transaction_entry.py
@@ -275,7 +275,9 @@ class TransactionEntry(ListableAPIResource["TransactionEntry"]):
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["TransactionEntry.ListParams"]
+        **params: Unpack[
+            "TransactionEntry.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["TransactionEntry"]:
         """
         Retrieves a list of TransactionEntry objects.

--- a/stripe/api_resources/webhook_endpoint.py
+++ b/stripe/api_resources/webhook_endpoint.py
@@ -409,7 +409,9 @@ class WebhookEndpoint(
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["WebhookEndpoint.CreateParams"]
+        **params: Unpack[
+            "WebhookEndpoint.CreateParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> "WebhookEndpoint":
         """
         A webhook endpoint must have a url and a list of enabled_events. You may optionally specify the Boolean connect parameter. If set to true, then a Connect webhook endpoint that notifies the specified url about events from all connected accounts is created; otherwise an account webhook endpoint that notifies the specified url only about events from your account is created. You can also create webhook endpoints in the [webhooks settings](https://dashboard.stripe.com/account/webhooks) section of the Dashboard.
@@ -478,7 +480,9 @@ class WebhookEndpoint(
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
-        **params: Unpack["WebhookEndpoint.ListParams"]
+        **params: Unpack[
+            "WebhookEndpoint.ListParams"
+        ]  # pyright: ignore[reportGeneralTypeIssues]
     ) -> ListObject["WebhookEndpoint"]:
         """
         Returns a list of your webhook endpoints.

--- a/stripe/stripe_object.py
+++ b/stripe/stripe_object.py
@@ -460,7 +460,7 @@ class StripeObject(Dict[str, Any]):
     # wholesale because some data that's returned from the API may not be valid
     # if it was set to be set manually. Here we override the class' copy
     # arguments so that we can bypass these possible exceptions on __setitem__.
-    def __copy__(self) -> Self:
+    def __copy__(self) -> "StripeObject":
         copied = StripeObject(
             self.get("id"),
             self.api_key,
@@ -482,7 +482,7 @@ class StripeObject(Dict[str, Any]):
     # wholesale because some data that's returned from the API may not be valid
     # if it was set to be set manually. Here we override the class' copy
     # arguments so that we can bypass these possible exceptions on __setitem__.
-    def __deepcopy__(self, memo: Dict[int, Any]) -> Self:
+    def __deepcopy__(self, memo: Dict[int, Any]) -> "StripeObject":
         copied = self.__copy__()
         memo[id(self)] = copied
 


### PR DESCRIPTION
See commit-by-commit.

For [Fix redundant keyword params](https://github.com/stripe/stripe-python/commit/706b0b8d900809a80f1c5299c1ce7815e346cb59) -- I checked that this was safe by looking into the implementation of `_static_request` or `_request` in each case and observing that `util.read_special_variable` was called (eventually) to grab the value from `params.
