### PR TITLE
Add request mocking to two test methods

### DIFF
--- a/tests/api_resources/test_invoice.py
+++ b/tests/api_resources/test_invoice.py
@@ -137,7 +137,7 @@ class TestInvoice(object):
         )
         assert isinstance(resource, stripe.Invoice)
 
-    def test_can_iterate_lines(self):
+    def test_can_iterate_lines(self, http_client_mock):
         resource = stripe.Invoice.retrieve(TEST_RESOURCE_ID)
         assert isinstance(resource.lines.data, list)
         assert isinstance(resource.lines.data[0], stripe.InvoiceLineItem)

--- a/tests/api_resources/test_invoice_line_item.py
+++ b/tests/api_resources/test_invoice_line_item.py
@@ -5,7 +5,7 @@ TEST_INVOICE_ID = "in_123"
 
 
 class TestInvoiceLineItem(object):
-    def test_deserialize(self):
+    def test_deserialize(self, http_client_mock):
         invoice = stripe.Invoice.retrieve(TEST_INVOICE_ID)
         assert isinstance(invoice.lines.data, list)
         assert isinstance(invoice.lines.data[0], stripe.InvoiceLineItem)


### PR DESCRIPTION
These two test methods do not mock, which also means they are not skipped if the mocking server is not running. Sprinkle in the mocking.