### PR TITLE
Use sys.executable in test_exports

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -3,11 +3,12 @@
 from typing import Any
 import stripe
 import subprocess
+import sys
 
 
 def assert_output(code: str, expected: str) -> None:
     process = subprocess.Popen(
-        ["python", "-c", f"import stripe; print({code})"],
+        [sys.executable, "-c", f"import stripe; print({code})"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )


### PR DESCRIPTION
Not all systems will have 'python' in the path to execute to check exports -- and indeed, it may not even be the interpreter that is under test and can import the module. Since we are already running under the test suite, use sys.executable to check.