### PR TITLE
Run pyright via tox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   lint:
-    name: Lint
+    name: Typecheck and lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -27,6 +27,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+      - name: Typecheck with pyright
+        run: make pyright
       - name: lint
         run: make lint
       - name: fmtcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,20 +68,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-          [
-            "3.6",
-            "3.7",
-            "3.8",
-            "3.9",
-            "3.10",
-            "3.11",
-            "3.12",
-            "pypy-3.7",
-            "pypy-3.8",
-            "pypy-3.9",
-            "pypy-3.10",
-          ]
+        include:
+            - python-version: "3.6"
+              env: py36
+            - python-version: "3.7"
+              env: py37
+            - python-version: "3.8"
+              env: py38
+            - python-version: "3.9"
+              env: py39
+            - python-version: "3.10"
+              env: py310
+            - python-version: "3.11"
+              env: py311
+            - python-version: "3.12"
+              env: py312
+            - python-version: "pypy-3.7"
+              env: py3.7
+            - python-version: "pypy-3.8"
+              env: py3.8
+            - python-version: "pypy-3.9"
+              env: py3.9
+            - python-version: "pypy-3.10"
+              env: py3.10
 
     steps:
       - uses: actions/checkout@v3
@@ -106,7 +115,7 @@ jobs:
         if: ${{ !contains(matrix.python-version, 'pypy') }}
 
       - name: Test with pytest
-        run: TOX_ARGS="-e ${{ matrix.python-version }}" make ci-test
+        run: TOX_ARGS="-e ${{ matrix.env }}" make ci-test
 
       - name: Calculate and publish coverage
         run: make coveralls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,17 +95,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }} and 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: "setup.py"
-
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
+          python-version: |
+            ${{ matrix.python-version }}
+            3.10
 
       - uses: stripe/openapi/actions/stripe-mock@master
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
           path: dist/
 
   test:
-    name: Test ${{ python-version }}
     # Specific ubuntu version to support python 3.6 testing
     # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877 for details
     # move to ubuntu-latest when we drop 3.6
@@ -91,6 +90,7 @@ jobs:
               env: py3.9
             - python-version: "pypy-3.10"
               env: py3.10
+    name: Test ${{ python-version }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       - uses: stripe/openapi/actions/stripe-mock@master
 
       - name: Typecheck with pyright
-        run: PYRIGHT_ARGS="--pythonversion ${{ matrix.python-version }}" make pyright
+        run: PYRIGHT_ARGS="-- --pythonversion ${{ matrix.python-version }}" make pyright
 
       - name: Test with pytest
         run: TOX_ARGS="-e ${{ matrix.python-version }}" make ci-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           path: dist/
 
   test:
-    name: Test
+    name: Test ${{ python-version }}
     # Specific ubuntu version to support python 3.6 testing
     # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877 for details
     # move to ubuntu-latest when we drop 3.6
@@ -91,7 +91,6 @@ jobs:
               env: py3.9
             - python-version: "pypy-3.10"
               env: py3.10
-
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -92,23 +95,10 @@ jobs:
           cache: "pip"
           cache-dependency-path: "setup.py"
 
-      - name: Upgrade pip and virtualenv to latest
-        run: pip install --upgrade pip virtualenv
-
       - uses: stripe/openapi/actions/stripe-mock@master
 
-      - name: Typecheck with pyright
-        run: make pyright
-        # Pip won't install newer versions of pyright on python 3.6 (odd, because pyright is a node module)
-        # so we skip running pyright, and do double duty on python 3.7 using the --pythonversion flag.
-        if: matrix.python-version != '3.6'
-
-      - name: Typecheck with pyright
-        run: make pyright PYRIGHT_ARGS="--pythonversion 3.6"
-        if: matrix.python-version == '3.7'
-
       - name: Test with pytest
-        run: make ci-test
+        run: TOX_ARGS="-e ${{ matrix.python-version }}" make ci-test
 
       - name: Calculate and publish coverage
         run: make coveralls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
     # move to ubuntu-latest when we drop 3.6
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python.version: "3.10"
       - name: lint
         run: make lint
       - name: fmtcheck
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python.version: "3.10"
 
       - name: Install tools
         run: make venv
@@ -67,53 +67,42 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-            - python-version: "3.6"
-              env: py36
-            - python-version: "3.7"
-              env: py37
-            - python-version: "3.8"
-              env: py38
-            - python-version: "3.9"
-              env: py39
-            - python-version: "3.10"
-              env: py310
-            - python-version: "3.11"
-              env: py311
-            - python-version: "3.12"
-              env: py312
-            - python-version: "pypy-3.7"
-              env: py3.7
-            - python-version: "pypy-3.8"
-              env: py3.8
-            - python-version: "pypy-3.9"
-              env: py3.9
-            - python-version: "pypy-3.10"
-              env: py3.10
-    name: Test ${{ python-version }}
+        python:
+          - { version: "3.6" , env: "py36" }
+          - { version: "3.7" , env: "py37" }
+          - { version: "3.8" , env: "py38" }
+          - { version: "3.9" , env: "py39" }
+          - { version: "3.10" , env: "py310" }
+          - { version: "3.11" , env: "py311" }
+          - { version: "3.12" , env: "py312" }
+          - { version: "pypy-3.7" , env: "py3.7" }
+          - { version: "pypy-3.8" , env: "py3.8" }
+          - { version: "pypy-3.9" , env: "py3.9" }
+          - { version: "pypy-3.10" , env: "py3.10" }
+    name: Test ${{ matrix.python.version }}
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }} and 3.10
+      - name: Set up Python ${{ matrix.python.version }} and 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: |
-            ${{ matrix.python-version }}
+          python.version: |
+            ${{ matrix.python.version }}
             3.10
 
       - uses: stripe/openapi/actions/stripe-mock@master
 
       - name: Typecheck with pyright
