### PR TITLE
Remove api_base from RequestOptions type

### DIFF
--- a/stripe/_request_options.py
+++ b/stripe/_request_options.py
@@ -4,7 +4,6 @@ from typing_extensions import NotRequired, TypedDict
 
 class RequestOptions(TypedDict):
     api_key: NotRequired[Optional[str]]
-    api_base: NotRequired[Optional[str]]
     stripe_version: NotRequired[Optional[str]]
     stripe_account: NotRequired[Optional[str]]
     idempotency_key: NotRequired[Optional[str]]


### PR DESCRIPTION
`api_base` never worked as a request option. If passed in as a keyword argument to a method, it would get treated as a request parameter. Removing as this option is misleading and unsupported.