### PR TITLE
Beta: revert broken logger

### DIFF
--- a/stripe/_util.py
+++ b/stripe/_util.py
@@ -111,14 +111,14 @@ def log_debug(message, **params):
     msg = logfmt(dict(message=message, **params))
     if _console_log_level() == "debug":
         print(msg, file=sys.stderr)
-    logger.debug(msg, params)
+    logger.debug(msg)
 
 
 def log_info(message, **params):
     msg = logfmt(dict(message=message, **params))
     if _console_log_level() in ["debug", "info"]:
         print(msg, file=sys.stderr)
-    logger.info(msg, params)
+    logger.info(msg)
 
 
 def _test_or_live_environment():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -62,9 +62,7 @@ class TestUtil(object):
                     )
                 else:
                     print_mock.assert_not_called()
-                logger_mock.assert_called_once_with(
-                    "message='foo \\nbar' y=3", {"y": 3}
-                )
+                logger_mock.assert_called_once_with("message='foo \\nbar' y=3")
             finally:
                 mocker.stopall()
 


### PR DESCRIPTION
## Summary
This pr reverts the changes from https://github.com/stripe/stripe-python/pull/921.

It appears that back in February, there was a bad merge in https://github.com/stripe/stripe-python/pull/931 that didn't properly apply the https://github.com/stripe/stripe-python/pull/923 revert of https://github.com/stripe/stripe-python/pull/921, so the broken logger has persisted in `beta`. @anniel-stripe and I discovered this while pairing and setting log_level=DEBUG in a test.