-        run: PYRIGHT_ARGS="-- --pythonversion ${{ matrix.python-version }}" make pyright
+        run: PYRIGHT_ARGS="-- --pythonversion ${{ matrix.python.version }}" make pyright
         # Skip typecheking in pypy legs
-        if: ${{ !contains(matrix.python-version, 'pypy') }}
+        if: ${{ !contains(matrix.python.version, 'pypy') }}
 
       - name: Test with pytest
-        run: TOX_ARGS="-e ${{ matrix.env }}" make ci-test
+        run: TOX_ARGS="-e ${{ matrix.python.env }}" make ci-test
 
       - name: Calculate and publish coverage
         run: make coveralls
-        if: env.COVERALLS_REPO_TOKEN && matrix.python-version == '3.10'
+        if: env.COVERALLS_REPO_TOKEN && matrix.python.version == '3.10'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
@@ -136,7 +125,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python.version: "3.10"
 
       - name: Configure GPG Key
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,15 +86,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v4
-
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
           cache-dependency-path: "setup.py"
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
 
       - uses: stripe/openapi/actions/stripe-mock@master
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v4
         with:
-          python.version: "3.10"
+          python-version: "3.10"
       - name: lint
         run: make lint
       - name: fmtcheck
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v4
         with:
-          python.version: "3.10"
+          python-version: "3.10"
 
       - name: Install tools
         run: make venv
@@ -86,7 +86,7 @@ jobs:
       - name: Set up Python ${{ matrix.python.version }} and 3.10
         uses: actions/setup-python@v4
         with:
-          python.version: |
+          python-version: |
             ${{ matrix.python.version }}
             3.10
 
@@ -125,7 +125,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v4
         with:
-          python.version: "3.10"
+          python-version: "3.10"
 
       - name: Configure GPG Key
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   lint:
-    name: Typecheck and lint
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -27,8 +27,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-      - name: Typecheck with pyright
-        run: make pyright
       - name: lint
         run: make lint
       - name: fmtcheck
@@ -101,6 +99,9 @@ jobs:
           python-version: "3.10"
 
       - uses: stripe/openapi/actions/stripe-mock@master
+
+      - name: Typecheck with pyright
+        run: PYRIGHT_ARGS="--pythonversion ${{ matrix.python-version }}" make pyright
 
       - name: Test with pytest
         run: TOX_ARGS="-e ${{ matrix.python-version }}" make ci-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,8 @@ jobs:
 
       - name: Typecheck with pyright
         run: PYRIGHT_ARGS="-- --pythonversion ${{ matrix.python-version }}" make pyright
