### PR TITLE
Add * separator to enforce keyword arguments

### DIFF
--- a/stripe/api_resources/abstract/api_resource.py
+++ b/stripe/api_resources/abstract/api_resource.py
@@ -68,7 +68,7 @@ class APIResource(StripeObject, Generic[T]):
         self,
         method_,
         url_,
-        # TODO (next major) add * here to force keyword-only arguments
+        *,
         api_key=None,
         idempotency_key=None,
         stripe_version=None,
@@ -80,12 +80,12 @@ class APIResource(StripeObject, Generic[T]):
             self,
             method_,
             url_,
-            api_key,
-            idempotency_key,
-            stripe_version,
-            stripe_account,
-            headers,
-            params,
+            api_key=api_key,
+            idempotency_key=idempotency_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            headers=headers,
+            params=params,
         )
 
         if type(self) is type(obj):
@@ -100,7 +100,7 @@ class APIResource(StripeObject, Generic[T]):
         self,
         method_: Literal["get", "post", "delete"],
         url_: str,
-        # TODO (next major) add * here to force keyword-only arguments
+        *,
         api_key: Optional[str] = None,
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
@@ -112,12 +112,12 @@ class APIResource(StripeObject, Generic[T]):
             self,
             method_,
             url_,
-            api_key,
-            idempotency_key,
-            stripe_version,
-            stripe_account,
-            headers,
-            params,
+            api_key=api_key,
+            idempotency_key=idempotency_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            headers=headers,
+            params=params,
         )
 
         self.refresh_from(obj)
@@ -130,7 +130,7 @@ class APIResource(StripeObject, Generic[T]):
         cls,
         method_,
         url_,
-        # TODO (next major) add * here to force keyword-only arguments
+        *,
         api_key=None,
         idempotency_key=None,
         stripe_version=None,
@@ -170,7 +170,7 @@ class APIResource(StripeObject, Generic[T]):
         cls,
         method_,
         url_,
-        # TODO (next major) add * here to force keyword-only arguments
+        *,
         api_key=None,
         idempotency_key=None,
         stripe_version=None,

--- a/stripe/api_resources/abstract/api_resource.py
+++ b/stripe/api_resources/abstract/api_resource.py
@@ -21,7 +21,13 @@ class APIResource(StripeObject, Generic[T]):
     OBJECT_NAME: ClassVar[str]
 
     @classmethod
-    def retrieve(cls, id, api_key=None, **params) -> T:
+    def retrieve(
+        cls,
+        id,
+        # TODO (next major): Add * here to force keyword-only arguments
+        api_key=None,
+        **params
+    ) -> T:
         instance = cls(id, api_key, **params)
         instance.refresh()
         return cast(T, instance)
@@ -62,6 +68,7 @@ class APIResource(StripeObject, Generic[T]):
         self,
         method_,
         url_,
+        # TODO (next major) add * here to force keyword-only arguments
         api_key=None,
         idempotency_key=None,
         stripe_version=None,
@@ -93,6 +100,7 @@ class APIResource(StripeObject, Generic[T]):
         self,
         method_: Literal["get", "post", "delete"],
         url_: str,
+        # TODO (next major) add * here to force keyword-only arguments
         api_key: Optional[str] = None,
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
@@ -122,6 +130,7 @@ class APIResource(StripeObject, Generic[T]):
         cls,
         method_,
         url_,
+        # TODO (next major) add * here to force keyword-only arguments
         api_key=None,
         idempotency_key=None,
         stripe_version=None,
@@ -161,6 +170,7 @@ class APIResource(StripeObject, Generic[T]):
         cls,
         method_,
         url_,
+        # TODO (next major) add * here to force keyword-only arguments
         api_key=None,
         idempotency_key=None,
         stripe_version=None,

--- a/stripe/api_resources/abstract/createable_api_resource.py
+++ b/stripe/api_resources/abstract/createable_api_resource.py
@@ -9,6 +9,7 @@ class CreateableAPIResource(APIResource[T]):
     @classmethod
     def create(
         cls,
+        # TODO (next major) add * here to force keyword-only arguments
         api_key=None,
         idempotency_key=None,
         stripe_version=None,

--- a/stripe/api_resources/abstract/createable_api_resource.py
+++ b/stripe/api_resources/abstract/createable_api_resource.py
@@ -21,10 +21,10 @@ class CreateableAPIResource(APIResource[T]):
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )

