### PR TITLE
Remove more deprecated methods

### DIFF
--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -43,7 +43,6 @@ from stripe._app_info import AppInfo
 
 from stripe._base_address import BaseAddress
 from stripe._api_mode import ApiMode
-from stripe import _util
 
 if TYPE_CHECKING:
     from stripe._stripe_object import StripeObject

--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -144,13 +144,6 @@ class APIRequestor(object):
         return APIRequestor._global_instance()._replace_options(params)
 
     @classmethod
-    @_util.deprecated(
-        "This method is internal to stripe-python and the public interface will be removed in a future stripe-python version"
-    )
-    def format_app_info(cls, info):
-        return cls._format_app_info(info)
-
-    @classmethod
     def _format_app_info(cls, info):
         str = info["name"]
         if info["version"]:

--- a/stripe/_error.py
+++ b/stripe/_error.py
@@ -71,10 +71,7 @@ class StripeError(Exception):
             self.request_id,
         )
 
-    @_util.deprecated(
-        "For internal stripe-python use only. The public interface will be removed in a future version."
-    )
-    def construct_error_object(self) -> Optional[ErrorObject]:
+    def _construct_error_object(self) -> Optional[ErrorObject]:
         if (
             self.json_body is None
             or not isinstance(self.json_body, dict)
@@ -88,11 +85,6 @@ class StripeError(Exception):
             requestor=stripe.APIRequestor._global_instance(),
             api_mode="V1",
         )
-
-    def _construct_error_object(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            return self.construct_error_object()
 
 
 class APIError(StripeError):

--- a/stripe/_error.py
+++ b/stripe/_error.py
@@ -4,9 +4,6 @@ from typing import Dict, Optional, Union, cast
 import stripe  # noqa: IMP101
 from stripe._error_object import ErrorObject
 
-from stripe import _util
-import warnings
-
 
 class StripeError(Exception):
     _message: Optional[str]

--- a/stripe/_list_object.py
+++ b/stripe/_list_object.py
@@ -12,13 +12,9 @@ from typing import (
     cast,
     Mapping,
 )
-from stripe import _util
 from stripe._api_requestor import APIRequestor
 from stripe._stripe_object import StripeObject
 from stripe._request_options import RequestOptions, extract_options_from_dict
-
-from urllib.parse import quote_plus
-import warnings
 
 T = TypeVar("T", bound=StripeObject)
 
@@ -30,16 +26,6 @@ class ListObject(StripeObject, Generic[T]):
     url: str
 
     def _list(self, **params: Mapping[str, Any]) -> Self:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=DeprecationWarning)
