### PR TITLE
HTTPClient refactor

### DIFF
--- a/flake8_stripe/flake8_stripe.py
+++ b/flake8_stripe/flake8_stripe.py
@@ -160,7 +160,6 @@ class StripeImportsChecker:
                     )
             if isinstance(node, ast.ImportFrom):
                 # Forbid: from stripe...module import Type
-                assert node.module is not None
                 parts = node.module.split(".")
                 if (
                     len(parts) > 1

--- a/flake8_stripe/flake8_stripe.py
+++ b/flake8_stripe/flake8_stripe.py
@@ -31,6 +31,8 @@ class TypingImportsChecker:
         "NotRequired",
         "Self",
         "Unpack",
+        "Awaitable",
+        "Never",
     ]
 
     allowed_typing_imports = [
@@ -158,6 +160,7 @@ class StripeImportsChecker:
                     )
             if isinstance(node, ast.ImportFrom):
                 # Forbid: from stripe...module import Type
+                assert node.module is not None
                 parts = node.module.split(".")
                 if (
                     len(parts) > 1

--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -15,11 +15,7 @@ from stripe._error import APIConnectionError
 from typing import Any, Dict, Optional, Tuple, ClassVar, Union, cast, Mapping
 from typing_extensions import (
     NoReturn,
-    Self,
     TypedDict,
-    Awaitable,
-    Type,
-    Never,
 )
 
 # - Requests is the preferred HTTP library

--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -311,8 +311,17 @@ class HTTPClient(HTTPClientBase):
 class RequestsClient(HTTPClient):
     name = "requests"
 
-    def __init__(self, timeout=80, session=None, **kwargs):
-        super(RequestsClient, self).__init__(**kwargs)
+    def __init__(
+        self,
+        timeout: int = 80,
+        session: Optional["Session"] = None,
+        verify_ssl_certs: bool = True,
+        proxy: Optional[Union[str, HTTPClient._Proxy]] = None,
+        **kwargs
+    ):
+        super(RequestsClient, self).__init__(
+            verify_ssl_certs=verify_ssl_certs, proxy=proxy
+        )
         self._session = session
         self._timeout = timeout
 
@@ -444,7 +453,12 @@ class RequestsClient(HTTPClient):
 class UrlFetchClient(HTTPClient):
     name = "urlfetch"
 
-    def __init__(self, verify_ssl_certs=True, proxy=None, deadline=55):
+    def __init__(
+        self,
+        verify_ssl_certs: bool = True,
+        proxy: Optional[HTTPClient._Proxy] = None,
+        deadline: int = 55,
+    ):
         super(UrlFetchClient, self).__init__(
             verify_ssl_certs=verify_ssl_certs, proxy=proxy
         )
@@ -536,7 +550,11 @@ class PycurlClient(HTTPClient):
     name = "pycurl"
     _parsed_proxy: Optional[_ParsedProxy]
 
-    def __init__(self, verify_ssl_certs=True, proxy=None):
+    def __init__(
+        self,
+        verify_ssl_certs: bool = True,
+        proxy: Optional[HTTPClient._Proxy] = None,
+    ):
         super(PycurlClient, self).__init__(
             verify_ssl_certs=verify_ssl_certs, proxy=proxy
         )
@@ -688,7 +706,11 @@ class PycurlClient(HTTPClient):
 class Urllib2Client(HTTPClient):
     name = "urllib.request"
 
-    def __init__(self, verify_ssl_certs=True, proxy=None):
+    def __init__(
+        self,
+        verify_ssl_certs: bool = True,
+        proxy: Optional[HTTPClient._Proxy] = None,
+    ):
         super(Urllib2Client, self).__init__(
             verify_ssl_certs=verify_ssl_certs, proxy=proxy
         )
@@ -697,10 +719,10 @@ class Urllib2Client(HTTPClient):
         if self._proxy:
             # We have to cast _Proxy to Dict[str, str] because pyright is not smart enough to
             # realize that all the value types are str.
-            proxy = urllibrequest.ProxyHandler(
+            proxy_handler = urllibrequest.ProxyHandler(
                 cast(Dict[str, str], self._proxy)
             )
-            self._opener = urllibrequest.build_opener(proxy)
+            self._opener = urllibrequest.build_opener(proxy_handler)
 
     def request(self, method, url, headers, post_data=None):
         return self._request_internal(

--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -284,9 +284,7 @@ class HTTPClient(HTTPClientBase):
                         method, url, headers, post_data
                     )
                 else:
-                    response = self.request(
-                        method, url, headers, post_data, _usage=_usage
-                    )
+                    response = self.request(method, url, headers, post_data)
                 connection_error = None
             except APIConnectionError as e:
                 connection_error = e

--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -21,7 +21,6 @@ from typing import (
     ClassVar,
     Union,
     cast,
-    Mapping,
 )
 from typing_extensions import (
     NoReturn,


### PR DESCRIPTION
## Summary
Contains refactoring changes from https://github.com/stripe/stripe-python/pull/1165 that we can merge into master to minimize how much master and beta diverge.

In particular, it extracts an `HTTPClientBase` parent class from `HTTPClient`, and removes some dead code related to warning that would only fire if Python2 (which this library is no longer compatible with) is used.