--- a/stripe/api_resources/account.py
+++ b/stripe/api_resources/account.py
@@ -3495,11 +3495,11 @@ class Account(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -3584,6 +3584,7 @@ class Account(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/account_link.py
+++ b/stripe/api_resources/account_link.py
@@ -78,10 +78,10 @@ class AccountLink(CreateableAPIResource["AccountLink"]):
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )

--- a/stripe/api_resources/account_session.py
+++ b/stripe/api_resources/account_session.py
@@ -103,11 +103,11 @@ class AccountSession(CreateableAPIResource["AccountSession"]):
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 

--- a/stripe/api_resources/apple_pay_domain.py
+++ b/stripe/api_resources/apple_pay_domain.py
@@ -96,11 +96,11 @@ class ApplePayDomain(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -171,6 +171,7 @@ class ApplePayDomain(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/application_fee.py
+++ b/stripe/api_resources/application_fee.py
@@ -220,6 +220,7 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/apps/secret.py
+++ b/stripe/api_resources/apps/secret.py
@@ -201,11 +201,11 @@ class Secret(CreateableAPIResource["Secret"], ListableAPIResource["Secret"]):
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -281,6 +281,7 @@ class Secret(CreateableAPIResource["Secret"], ListableAPIResource["Secret"]):
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/balance_transaction.py
+++ b/stripe/api_resources/balance_transaction.py
@@ -283,6 +283,7 @@ class BalanceTransaction(ListableAPIResource["BalanceTransaction"]):
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/billing_portal/configuration.py
+++ b/stripe/api_resources/billing_portal/configuration.py
@@ -664,11 +664,11 @@ class Configuration(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -694,6 +694,7 @@ class Configuration(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/billing_portal/session.py
+++ b/stripe/api_resources/billing_portal/session.py
@@ -461,11 +461,11 @@ class Session(CreateableAPIResource["Session"]):
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 

--- a/stripe/api_resources/charge.py
+++ b/stripe/api_resources/charge.py
@@ -2296,11 +2296,11 @@ class Charge(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -2326,6 +2326,7 @@ class Charge(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/checkout/session.py
+++ b/stripe/api_resources/checkout/session.py
@@ -3565,11 +3565,11 @@ class Session(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -3683,6 +3683,7 @@ class Session(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/country_spec.py
+++ b/stripe/api_resources/country_spec.py
@@ -121,6 +121,7 @@ class CountrySpec(ListableAPIResource["CountrySpec"]):
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/coupon.py
+++ b/stripe/api_resources/coupon.py
@@ -275,11 +275,11 @@ class Coupon(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -346,6 +346,7 @@ class Coupon(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/credit_note.py
+++ b/stripe/api_resources/credit_note.py
@@ -749,11 +749,11 @@ class CreditNote(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -779,6 +779,7 @@ class CreditNote(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/credit_note_line_item.py
+++ b/stripe/api_resources/credit_note_line_item.py
@@ -177,6 +177,7 @@ class CreditNoteLineItem(ListableAPIResource["CreditNoteLineItem"]):
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/customer.py
+++ b/stripe/api_resources/customer.py
@@ -1396,11 +1396,11 @@ class Customer(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -1637,6 +1637,7 @@ class Customer(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/customer_cash_balance_transaction.py
+++ b/stripe/api_resources/customer_cash_balance_transaction.py
@@ -237,6 +237,7 @@ class CustomerCashBalanceTransaction(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/dispute.py
+++ b/stripe/api_resources/dispute.py
@@ -552,6 +552,7 @@ class Dispute(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/event.py
+++ b/stripe/api_resources/event.py
@@ -405,6 +405,7 @@ class Event(ListableAPIResource["Event"]):
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/exchange_rate.py
+++ b/stripe/api_resources/exchange_rate.py
@@ -98,6 +98,7 @@ class ExchangeRate(ListableAPIResource["ExchangeRate"]):
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/file.py
+++ b/stripe/api_resources/file.py
@@ -163,6 +163,7 @@ class File(ListableAPIResource["File"]):
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/file_link.py
+++ b/stripe/api_resources/file_link.py
@@ -174,11 +174,11 @@ class FileLink(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -204,6 +204,7 @@ class FileLink(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/financial_connections/account.py
+++ b/stripe/api_resources/financial_connections/account.py
@@ -386,6 +386,7 @@ class Account(ListableAPIResource["Account"]):
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/financial_connections/session.py
+++ b/stripe/api_resources/financial_connections/session.py
@@ -166,11 +166,11 @@ class Session(CreateableAPIResource["Session"]):
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 

--- a/stripe/api_resources/identity/verification_report.py
+++ b/stripe/api_resources/identity/verification_report.py
@@ -404,6 +404,7 @@ class VerificationReport(ListableAPIResource["VerificationReport"]):
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/identity/verification_session.py
+++ b/stripe/api_resources/identity/verification_session.py
@@ -506,11 +506,11 @@ class VerificationSession(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -536,6 +536,7 @@ class VerificationSession(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/invoice.py
+++ b/stripe/api_resources/invoice.py
@@ -3572,11 +3572,11 @@ class Invoice(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -3725,6 +3725,7 @@ class Invoice(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/invoice_item.py
+++ b/stripe/api_resources/invoice_item.py
@@ -471,11 +471,11 @@ class InvoiceItem(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -546,6 +546,7 @@ class InvoiceItem(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/issuing/authorization.py
+++ b/stripe/api_resources/issuing/authorization.py
@@ -978,6 +978,7 @@ class Authorization(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/issuing/card.py
+++ b/stripe/api_resources/issuing/card.py
@@ -1540,11 +1540,11 @@ class Card(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -1570,6 +1570,7 @@ class Card(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/issuing/cardholder.py
+++ b/stripe/api_resources/issuing/cardholder.py
@@ -1695,11 +1695,11 @@ class Cardholder(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -1725,6 +1725,7 @@ class Cardholder(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/issuing/dispute.py
+++ b/stripe/api_resources/issuing/dispute.py
@@ -875,11 +875,11 @@ class Dispute(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -905,6 +905,7 @@ class Dispute(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/issuing/token.py
+++ b/stripe/api_resources/issuing/token.py
@@ -330,6 +330,7 @@ class Token(ListableAPIResource["Token"], UpdateableAPIResource["Token"]):
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/issuing/transaction.py
+++ b/stripe/api_resources/issuing/transaction.py
@@ -796,6 +796,7 @@ class Transaction(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/payment_intent.py
+++ b/stripe/api_resources/payment_intent.py
@@ -7839,11 +7839,11 @@ class PaymentIntent(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -8041,6 +8041,7 @@ class PaymentIntent(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/payment_link.py
+++ b/stripe/api_resources/payment_link.py
@@ -2095,11 +2095,11 @@ class PaymentLink(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -2125,6 +2125,7 @@ class PaymentLink(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/payment_method.py
+++ b/stripe/api_resources/payment_method.py
@@ -1836,11 +1836,11 @@ class PaymentMethod(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -1946,6 +1946,7 @@ class PaymentMethod(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/payment_method_configuration.py
+++ b/stripe/api_resources/payment_method_configuration.py
@@ -2226,11 +2226,11 @@ class PaymentMethodConfiguration(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -2256,6 +2256,7 @@ class PaymentMethodConfiguration(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/payment_method_domain.py
+++ b/stripe/api_resources/payment_method_domain.py
@@ -221,11 +221,11 @@ class PaymentMethodDomain(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -251,6 +251,7 @@ class PaymentMethodDomain(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/payout.py
+++ b/stripe/api_resources/payout.py
@@ -378,11 +378,11 @@ class Payout(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -408,6 +408,7 @@ class Payout(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/plan.py
+++ b/stripe/api_resources/plan.py
@@ -402,11 +402,11 @@ class Plan(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -473,6 +473,7 @@ class Plan(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/price.py
+++ b/stripe/api_resources/price.py
@@ -740,11 +740,11 @@ class Price(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -770,6 +770,7 @@ class Price(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/product.py
+++ b/stripe/api_resources/product.py
@@ -560,11 +560,11 @@ class Product(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -633,6 +633,7 @@ class Product(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/promotion_code.py
+++ b/stripe/api_resources/promotion_code.py
@@ -291,11 +291,11 @@ class PromotionCode(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -321,6 +321,7 @@ class PromotionCode(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/quote.py
+++ b/stripe/api_resources/quote.py
@@ -1200,11 +1200,11 @@ class Quote(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -1310,6 +1310,7 @@ class Quote(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/radar/early_fraud_warning.py
+++ b/stripe/api_resources/radar/early_fraud_warning.py
@@ -111,6 +111,7 @@ class EarlyFraudWarning(ListableAPIResource["EarlyFraudWarning"]):
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/radar/value_list.py
+++ b/stripe/api_resources/radar/value_list.py
@@ -208,11 +208,11 @@ class ValueList(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -283,6 +283,7 @@ class ValueList(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/radar/value_list_item.py
+++ b/stripe/api_resources/radar/value_list_item.py
@@ -148,11 +148,11 @@ class ValueListItem(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -223,6 +223,7 @@ class ValueListItem(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/refund.py
+++ b/stripe/api_resources/refund.py
@@ -364,11 +364,11 @@ class Refund(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -394,6 +394,7 @@ class Refund(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/reporting/report_run.py
+++ b/stripe/api_resources/reporting/report_run.py
@@ -230,11 +230,11 @@ class ReportRun(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -260,6 +260,7 @@ class ReportRun(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/reporting/report_type.py
+++ b/stripe/api_resources/reporting/report_type.py
@@ -94,6 +94,7 @@ class ReportType(ListableAPIResource["ReportType"]):
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/review.py
+++ b/stripe/api_resources/review.py
@@ -283,6 +283,7 @@ class Review(ListableAPIResource["Review"]):
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/setup_attempt.py
+++ b/stripe/api_resources/setup_attempt.py
@@ -771,6 +771,7 @@ class SetupAttempt(ListableAPIResource["SetupAttempt"]):
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/setup_intent.py
+++ b/stripe/api_resources/setup_intent.py
@@ -3427,11 +3427,11 @@ class SetupIntent(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -3457,6 +3457,7 @@ class SetupIntent(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/shipping_rate.py
+++ b/stripe/api_resources/shipping_rate.py
@@ -355,11 +355,11 @@ class ShippingRate(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -385,6 +385,7 @@ class ShippingRate(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/sigma/scheduled_query_run.py
+++ b/stripe/api_resources/sigma/scheduled_query_run.py
@@ -117,6 +117,7 @@ class ScheduledQueryRun(ListableAPIResource["ScheduledQueryRun"]):
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/source.py
+++ b/stripe/api_resources/source.py
@@ -1131,11 +1131,11 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 

--- a/stripe/api_resources/subscription.py
+++ b/stripe/api_resources/subscription.py
@@ -1936,11 +1936,11 @@ class Subscription(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -2048,6 +2048,7 @@ class Subscription(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/subscription_item.py
+++ b/stripe/api_resources/subscription_item.py
@@ -419,11 +419,11 @@ class SubscriptionItem(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -494,6 +494,7 @@ class SubscriptionItem(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/subscription_schedule.py
+++ b/stripe/api_resources/subscription_schedule.py
@@ -1387,11 +1387,11 @@ class SubscriptionSchedule(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -1417,6 +1417,7 @@ class SubscriptionSchedule(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/tax/calculation.py
+++ b/stripe/api_resources/tax/calculation.py
@@ -641,11 +641,11 @@ class Calculation(CreateableAPIResource["Calculation"]):
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 

--- a/stripe/api_resources/tax/registration.py
+++ b/stripe/api_resources/tax/registration.py
@@ -1649,11 +1649,11 @@ class Registration(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -1679,6 +1679,7 @@ class Registration(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/tax_code.py
+++ b/stripe/api_resources/tax_code.py
@@ -77,6 +77,7 @@ class TaxCode(ListableAPIResource["TaxCode"]):
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/tax_rate.py
+++ b/stripe/api_resources/tax_rate.py
@@ -265,11 +265,11 @@ class TaxRate(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -295,6 +295,7 @@ class TaxRate(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/terminal/configuration.py
+++ b/stripe/api_resources/terminal/configuration.py
@@ -952,11 +952,11 @@ class Configuration(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -1027,6 +1027,7 @@ class Configuration(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/terminal/connection_token.py
+++ b/stripe/api_resources/terminal/connection_token.py
@@ -59,10 +59,10 @@ class ConnectionToken(CreateableAPIResource["ConnectionToken"]):
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )

--- a/stripe/api_resources/terminal/location.py
+++ b/stripe/api_resources/terminal/location.py
@@ -228,11 +228,11 @@ class Location(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -301,6 +301,7 @@ class Location(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/terminal/reader.py
+++ b/stripe/api_resources/terminal/reader.py
@@ -634,11 +634,11 @@ class Reader(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -705,6 +705,7 @@ class Reader(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/test_helpers/test_clock.py
+++ b/stripe/api_resources/test_helpers/test_clock.py
@@ -216,11 +216,11 @@ class TestClock(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -291,6 +291,7 @@ class TestClock(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/token.py
+++ b/stripe/api_resources/token.py
@@ -1087,11 +1087,11 @@ class Token(CreateableAPIResource["Token"]):
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 

--- a/stripe/api_resources/topup.py
+++ b/stripe/api_resources/topup.py
@@ -332,11 +332,11 @@ class Topup(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -362,6 +362,7 @@ class Topup(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/transfer.py
+++ b/stripe/api_resources/transfer.py
@@ -295,11 +295,11 @@ class Transfer(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -325,6 +325,7 @@ class Transfer(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/treasury/credit_reversal.py
+++ b/stripe/api_resources/treasury/credit_reversal.py
@@ -156,11 +156,11 @@ class CreditReversal(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -186,6 +186,7 @@ class CreditReversal(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/treasury/debit_reversal.py
+++ b/stripe/api_resources/treasury/debit_reversal.py
@@ -170,11 +170,11 @@ class DebitReversal(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -200,6 +200,7 @@ class DebitReversal(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/treasury/financial_account.py
+++ b/stripe/api_resources/treasury/financial_account.py
@@ -786,11 +786,11 @@ class FinancialAccount(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -816,6 +816,7 @@ class FinancialAccount(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/treasury/inbound_transfer.py
+++ b/stripe/api_resources/treasury/inbound_transfer.py
@@ -437,11 +437,11 @@ class InboundTransfer(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -467,6 +467,7 @@ class InboundTransfer(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/treasury/outbound_payment.py
+++ b/stripe/api_resources/treasury/outbound_payment.py
@@ -615,11 +615,11 @@ class OutboundPayment(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -645,6 +645,7 @@ class OutboundPayment(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/treasury/outbound_transfer.py
+++ b/stripe/api_resources/treasury/outbound_transfer.py
@@ -454,11 +454,11 @@ class OutboundTransfer(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -484,6 +484,7 @@ class OutboundTransfer(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/treasury/received_credit.py
+++ b/stripe/api_resources/treasury/received_credit.py
@@ -383,6 +383,7 @@ class ReceivedCredit(ListableAPIResource["ReceivedCredit"]):
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/treasury/received_debit.py
+++ b/stripe/api_resources/treasury/received_debit.py
@@ -332,6 +332,7 @@ class ReceivedDebit(ListableAPIResource["ReceivedDebit"]):
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/treasury/transaction.py
+++ b/stripe/api_resources/treasury/transaction.py
@@ -295,6 +295,7 @@ class Transaction(ListableAPIResource["Transaction"]):
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/treasury/transaction_entry.py
+++ b/stripe/api_resources/treasury/transaction_entry.py
@@ -287,6 +287,7 @@ class TransactionEntry(ListableAPIResource["TransactionEntry"]):
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/api_resources/webhook_endpoint.py
+++ b/stripe/api_resources/webhook_endpoint.py
@@ -420,11 +420,11 @@ class WebhookEndpoint(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                api_key,
-                idempotency_key,
-                stripe_version,
-                stripe_account,
-                params,
+                api_key=api_key,
+                idempotency_key=idempotency_key,
+                stripe_version=stripe_version,
+                stripe_account=stripe_account,
+                params=params,
             ),
         )
 
@@ -495,6 +495,7 @@ class WebhookEndpoint(
             params=params,
         )
         if not isinstance(result, ListObject):
+
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/error.py
+++ b/stripe/error.py
@@ -16,6 +16,7 @@ class StripeError(Exception):
     def __init__(
         self,
         message: Optional[str] = None,
+        # TODO (next major): Add * here to force keyword-only arguments
         http_body: Optional[Union[bytes, str]] = None,
         http_status: Optional[int] = None,
         json_body: Optional[object] = None,
@@ -90,6 +91,7 @@ class APIConnectionError(StripeError):
     def __init__(
         self,
         message,
+        # TODO (next major): Add * here to force keyword-only arguments
         http_body=None,
         http_status=None,
         json_body=None,
@@ -125,6 +127,7 @@ class CardError(StripeErrorWithParamCode):
         message,
         param,
         code,
+        # TODO (next major): Add * here to force keyword-only arguments
         http_body=None,
         http_status=None,
         json_body=None,
@@ -145,6 +148,7 @@ class InvalidRequestError(StripeErrorWithParamCode):
         self,
         message,
         param,
+        # TODO (next major): Add * here to force keyword-only arguments
         code=None,
         http_body=None,
         http_status=None,
@@ -170,6 +174,12 @@ class RateLimitError(StripeError):
 
 
 class SignatureVerificationError(StripeError):
-    def __init__(self, message, sig_header, http_body=None):
+    def __init__(
+        self,
+        message,
+        sig_header,
+        # TODO (next major): Add * here to force keyword-only arguments
+        http_body=None,
+    ):
         super(SignatureVerificationError, self).__init__(message, http_body)
         self.sig_header = sig_header

--- a/stripe/http_client.py
+++ b/stripe/http_client.py
@@ -109,6 +109,7 @@ class HTTPClient(object):
 
     def __init__(
         self,
+        # TODO (next major): Add * here to force keyword-only arguments
         verify_ssl_certs: bool = True,
         proxy: Optional[Union[str, _Proxy]] = None,
     ):
@@ -134,14 +135,24 @@ class HTTPClient(object):
 
     # TODO: more specific types here would be helpful
     def request_with_retries(
-        self, method, url, headers, post_data=None
+        self,
+        method,
+        url,
+        headers,
+        # TODO (next major): Add * here to force keyword-only arguments
+        post_data=None,
     ) -> Tuple[Any, int, Any]:
         return self._request_with_retries_internal(
             method, url, headers, post_data, is_streaming=False
         )
 
     def request_stream_with_retries(
-        self, method, url, headers, post_data=None
+        self,
+        method,
+        url,
+        headers,
+        # TODO (next major): Add * here to force keyword-only arguments
+        post_data=None,
     ) -> Tuple[Any, int, Any]:
         return self._request_with_retries_internal(
             method, url, headers, post_data, is_streaming=True
@@ -194,12 +205,26 @@ class HTTPClient(object):
                     assert connection_error is not None
                     raise connection_error
 
-    def request(self, method, url, headers, post_data=None):
+    def request(
+        self,
+        method,
+        url,
+        headers,
+        # TODO (next major): Add * here to force keyword-only arguments
+        post_data=None,
+    ):
         raise NotImplementedError(
             "HTTPClient subclasses must implement `request`"
         )
 
-    def request_stream(self, method, url, headers, post_data=None):
+    def request_stream(
+        self,
+        method,
+        url,
+        headers,
+        # TODO (next major): Add * here to force keyword-only arguments
+        post_data=None,
+    ):
         raise NotImplementedError(
             "HTTPClient subclasses must implement `request_stream`"
         )
@@ -312,7 +337,13 @@ class HTTPClient(object):
 class RequestsClient(HTTPClient):
     name = "requests"
 
-    def __init__(self, timeout=80, session=None, **kwargs):
+    def __init__(
+        self,
+        # TODO (next major): Add * here to force keyword-only arguments
+        timeout=80,
+        session=None,
+        **kwargs
+    ):
         super(RequestsClient, self).__init__(**kwargs)
         self._session = session
         self._timeout = timeout
@@ -320,12 +351,26 @@ class RequestsClient(HTTPClient):
         assert requests is not None
         self.requests = requests
 
-    def request(self, method, url, headers, post_data=None):
+    def request(
+        self,
+        method,
+        url,
+        headers,
+        # TODO (next major): Add * here to force keyword-only arguments
+        post_data=None,
+    ):
         return self._request_internal(
             method, url, headers, post_data, is_streaming=False
         )
 
-    def request_stream(self, method, url, headers, post_data=None):
+    def request_stream(
+        self,
+        method,
+        url,
+        headers,
+        # TODO (next major): Add * here to force keyword-only arguments
+        post_data=None,
+    ):
         return self._request_internal(
             method, url, headers, post_data, is_streaming=True
         )
@@ -445,7 +490,13 @@ class RequestsClient(HTTPClient):
 class UrlFetchClient(HTTPClient):
     name = "urlfetch"
 
-    def __init__(self, verify_ssl_certs=True, proxy=None, deadline=55):
+    def __init__(
+        self,
+        # TODO (next major): Add * here to force keyword-only arguments
+        verify_ssl_certs=True,
+        proxy=None,
+        deadline=55,
+    ):
         super(UrlFetchClient, self).__init__(
             verify_ssl_certs=verify_ssl_certs, proxy=proxy
         )
@@ -467,12 +518,26 @@ class UrlFetchClient(HTTPClient):
         assert urlfetch is not None
         self.urlfetch = urlfetch
 
-    def request(self, method, url, headers, post_data=None):
+    def request(
+        self,
+        method,
+        url,
+        headers,
+        # TODO (next major): Add * here to force keyword-only arguments
+        post_data=None,
+    ):
         return self._request_internal(
             method, url, headers, post_data, is_streaming=False
         )
 
-    def request_stream(self, method, url, headers, post_data=None):
+    def request_stream(
+        self,
+        method,
+        url,
+        headers,
+        # TODO (next major): Add * here to force keyword-only arguments
+        post_data=None,
+    ):
         return self._request_internal(
             method, url, headers, post_data, is_streaming=True
         )
@@ -537,7 +602,12 @@ class PycurlClient(HTTPClient):
     name = "pycurl"
     _parsed_proxy: Optional[_ParsedProxy]
 
-    def __init__(self, verify_ssl_certs=True, proxy=None):
+    def __init__(
+        self,
+        # TODO (next major): Add * here to force keyword-only arguments
+        verify_ssl_certs=True,
+        proxy=None,
+    ):
         super(PycurlClient, self).__init__(
             verify_ssl_certs=verify_ssl_certs, proxy=proxy
         )
@@ -564,12 +634,26 @@ class PycurlClient(HTTPClient):
         headers = email.message_from_string(raw_headers)
         return dict((k.lower(), v) for k, v in dict(headers).items())
 
-    def request(self, method, url, headers, post_data=None):
+    def request(
+        self,
+        method,
+        url,
+        headers,
+        # TODO (next major): Add * here to force keyword-only arguments
+        post_data=None,
+    ):
         return self._request_internal(
             method, url, headers, post_data, is_streaming=False
         )
 
-    def request_stream(self, method, url, headers, post_data=None):
+    def request_stream(
+        self,
+        method,
+        url,
+        headers,
+        # TODO (next major): Add * here to force keyword-only arguments
+        post_data=None,
+    ):
         return self._request_internal(
             method, url, headers, post_data, is_streaming=True
         )
@@ -689,7 +773,12 @@ class PycurlClient(HTTPClient):
 class Urllib2Client(HTTPClient):
     name = "urllib.request"
 
-    def __init__(self, verify_ssl_certs=True, proxy=None):
+    def __init__(
+        self,
+        # TODO (next major): Add * here to force keyword-only arguments
+        verify_ssl_certs=True,
+        proxy=None,
+    ):
         super(Urllib2Client, self).__init__(
             verify_ssl_certs=verify_ssl_certs, proxy=proxy
         )
@@ -703,12 +792,26 @@ class Urllib2Client(HTTPClient):
             )
             self._opener = urllibrequest.build_opener(proxy)
 
-    def request(self, method, url, headers, post_data=None):
+    def request(
+        self,
+        method,
+        url,
+        headers,
+        # TODO (next major): Add * here to force keyword-only arguments
+        post_data=None,
+    ):
         return self._request_internal(
             method, url, headers, post_data, is_streaming=False
         )
 
-    def request_stream(self, method, url, headers, post_data=None):
+    def request_stream(
+        self,
+        method,
+        url,
+        headers,
+        # TODO (next major): Add * here to force keyword-only arguments
+        post_data=None,
+    ):
         return self._request_internal(
             method, url, headers, post_data, is_streaming=True
         )

--- a/stripe/stripe_object.py
+++ b/stripe/stripe_object.py
@@ -85,6 +85,7 @@ class StripeObject(Dict[str, Any]):
 
     def __init__(
         self,
+        # TODO (next major): Add * here to force keyword-only arguments
         id: Optional[str] = None,
         api_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
@@ -215,6 +216,7 @@ class StripeObject(Dict[str, Any]):
         cls,
         values: Dict[str, Any],
         key: Optional[str],
+        # TODO (next major): Add * here to force keyword-only arguments
         stripe_version: Optional[str] = None,
         stripe_account: Optional[str] = None,
         last_response: Optional[StripeResponse] = None,
@@ -238,6 +240,7 @@ class StripeObject(Dict[str, Any]):
     def refresh_from(
         self,
         values: Dict[str, Any],
+        # TODO (next major) add * here to force keyword-only arguments
         api_key: Optional[str] = None,
         partial: Optional[bool] = False,
         stripe_version: Optional[str] = None,
@@ -312,6 +315,7 @@ class StripeObject(Dict[str, Any]):
         self,
         method: Literal["get", "post", "delete"],
         url: str,
+        # TODO (next major) add * here to force keyword-only arguments
         params: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, str]] = None,
     ) -> "StripeObject":
@@ -325,6 +329,7 @@ class StripeObject(Dict[str, Any]):
         self,
         method_: Literal["get", "post", "delete"],
         url_: str,
+        # TODO (next major) add * here to force keyword-only arguments
         api_key: Optional[str] = None,
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,
@@ -371,6 +376,7 @@ class StripeObject(Dict[str, Any]):
         self,
         method: str,
         url: str,
+        # TODO (next major) add * here to force keyword-only arguments
         params: Optional[Mapping[str, Any]] = None,
         headers: Optional[Mapping[str, str]] = None,
     ) -> StripeStreamResponse:

--- a/stripe/stripe_object.py
+++ b/stripe/stripe_object.py
@@ -329,7 +329,7 @@ class StripeObject(Dict[str, Any]):
         self,
         method_: Literal["get", "post", "delete"],
         url_: str,
-        # TODO (next major) add * here to force keyword-only arguments
+        *,
         api_key: Optional[str] = None,
         idempotency_key: Optional[str] = None,
         stripe_version: Optional[str] = None,

--- a/stripe/util.py
+++ b/stripe/util.py
@@ -209,6 +209,7 @@ Resp = Union[StripeResponse, Dict[str, Any], List["Resp"]]
 @overload
 def convert_to_stripe_object(
     resp: Union[StripeResponse, Dict[str, Any]],
+    # TODO (next major): Add * here to force keyword-only arguments
     api_key: Optional[str] = None,
     stripe_version: Optional[str] = None,
     stripe_account: Optional[str] = None,

--- a/stripe/webhook.py
+++ b/stripe/webhook.py
@@ -13,7 +13,12 @@ class Webhook(object):
 
     @staticmethod
     def construct_event(
-        payload, sig_header, secret, tolerance=DEFAULT_TOLERANCE, api_key=None
+        payload,
+        sig_header,
+        secret,
+        # TODO (next major): Add * here to force keyword-only arguments
+        tolerance=DEFAULT_TOLERANCE,
+        api_key=None,
     ):
         if hasattr(payload, "decode"):
             payload = payload.decode("utf-8")


### PR DESCRIPTION
## Background
Many methods in stripe-python take keyword arguments and/or a **params kwargs-spread argument. By default, keyword arguments in python can also be passed positionally. This means that rearranging keyword arguments in the method definition is a breaking change, and also collapsing a keyword argument into the **params kwarg spread is also a breaking change.

If you include the `*` character before your keyword arguments, you can prevent them from being passed positionally. This is usually more inline with our intent of how the keyword arguments should be used, and gives us more flexibility in changing the implementations.

## Summary

Adds the star separator for appropriate underscore-prefixed private methods.
Adds TODO (next major) comments in the places where we should add a star separator in methods that aren't underscore-prefixed.