-            return self.list(  # pyright: ignore[reportDeprecated]
-                **params,
-            )
-
-    @_util.deprecated(
-        "This will be removed in a future version of stripe-python. Please call the `list` method on the corresponding resource directly, instead of using `list` from the list object."
-    )
-    def list(self, **params: Mapping[str, Any]) -> Self:
         url = self.get("url")
         if not isinstance(url, str):
             raise ValueError(
@@ -47,48 +33,6 @@ class ListObject(StripeObject, Generic[T]):
             )
         return cast(
             Self,
-            self._request(
-                "get",
-                url,
-                params=params,
-                base_address="api",
-                api_mode="V1",
-            ),
-        )
-
-    @_util.deprecated(
-        "This will be removed in a future version of stripe-python. Please call the `create` method on the corresponding resource directly, instead of using `create` from the list object."
-    )
-    def create(self, **params: Mapping[str, Any]) -> T:
-        url = self.get("url")
-        if not isinstance(url, str):
-            raise ValueError(
-                'Cannot call .create on a list object for the collection of an object without a string "url" property'
-            )
-        return cast(
-            T,
-            self._request(
-                "post",
-                url,
-                params=params,
-                base_address="api",
-                api_mode="V1",
-            ),
-        )
-
-    @_util.deprecated(
-        "This will be removed in a future version of stripe-python. Please call the `retrieve` method on the corresponding resource directly, instead of using `retrieve` from the list object."
-    )
-    def retrieve(self, id: str, **params: Mapping[str, Any]):
-        url = self.get("url")
-        if not isinstance(url, str):
-            raise ValueError(
-                'Cannot call .retrieve on a list object for the collection of an object without a string "url" property'
-            )
-
-        url = "%s/%s" % (self.get("url"), quote_plus(id))
-        return cast(
-            T,
             self._request(
                 "get",
                 url,
@@ -141,16 +85,6 @@ class ListObject(StripeObject, Generic[T]):
 
             if page.is_empty:
                 break
-
-    @classmethod
-    @_util.deprecated(
-        "This method is for internal stripe-python use only. The public interface will be removed in a future version."
-    )
-    def empty_list(
-        cls,
-        **params: Unpack[RequestOptions],
-    ) -> Self:
-        return cls._empty_list(**params)
 
     @classmethod
     def _empty_list(

--- a/stripe/_search_result_object.py
+++ b/stripe/_search_result_object.py
@@ -12,6 +12,8 @@ from typing import (
 
 from stripe._api_requestor import APIRequestor
 from stripe._stripe_object import StripeObject
+from stripe import _util
+import warnings
 from stripe._request_options import RequestOptions, extract_options_from_dict
 
 T = TypeVar("T", bound=StripeObject)
@@ -24,6 +26,16 @@ class SearchResultObject(StripeObject, Generic[T]):
     next_page: str
 
     def _search(self, **params: Mapping[str, Any]) -> Self:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            return self.search(  # pyright: ignore[reportDeprecated]
+                **params,
+            )
+
+    @_util.deprecated(
+        "This will be removed in a future version of stripe-python. Please call the `search` method on the corresponding resource directly, instead of the generic search on SearchResultObject."
+    )
+    def search(self, **params: Mapping[str, Any]) -> Self:
         url = self.get("url")
         if not isinstance(url, str):
             raise ValueError(

--- a/stripe/_search_result_object.py
+++ b/stripe/_search_result_object.py
@@ -12,8 +12,6 @@ from typing import (
 
 from stripe._api_requestor import APIRequestor
 from stripe._stripe_object import StripeObject
-from stripe import _util
-import warnings
 from stripe._request_options import RequestOptions, extract_options_from_dict
 
 T = TypeVar("T", bound=StripeObject)
@@ -26,16 +24,6 @@ class SearchResultObject(StripeObject, Generic[T]):
     next_page: str
 
     def _search(self, **params: Mapping[str, Any]) -> Self:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            return self.search(  # pyright: ignore[reportDeprecated]
-                **params,
-            )
-
-    @_util.deprecated(
-        "This will be removed in a future version of stripe-python. Please call the `search` method on the corresponding resource directly, instead of the generic search on SearchResultObject."
-    )
-    def search(self, **params: Mapping[str, Any]) -> Self:
         url = self.get("url")
         if not isinstance(url, str):
             raise ValueError(
@@ -95,18 +83,6 @@ class SearchResultObject(StripeObject, Generic[T]):
                 **params,
             ),
             api_mode="V1",
-        )
-
-    @classmethod
-    @_util.deprecated(
-        "For internal stripe-python use only. This will be removed in a future version."
-    )
-    def empty_search_result(
-        cls,
-        **params: Unpack[RequestOptions],
-    ) -> Self:
-        return cls._empty_search_result(
-            **params,
         )
 
     @property

--- a/stripe/_stripe_object.py
+++ b/stripe/_stripe_object.py
@@ -84,12 +84,6 @@ class StripeObject(Dict[str, Any]):
                 return _encode_datetime(o)
             return super(StripeObject._ReprJSONEncoder, self).default(o)
 
-    @_util.deprecated(
-        "For internal stripe-python use only. The public interface will be removed in a future version"
-    )
-    class ReprJSONEncoder(_ReprJSONEncoder):
-        pass
-
     _retrieve_params: Mapping[str, Any]
     _previous: Optional[Mapping[str, Any]]
 
@@ -375,13 +369,6 @@ class StripeObject(Dict[str, Any]):
             super(StripeObject, self).__setitem__(k, obj)
 
         self._previous = values
-
-    @classmethod
-    @_util.deprecated(
-        "This will be removed in a future version of stripe-python."
-    )
-    def api_base(cls) -> Optional[str]:
-        return None
 
     @_util.deprecated(
         "This will be removed in a future version of stripe-python."

--- a/stripe/oauth_error.py
+++ b/stripe/oauth_error.py
@@ -17,7 +17,7 @@ class OAuthError(StripeError):
             description, http_body, http_status, json_body, headers, code
         )
 
-    def construct_error_object(self):
+    def _construct_error_object(self):
         if self.json_body is None:
             return None
 

--- a/tests/api_resources/test_list_object.py
+++ b/tests/api_resources/test_list_object.py
@@ -90,7 +90,7 @@ class TestListObject(object):
         assert lo.is_empty is True
 
     def test_empty_list(self):
-        lo = stripe.ListObject.empty_list()
+        lo = stripe.ListObject._empty_list()
         assert lo.is_empty
 
     def test_iter(self):
@@ -176,7 +176,7 @@ class TestListObject(object):
         )
 
         next_lo = lo.next_page()
-        assert next_lo == stripe.ListObject.empty_list()
+        assert next_lo == stripe.ListObject._empty_list()
 
     def test_prev_page(self, http_client_mock):
         lo = stripe.ListObject.construct_from(

--- a/tests/api_resources/test_search_result_object.py
+++ b/tests/api_resources/test_search_result_object.py
@@ -47,7 +47,7 @@ class TestSearchResultObject(object):
         assert sro.is_empty is True
 
     def test_empty_search_result(self):
-        sro = stripe.SearchResultObject.empty_search_result()
+        sro = stripe.SearchResultObject._empty_search_result()
         assert sro.is_empty
 
     def test_iter(self):
@@ -149,7 +149,7 @@ class TestSearchResultObject(object):
         )
 
         next_sro = sro.next_search_result_page()
-        assert next_sro == stripe.SearchResultObject.empty_search_result()
+        assert next_sro == stripe.SearchResultObject._empty_search_result()
 
     def test_serialize_empty_search_result(self):
         empty = stripe.SearchResultObject.construct_from(


### PR DESCRIPTION
Did an audit of methods / classes with `@_util.deprecated` decorators. I removed ones that were for internal stripe-python use only (like `ListObject.empty_list()`), as well as interfaces that will already be broken since we made request options keyword-only in https://github.com/stripe/stripe-python/pull/1200.

## Changelog
* ⚠️ Remove `APIRequestor.format_app_info()`. This method was intended for internal stripe-python use only.
* ⚠️ Remove `StripeError.construct_error_object()`. This method was intended for internal stripe-python use only.
* ⚠️ Remove `ListObject.empty_list()`. This method was intended for internal stripe-python use only.
* ⚠️ Remove `SearchResultObject.empty_search_result()`. This method was intended for internal stripe-python use only.
* ⚠️ Remove `StripeObject.ReprJSONEncoder`. This class was intended for internal stripe-python use only.
* ⚠️ Remove `StripeObject.api_base`. This property was defunct and returned `None`.