### PR TITLE
Support accessing reserved word resource properties via attribute

### DIFF
--- a/stripe/_stripe_object.py
+++ b/stripe/_stripe_object.py
@@ -146,6 +146,8 @@ class StripeObject(Dict[str, Any]):
                 raise AttributeError(k)
 
             try:
+                if k in self._field_remappings:
+                    k = self._field_remappings[k]
                 return self[k]
             except KeyError as err:
                 raise AttributeError(*err.args)
@@ -529,6 +531,8 @@ class StripeObject(Dict[str, Any]):
             super(StripeObject, copied).__setitem__(k, deepcopy(v, memo))
 
         return copied
+
+    _field_remappings: ClassVar[Dict[str, str]] = {}
 
     _inner_class_types: ClassVar[Dict[str, Type["StripeObject"]]] = {}
     _inner_class_dicts: ClassVar[List[str]] = []

--- a/tests/test_stripe_object.py
+++ b/tests/test_stripe_object.py
@@ -376,3 +376,10 @@ class TestStripeObject(object):
         )
 
         assert obj.serialize(None) == {"nested": ""}
+
+    def test_field_name_remapping(self):
+        class Foo(stripe.stripe_object.StripeObject):
+            _field_remappings = {"getter_name": "data_name"}
+
+        obj = Foo.construct_from({"data_name": "foo"}, "mykey")
+        assert obj.getter_name == "foo"


### PR DESCRIPTION
Currently, accessing a property with the same name as a Python reserved word as a resource attribute does not work. The only known case of this is for the country code `is` on `country_options` of a Tax Registration resource.

Accessing the property as an object attribute will result in a syntax error:
```python
>>> taxreg.country_options.is
  File "<stdin>", line 1
    reg.country_options.is
                        ^^
SyntaxError: invalid syntax
```
This means the nested property can only be accessed via dictionary key: `reg.country_options["is"]`.

`_field_remappings` allows reserved word properties to be accessed as an attribute via the property name + `_`, like so:
```python
>>> taxreg.country_options.is_
<Is at 0x104b5ef70> JSON: {
  "type": "standard"
}
```

The `_field_remappings` property is already generated in [stripe/tax/_registration.py](https://github.com/stripe/stripe-python/blob/d2b8ed1934ca9c5a9fcfeba89306d193972bdb24/stripe/tax/_registration.py#L675).

