### PR TITLE
Allow setting api_key, stripe_version, and stripe_account on StripeObject

### DIFF
--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -41,7 +41,7 @@ from stripe._requestor_options import (
 from stripe._http_client import HTTPClient, new_default_http_client
 from stripe._app_info import AppInfo
 
-from stripe._base_address import BaseAddress, BaseAddresses
+from stripe._base_address import BaseAddress
 from stripe._api_mode import ApiMode
 from stripe import _util
 
@@ -108,33 +108,17 @@ class APIRequestor(object):
     def api_key(self):
         return self._options.api_key
 
-    @api_key.setter
-    def api_key(self, value):
-        self._options.api_key = value
-
     @property
     def stripe_account(self):
         return self._options.stripe_account
-
-    @stripe_account.setter
-    def stripe_account(self, value: Optional[str]):
-        self._options.stripe_account = value
 
     @property
     def stripe_version(self):
         return self._options.stripe_version
 
-    @stripe_version.setter
-    def stripe_version(self, value: Optional[str]):
-        self._options.stripe_version = value
-
     @property
     def base_addresses(self):
         return self._options.base_addresses
-
-    @base_addresses.setter
-    def base_addresses(self, value: BaseAddresses):
-        self._options.base_addresses = value
 
     @classmethod
     def _global_instance(cls):

--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -41,7 +41,7 @@ from stripe._requestor_options import (
 from stripe._http_client import HTTPClient, new_default_http_client
 from stripe._app_info import AppInfo
 
-from stripe._base_address import BaseAddress
+from stripe._base_address import BaseAddress, BaseAddresses
 from stripe._api_mode import ApiMode
 from stripe import _util
 
@@ -108,17 +108,33 @@ class APIRequestor(object):
     def api_key(self):
         return self._options.api_key
 
+    @api_key.setter
+    def api_key(self, value):
+        self._options.api_key = value
+
     @property
     def stripe_account(self):
         return self._options.stripe_account
+
+    @stripe_account.setter
+    def stripe_account(self, value: Optional[str]):
+        self._options.stripe_account = value
 
     @property
     def stripe_version(self):
         return self._options.stripe_version
 
+    @stripe_version.setter
+    def stripe_version(self, value: Optional[str]):
+        self._options.stripe_version = value
+
     @property
     def base_addresses(self):
         return self._options.base_addresses
+
+    @base_addresses.setter
+    def base_addresses(self, value: BaseAddresses):
+        self._options.base_addresses = value
 
     @classmethod
     def _global_instance(cls):

--- a/stripe/_stripe_object.py
+++ b/stripe/_stripe_object.py
@@ -161,7 +161,7 @@ class StripeObject(Dict[str, Any]):
 
         def __setattr__(self, k, v):
             if k in {"api_key", "stripe_account", "stripe_version"}:
-                self._requestor.__setattr__(k, v)
+                self._requestor = self._requestor._replace_options({k: v})
                 return None
 
             if k[0] == "_" or k in self.__dict__:

--- a/stripe/_stripe_object.py
+++ b/stripe/_stripe_object.py
@@ -164,10 +164,7 @@ class StripeObject(Dict[str, Any]):
                 self._requestor.__setattr__(k, v)
                 return None
 
-            if (
-                k[0] == "_"
-                or k in self.__dict__
-            ):
+            if k[0] == "_" or k in self.__dict__:
                 return super(StripeObject, self).__setattr__(k, v)
 
             self[k] = v

--- a/stripe/_stripe_object.py
+++ b/stripe/_stripe_object.py
@@ -135,13 +135,25 @@ class StripeObject(Dict[str, Any]):
     def api_key(self):
         return self._requestor.api_key
 
+    @api_key.setter
+    def api_key(self, value: Optional[str]):
+        self._requestor.api_key = value
+
     @property
     def stripe_account(self):
         return self._requestor.stripe_account
 
+    @stripe_account.setter
+    def stripe_account(self, value: Optional[str]):
+        self._requestor.stripe_account = value
+
     @property
     def stripe_version(self):
         return self._requestor.stripe_version
+
+    @stripe_version.setter
+    def stripe_version(self, value: Optional[str]):
+        self._requestor.stripe_version = value
 
     @property
     def last_response(self) -> Optional[StripeResponse]:
@@ -160,7 +172,11 @@ class StripeObject(Dict[str, Any]):
     if not TYPE_CHECKING:
 
         def __setattr__(self, k, v):
-            if k[0] == "_" or k in self.__dict__:
+            if (
+                k[0] == "_"
+                or k in self.__dict__
+                or k in {"api_key", "stripe_account", "stripe_version"}
+            ):
                 return super(StripeObject, self).__setattr__(k, v)
 
             self[k] = v

--- a/stripe/_stripe_object.py
+++ b/stripe/_stripe_object.py
@@ -135,25 +135,13 @@ class StripeObject(Dict[str, Any]):
     def api_key(self):
         return self._requestor.api_key
 
-    @api_key.setter
-    def api_key(self, value: Optional[str]):
-        self._requestor.api_key = value
-
     @property
     def stripe_account(self):
         return self._requestor.stripe_account
 
-    @stripe_account.setter
-    def stripe_account(self, value: Optional[str]):
-        self._requestor.stripe_account = value
-
     @property
     def stripe_version(self):
         return self._requestor.stripe_version
-
-    @stripe_version.setter
-    def stripe_version(self, value: Optional[str]):
-        self._requestor.stripe_version = value
 
     @property
     def last_response(self) -> Optional[StripeResponse]:
@@ -172,10 +160,13 @@ class StripeObject(Dict[str, Any]):
     if not TYPE_CHECKING:
 
         def __setattr__(self, k, v):
+            if k in {"api_key", "stripe_account", "stripe_version"}:
+                self._requestor.__setattr__(k, v)
+                return None
+
             if (
                 k[0] == "_"
                 or k in self.__dict__
-                or k in {"api_key", "stripe_account", "stripe_version"}
             ):
                 return super(StripeObject, self).__setattr__(k, v)
 

--- a/tests/test_stripe_object.py
+++ b/tests/test_stripe_object.py
@@ -413,3 +413,19 @@ class TestStripeObject(object):
         assert orig_requestor is not new_requestor
         assert obj.api_key == "newkey"
         assert orig_requestor.api_key == "origkey"
+
+    def test_can_update_api_key(self, http_client_mock):
+        obj = stripe.stripe_object.StripeObject("id", "key")
+
+        http_client_mock.stub_request(
+            "get",
+            path="/foo",
+        )
+
+        obj.api_key = "key2"
+        obj.request("get", "/foo")
+
+        http_client_mock.assert_requested(
+            api_key="key2",
+            stripe_account=None,
+        )

--- a/tests/test_stripe_object.py
+++ b/tests/test_stripe_object.py
@@ -425,6 +425,8 @@ class TestStripeObject(object):
         obj.api_key = "key2"
         obj.request("get", "/foo")
 
+        assert "api_key" not in obj.items()
+
         http_client_mock.assert_requested(
             api_key="key2",
             stripe_account=None,


### PR DESCRIPTION
Re: https://github.com/stripe/stripe-python/pull/1200/files#r1462439802

While looking through https://github.com/stripe/stripe-python/pull/1200 for breaking changes, I discovered that changing ["api_key", "stripe_account", and "stripe_version" attributes to _properties_ ](https://github.com/stripe/stripe-python/pull/1200/files#diff-fa6c706090a75f1b4f7a788687aeaa3d36d89fa1b9fc34b98794094984881345R130-R145)on the StripeObject (and APIRequestor) would break anyone who might be setting those attributes on an API resource in a confusing way.

The following code snippet uses "new_key" in the current version of stripe-python master, but uses "old_key" in the implementation in https://github.com/stripe/stripe-python/pull/1200:
```python
stripe.api_key = "old_key"

cus = stripe.Customer.retrieve("cus_123")
cus.api_key = "new_key"
cus.delete()  # Should use new_key?
```
Even more confusingly, the implementation in https://github.com/stripe/stripe-python/pull/1200 causes `"api_key"` to be set on the underlying dictionary of the StripeObject:
```python
>>> cus
<Customer customer id=cus_123 at 0x105c6c900> JSON: {
  "address": null,
  "api_key": "sk_test_123",
  "balance": 0,
  ...
}
```

### Alternatives considered
Keep the behavior as is in https://github.com/stripe/stripe-python/pull/1200, knowing that "api_key", etc. will no longer be settable on the StripeObject's requestor. However, I think it's worth supporting this setting behavior so users don't encounter the silent behavioral change outlined above.