### PR TITLE
Deprecate `StripeObject.request`

### DIFF
--- a/stripe/_charge.py
+++ b/stripe/_charge.py
@@ -2364,9 +2364,7 @@ class Charge(
             "idempotency_key": idempotency_key,
         }
         url = self.instance_url()
-        self._refresh_from(
-            values=self.request("post", url, params), api_mode="V1"
-        )
+        self._request_and_refresh("post", url, params)
         return self
 
     def mark_as_safe(self, idempotency_key=None) -> "Charge":
@@ -2375,9 +2373,7 @@ class Charge(
             "idempotency_key": idempotency_key,
         }
         url = self.instance_url()
-        self._refresh_from(
-            values=self.request("post", url, params), api_mode="V1"
-        )
+        self._request_and_refresh("post", url, params)
         return self
 
     _inner_class_types = {

--- a/stripe/_source.py
+++ b/stripe/_source.py
@@ -1271,9 +1271,7 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
             owner_extn = quote_plus(customer)
             url = "%s/%s/sources/%s" % (base, owner_extn, extn)
 
-            self._refresh_from(
-                values=self.request("delete", url, params), api_mode="V1"
-            )
+            self._request_and_refresh("delete", url, params)
             return cast("Source", self)
 
         else:

--- a/stripe/_stripe_object.py
+++ b/stripe/_stripe_object.py
@@ -383,6 +383,27 @@ class StripeObject(Dict[str, Any]):
     def api_base(cls) -> Optional[str]:
         return None
 
+    @_util.deprecated(
+        "This will be removed in a future version of stripe-python."
+    )
+    def request(
+        self,
+        method: Literal["get", "post", "delete"],
+        url: str,
+        params: Optional[Dict[str, Any]] = None,
+        *,
+        base_address: BaseAddress = "api",
+        api_mode: ApiMode = "V1",
+    ) -> "StripeObject":
+        return StripeObject._request(
+            self,
+            method,
+            url,
+            params=params,
+            base_address=base_address,
+            api_mode=api_mode,
+        )
+
     # The `method_` and `url_` arguments are suffixed with an underscore to
     # avoid conflicting with actual request parameters in `params`.
     def _request(

--- a/stripe/_stripe_object.py
+++ b/stripe/_stripe_object.py
@@ -383,24 +383,6 @@ class StripeObject(Dict[str, Any]):
     def api_base(cls) -> Optional[str]:
         return None
 
-    def request(
-        self,
-        method: Literal["get", "post", "delete"],
-        url: str,
-        params: Optional[Dict[str, Any]] = None,
-        *,
-        base_address: BaseAddress = "api",
-        api_mode: ApiMode = "V1",
-    ) -> "StripeObject":
-        return StripeObject._request(
-            self,
-            method,
-            url,
-            params=params,
-            base_address=base_address,
-            api_mode=api_mode,
-        )
-
     # The `method_` and `url_` arguments are suffixed with an underscore to
     # avoid conflicting with actual request parameters in `params`.
     def _request(

--- a/tests/test_stripe_object.py
+++ b/tests/test_stripe_object.py
@@ -392,7 +392,7 @@ class TestStripeObject(object):
             path="/foo",
         )
 
-        obj.request("get", "/foo")
+        obj._request("get", "/foo", base_address="api", api_mode="V1")
 
         http_client_mock.assert_requested(
             api_key="key",
@@ -423,7 +423,7 @@ class TestStripeObject(object):
         )
 
         obj.api_key = "key2"
-        obj.request("get", "/foo")
+        obj._request("get", "/foo", base_address="api", api_mode="V1")
 
         assert "api_key" not in obj.items()
 


### PR DESCRIPTION
And remove internal usages. This was only used in `Charge.mark_as_safe / Charge.mark_as_fraudulent` and `Source.detach` to accomplish the same behavior already provided by `_request_and_refresh`.