+        # Skip typecheking in pypy legs
+        if: ${{ !contains(matrix.python-version, 'pypy') }}
 
       - name: Test with pytest
         run: TOX_ARGS="-e ${{ matrix.python-version }}" make ci-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,8 @@ jobs:
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
 
       - uses: stripe/openapi/actions/stripe-mock@master
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           - { version: "pypy-3.8" , env: "py3.8" }
           - { version: "pypy-3.9" , env: "py3.9" }
           - { version: "pypy-3.10" , env: "py3.10" }
-    name: Test ${{ matrix.python.version }}
+    name: Test (${{ matrix.python.version }})
     steps:
       - uses: actions/checkout@v3
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ $(VENV_NAME)/bin/activate: setup.py requirements.txt
 	@touch $(VENV_NAME)/bin/activate
 
 test: venv pyright
-	@${VENV_NAME}/bin/tox -p auto $(TOX_ARGS)
+	@${VENV_NAME}/bin/tox -p auto -e $(PYTHON) $(TOX_ARGS)
 
 test-nomock: venv
 	@${VENV_NAME}/bin/tox -p auto -- --nomock $(TOX_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ $(VENV_NAME)/bin/activate: setup.py requirements.txt
 	${VENV_NAME}/bin/python -m pip install -r requirements.txt
 	@touch $(VENV_NAME)/bin/activate
 
-test: venv
+test: venv pyright
 	@${VENV_NAME}/bin/tox -p auto $(TOX_ARGS)
 
 test-nomock: venv

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 VENV_NAME?=venv
 PIP?=pip
 PYTHON?=python3.10
+DEFAULT_TEST_ENV?=py310
 
 venv: $(VENV_NAME)/bin/activate
 
@@ -9,8 +10,8 @@ $(VENV_NAME)/bin/activate: setup.py requirements.txt
 	${VENV_NAME}/bin/python -m pip install -r requirements.txt
 	@touch $(VENV_NAME)/bin/activate
 
-test: venv pyright
-	@${VENV_NAME}/bin/tox -p auto -e $(PYTHON) $(TOX_ARGS)
+test: venv pyright lint
+	@${VENV_NAME}/bin/tox -p auto -e $(DEFAULT_TEST_ENV) $(TOX_ARGS)
 
 test-nomock: venv
 	@${VENV_NAME}/bin/tox -p auto -- --nomock $(TOX_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VENV_NAME?=venv
 PIP?=pip
-PYTHON?=python3
+PYTHON?=python3.10
 
 venv: $(VENV_NAME)/bin/activate
 

--- a/Makefile
+++ b/Makefile
@@ -22,17 +22,7 @@ coveralls: venv
 	@${VENV_NAME}/bin/tox -e coveralls
 
 pyright: venv
-	# In order for pyright to be able to follow imports, we need "editable_mode=compat" to force setuptools to do
-	# an editable install via a .pth file mechanism and not "import hooks". See
-	# the "editable installs" section of https://github.com/microsoft/pyright/blob/main/docs/import-resolution.md#editable-installs
-
-	# This command might fail if we're on python 3.6, as versions of pip that
-	# support python 3.6 don't know about "--config-settings", but in this case
-	# we don't need to pass config-settings anyway because "editable_mode=compat" just
-	# means to perform as these old versions of pip already do.
-	pip install -e . --config-settings editable_mode=compat || pip install -e .
-	@${VENV_NAME}/bin/pyright --version
-	@${VENV_NAME}/bin/pyright $(PYRIGHT_ARGS)
+	@${VENV_NAME}/bin/tox -e pyright $(PYRIGHT_ARGS)
 
 fmt: venv
 	@${VENV_NAME}/bin/tox -e fmt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-line-length=79
+line-length = 79
 target-version = [
   "py35",
   "py36",
@@ -7,8 +7,8 @@ target-version = [
   "py38",
   "py39",
   "py310",
-#   "py311",  # black 21.12b0 doesn't
-#   "py312",  # support these targets
+  #   "py311",  # black 21.12b0 doesn't
+  #   "py312",  # support these targets
 ]
 exclude = '''
 /(
@@ -23,14 +23,10 @@ exclude = '''
 )
 '''
 [tool.pyright]
-executionEnvironments=[
-  {"root" = "stripe"},
-  {"root" = "tests"}
-]
-include=["stripe", "tests/test_generated_examples.py"]
-exclude=["build", "**/__pycache__"]
-reportMissingTypeArgument=true
-reportUnnecessaryCast=true
-reportUnnecessaryComparison=true
-reportUnnecessaryContains=true
-reportUnnecessaryIsInstance=true
+include = ["stripe", "tests/test_generated_examples.py"]
+exclude = ["build", "**/__pycache__"]
+reportMissingTypeArgument = true
+reportUnnecessaryCast = true
+reportUnnecessaryComparison = true
+reportUnnecessaryContains = true
+reportUnnecessaryIsInstance = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-# cryptography 40.0.0 deprecates support for Python 3.6 and PyPy3 < 7.3.10
-cryptography<40
+# These requirements must be installable only on py3.10 +
 twine
 # 4.5.0 is the last version that works with virtualenv<20.22.0
 tox == 4.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,5 @@ tox == 4.11.3
 pyright == 1.1.336
 black == 22.8.0
 flake8
-tox-gh-actions == 3.1.3
 
 -r test-requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@
 cryptography<40
 tox
 twine
-pyright
+tox == 4.11.3
+pyright == 1.1.336
 pytest-cov >= 2.8.1, < 2.11.0
 pytest-mock >= 2.0.0
 pytest-xdist >= 1.31.0
@@ -14,4 +15,4 @@ click==8.0.4 # Version 8.1 breaks black
 flake8
 coverage >= 4.5.3, < 5
 coveralls
-tox-gh-actions
+tox-gh-actions == 3.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,7 @@ tox == 4.11.3
 pyright == 1.1.336
 black == 22.8.0
 flake8
+#Virtualenv 20.22.0 dropped support for all Python versions smaller or equal to Python 3.6.
+virtualenv<20.22.0
 
 -r test-requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,8 @@ cryptography<40
 twine
 tox == 4.11.3
 pyright == 1.1.336
-pytest-cov >= 2.8.1, < 2.11.0
-pytest-mock >= 2.0.0
-pytest-xdist >= 1.31.0
-pytest >= 6.0.0
 black == 22.8.0
 flake8
-coverage >= 4.5.3, < 5
-coveralls
 tox-gh-actions == 3.1.3
+
+-r test-requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 # cryptography 40.0.0 deprecates support for Python 3.6 and PyPy3 < 7.3.10
 cryptography<40
-tox
 twine
 tox == 4.11.3
 pyright == 1.1.336

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # cryptography 40.0.0 deprecates support for Python 3.6 and PyPy3 < 7.3.10
 cryptography<40
 twine
+# 4.5.0 is the last version that works with virtualenv<20.22.0
 tox == 4.5.0
 #Virtualenv 20.22.0 dropped support for all Python versions smaller or equal to Python 3.6.
 virtualenv<20.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 # cryptography 40.0.0 deprecates support for Python 3.6 and PyPy3 < 7.3.10
 cryptography<40
 twine
-tox == 4.11.3
+tox == 4.5.0
+#Virtualenv 20.22.0 dropped support for all Python versions smaller or equal to Python 3.6.
+virtualenv<20.22.0
 pyright == 1.1.336
 black == 22.8.0
 flake8
-#Virtualenv 20.22.0 dropped support for all Python versions smaller or equal to Python 3.6.
-virtualenv<20.22.0
 
 -r test-requirements.txt

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,8 @@
+
+pyright == 1.1.336
+pytest-cov >= 2.8.1, < 2.11.0
+pytest-mock >= 2.0.0
+pytest-xdist >= 1.31.0
+pytest >= 6.0.0
+coverage >= 4.5.3, < 5
+coveralls

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+# These requirements must be installable on all our supported versions
 pytest-cov >= 2.8.1, < 2.11.0
 pytest-mock >= 2.0.0
 pytest-xdist >= 1.31.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,3 @@
-
-pyright == 1.1.336
 pytest-cov >= 2.8.1, < 2.11.0
 pytest-mock >= 2.0.0
 pytest-xdist >= 1.31.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,10 @@
 import atexit
 import os
 import sys
-from distutils.version import StrictVersion
-
 import pytest
 
 import stripe
 from urllib.request import urlopen
-from urllib.error import HTTPError
 
 from tests.request_mock import RequestMock
 from tests.stripe_mock import StripeMock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,12 @@ import sys
 import pytest
 
 import stripe
-from urllib.request import urlopen
+import requests
 
 from tests.request_mock import RequestMock
 from tests.stripe_mock import StripeMock
+
+MOCK_MINIMUM_VERSION = "0.109.0"
 
 # Starts stripe-mock if an OpenAPI spec override is found in `openapi/`, and
 # otherwise fall back to `STRIPE_MOCK_PORT` or 12111.
@@ -25,7 +27,7 @@ def stop_stripe_mock():
 def pytest_configure(config):
     if not config.getoption("--nomock"):
         try:
-            urlopen("http://localhost:%s/" % MOCK_PORT)
+            requests.get("http://localhost:%s/" % MOCK_PORT)
         except Exception:
             sys.exit(
                 "Couldn't reach stripe-mock at `localhost:%s`. Is "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,9 +28,7 @@ def stop_stripe_mock():
 def pytest_configure(config):
     if not config.getoption("--nomock"):
         try:
-            resp = urlopen("http://localhost:%s/" % MOCK_PORT)
-        except HTTPError as e:
-            info = e.info()
+            urlopen("http://localhost:%s/" % MOCK_PORT)
         except Exception:
             sys.exit(
                 "Couldn't reach stripe-mock at `localhost:%s`. Is "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,8 +12,6 @@ from urllib.error import HTTPError
 from tests.request_mock import RequestMock
 from tests.stripe_mock import StripeMock
 
-MOCK_MINIMUM_VERSION = "0.109.0"
-
 # Starts stripe-mock if an OpenAPI spec override is found in `openapi/`, and
 # otherwise fall back to `STRIPE_MOCK_PORT` or 12111.
 if StripeMock.start():
@@ -31,18 +29,6 @@ def pytest_configure(config):
     if not config.getoption("--nomock"):
         try:
             resp = urlopen("http://localhost:%s/" % MOCK_PORT)
-            info = resp.info()
-            version = info.get("Stripe-Mock-Version")
-            if version != "master" and StrictVersion(version) < StrictVersion(
-                MOCK_MINIMUM_VERSION
-            ):
-                sys.exit(
-                    "Your version of stripe-mock (%s) is too old. The minimum "
-                    "version to run this test suite is %s. Please "
-                    "see its repository for upgrade instructions."
-                    % (version, MOCK_MINIMUM_VERSION)
-                )
-
         except HTTPError as e:
             info = e.info()
         except Exception:

--- a/tox.ini
+++ b/tox.ini
@@ -48,8 +48,6 @@ basepython = python3.10
 skip_install = true
 commands =
   pyright
-deps =
-  -r requirements.txt
 
 [testenv:fmt]
 description = run code formatting using black

--- a/tox.ini
+++ b/tox.ini
@@ -42,28 +42,13 @@ commands = pytest --cov {posargs:-n auto} --ignore stripe
 # CFLAGS="-I$(brew --prefix openssl@1.1)/include"
 passenv = LDFLAGS,CFLAGS
 
-[testenv:pyright]
+[testenv:{lint,fmt,pyright}]
 basepython = python3.10
 skip_install = true
 commands =
-  pyright
-deps =
-  -r requirements.txt
-
-[testenv:fmt]
-description = run code formatting using black
-basepython = python3.10
-commands = black . {posargs}
-skip_install = true
-deps =
-  -r requirements.txt
-
-[testenv:lint]
-description = run static analysis and style check using flake8
-basepython = python3.10
-commands =
-  python -m flake8  --show-source stripe tests setup.py
-skip_install = true
+  pyright: pyright
+  lint: python -m flake8  --show-source stripe tests setup.py
+  fmt: black . {posargs}
 deps =
   -r requirements.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ python =
     3.7: py37
     3.6: py36
     pypy-3: pypy3
+ignore_base_python_conflict = false
 
 [tool:pytest]
 testpaths = tests

--- a/tox.ini
+++ b/tox.ini
@@ -9,17 +9,6 @@ envlist =
     lint
     pyright
     py{312,311,310,39,38,37,36,py3}
-
-[gh-actions]
-python =
-    3.12: py312
-    3.11: py311
-    3.10: py310
-    3.9: py39
-    3.8: py38
-    3.7: py37
-    3.6: py36
-    pypy-3: pypy3
 ignore_base_python_conflict = false
 
 [tool:pytest]

--- a/tox.ini
+++ b/tox.ini
@@ -44,8 +44,11 @@ commands = pytest --cov {posargs:-n auto} --ignore stripe
 passenv = LDFLAGS,CFLAGS
 
 [testenv:pyright]
+skipsdist = true
+skip_install = true
+usedevelop = true
 basepython = python3.10
-use_develop = true
+package = editable-legacy
 commands = pyright
 deps =
   -r requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ description = run the unit tests under {basepython}
 setenv =
     COVERAGE_FILE = {toxworkdir}/.coverage.{envname}
 deps =
-  -r requirements.txt
+  -r test-requirements.txt
 
 # ignore stripe directory as all tests are inside ./tests
 commands = pytest --cov {posargs:-n auto} --ignore stripe
@@ -48,12 +48,16 @@ basepython = python3.10
 skip_install = true
 commands =
   pyright
+deps =
+  -r requirements.txt
 
 [testenv:fmt]
 description = run code formatting using black
 basepython = python3.10
 commands = black . {posargs}
 skip_install = true
+deps =
+  -r requirements.txt
 
 [testenv:lint]
 description = run static analysis and style check using flake8
@@ -61,6 +65,8 @@ basepython = python3.10
 commands =
   python -m flake8  --show-source stripe tests setup.py
 skip_install = true
+deps =
+  -r requirements.txt
 
 [testenv:coveralls]
 description = upload coverage to coveralls.io

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@
 envlist =
     fmt
     lint
+    pyright
     py{312,311,310,39,38,37,36,py3}
 skip_missing_interpreters = true
 
@@ -41,6 +42,13 @@ commands = pytest --cov {posargs:-n auto} --ignore stripe
 # LDFLAGS="-L$(brew --prefix openssl@1.1)/lib"
 # CFLAGS="-I$(brew --prefix openssl@1.1)/include"
 passenv = LDFLAGS,CFLAGS
+
+[testenv:pyright]
+basepython = python3.10
+use_develop = true
+commands = pyright
+deps =
+  -r requirements.txt
 
 [testenv:fmt]
 description = run code formatting using black

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,9 @@ setenv =
 deps =
   -r test-requirements.txt
 
+[testenv:py36]
+basepython = python3.6
+
 # ignore stripe directory as all tests are inside ./tests
 commands = pytest --cov {posargs:-n auto} --ignore stripe
 # compilation flags can be useful when prebuilt wheels cannot be used, e.g.

--- a/tox.ini
+++ b/tox.ini
@@ -44,12 +44,10 @@ commands = pytest --cov {posargs:-n auto} --ignore stripe
 passenv = LDFLAGS,CFLAGS
 
 [testenv:pyright]
-skipsdist = true
-skip_install = true
-usedevelop = true
 basepython = python3.10
-package = editable-legacy
-commands = pyright
+skip_install = true
+commands =
+  pyright
 deps =
   -r requirements.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ passenv = LDFLAGS,CFLAGS
 basepython = python3.10
 skip_install = true
 commands =
-  pyright: pyright
+  pyright: pyright {posargs}
   lint: python -m flake8  --show-source stripe tests setup.py
   fmt: black . {posargs}
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -23,9 +23,6 @@ setenv =
 deps =
   -r test-requirements.txt
 
-[testenv:py36]
-basepython = python3.6
-
 # ignore stripe directory as all tests are inside ./tests
 commands = pytest --cov {posargs:-n auto} --ignore stripe
 # compilation flags can be useful when prebuilt wheels cannot be used, e.g.

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ envlist =
     lint
     pyright
     py{312,311,310,39,38,37,36,py3}
-skip_missing_interpreters = true
 
 [gh-actions]
 python =


### PR DESCRIPTION
Updates our infrastructure to always run tools on python3.10 and only run tests on different versions of python.