### PR TITLE
Beta: better support for trio in HTTPClientAsync

### DIFF
--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -986,8 +986,16 @@ class HTTPXClient(HTTPClientAsync):
     ):
         super(HTTPXClient, self).__init__(**kwargs)
 
-        assert httpx is not None
-        assert anyio is not None
+        if httpx is None:
+            raise ImportError(
+                "Unexpected: tried to initialize HTTPXClient but the httpx module is not present."
+            )
+
+        if anyio is None:
+            raise ImportError(
+                "Unexpected: tried to initialize HTTPXClient but the anyio module is not present."
+            )
+
         self.httpx = httpx
         self.anyio = anyio
 

--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -5,7 +5,6 @@ import time
 import random
 import threading
 import json
-import asyncio
 
 # Used for global variables
 import stripe  # noqa: IMP101

--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -51,9 +51,11 @@ except ImportError:
 
 try:
     import httpx
+    import anyio
     from httpx import Timeout as HTTPXTimeout
 except ImportError:
     httpx = None
+    anyio = None
 
 try:
     import requests
@@ -986,7 +988,9 @@ class HTTPXClient(HTTPClientAsync):
         super(HTTPXClient, self).__init__(**kwargs)
 
         assert httpx is not None
+        assert anyio is not None
         self.httpx = httpx
+        self.anyio = anyio
 
         kwargs = {}
         if self._verify_ssl_certs:
@@ -998,7 +1002,7 @@ class HTTPXClient(HTTPClientAsync):
         self._timeout = timeout
 
     def sleep_async(self, secs):
-        return asyncio.sleep(secs)
+        return self.anyio.sleep(secs)
 
     async def request_async(
         self, method, url, headers, post_data=None, timeout=80.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,6 +2,7 @@
 
 # This is the last version of httpx compatible with Python 3.6
 httpx == 0.22.0
+anyio[trio] == 3.7.1
 
 pytest-cov >= 2.8.1, < 2.11.0
 pytest-mock >= 2.0.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,8 +2,6 @@
 
 # This is the last version of httpx compatible with Python 3.6
 httpx == 0.22.0
-# This is the last version of pytest-asyncio compatible with Python 3.6
-pytest-asyncio == 0.16.0
 
 pytest-cov >= 2.8.1, < 2.11.0
 pytest-mock >= 2.0.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@
 
 # This is the last version of httpx compatible with Python 3.6
 httpx == 0.22.0
-anyio[trio] == 3.7.1
+anyio[trio] == 3.6.2
 
 pytest-cov >= 2.8.1, < 2.11.0
 pytest-mock >= 2.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from tests.stripe_mock import StripeMock
 from tests.http_client_mock import HTTPClientMock
 
 
-pytest_plugins = ("pytest_asyncio",)
+pytest_plugins = ("anyio",)
 
 
 MOCK_MINIMUM_VERSION = "0.109.0"

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1205,7 +1205,7 @@ class TestHTTPXClient(StripeClientTestCase, ClientTestBaseAsync):
             method, url, headers, post_data
         )
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_request(self, request_mock, mock_response, check_call):
 
         mock_response('{"foo": "baz"}', 200)
@@ -1227,7 +1227,7 @@ class TestHTTPXClient(StripeClientTestCase, ClientTestBaseAsync):
 
             check_call(request_mock, method, abs_url, data, headers)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_request_stream(
         self, mocker, request_mock, mock_response, check_call
     ):
@@ -1239,7 +1239,7 @@ class TestHTTPXClient(StripeClientTestCase, ClientTestBaseAsync):
         with pytest.raises(stripe.APIConnectionError):
             await self.make_request_async("get", self.valid_url, {}, None)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_timeout(self, request_mock, mock_response, check_call):
         headers = {"my-header": "header val"}
         data = {}
@@ -1250,7 +1250,7 @@ class TestHTTPXClient(StripeClientTestCase, ClientTestBaseAsync):
 
         check_call(None, "POST", self.valid_url, data, headers, timeout=5)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_request_stream_forwards_stream_param(
         self, mocker, request_mock, mock_response, check_call
     ):
@@ -1336,7 +1336,7 @@ class TestHTTPXClientRetryBehavior(TestHTTPXClient):
             "GET", self.valid_url, {}, None, self.max_retries()
         )
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_retry_error_until_response(
         self, mock_retry, mock_response, check_call_numbers, mocker
     ):
@@ -1345,7 +1345,7 @@ class TestHTTPXClientRetryBehavior(TestHTTPXClient):
         assert code == 202
         check_call_numbers(2)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_retry_error_until_exceeded(
         self, mock_retry, mock_response, check_call_numbers
     ):
@@ -1355,7 +1355,7 @@ class TestHTTPXClientRetryBehavior(TestHTTPXClient):
 
         check_call_numbers(self.max_retries())
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_retry_error(
         self, mock_retry, mock_response, check_call_numbers
     ):
@@ -1364,7 +1364,7 @@ class TestHTTPXClientRetryBehavior(TestHTTPXClient):
             await self.make_request()
         check_call_numbers(1)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_retry_codes(
         self, mock_retry, mock_response, check_call_numbers
     ):
@@ -1375,7 +1375,7 @@ class TestHTTPXClientRetryBehavior(TestHTTPXClient):
         assert code == 202
         check_call_numbers(2)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_retry_codes_until_exceeded(
         self, mock_retry, mock_response, check_call_numbers
     ):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -366,7 +366,7 @@ class TestIntegration(object):
 
         assert req.path == "/v1/customers"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_async_httpx_raw_request_unretryable(self):
         class MockServerRequestHandler(MyTestHandler):
             def do_request(self, n):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -291,7 +291,7 @@ class TestIntegration(object):
         assert MockServerRequestHandler.num_requests == 20
         assert len(MockServerRequestHandler.seen_metrics) == 10
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_async_raw_request_success(self):
         class MockServerRequestHandler(MyTestHandler):
             default_body = '{"id": "cus_123", "object": "customer"}'.encode(
@@ -315,7 +315,7 @@ class TestIntegration(object):
         assert req.command == "POST"
         assert isinstance(cus, stripe.Customer)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_async_raw_request_timeout(self):
         class MockServerRequestHandler(MyTestHandler):
             def do_request(self, n):
@@ -340,7 +340,7 @@ class TestIntegration(object):
 
         assert "A ReadTimeout was raised" in str(exception.user_message)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_async_httpx_raw_request_retries(self):
         class MockServerRequestHandler(MyTestHandler):
             def do_request(self, n):

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -75,7 +75,7 @@ class TestPreview(object):
 
         assert resp.body == expected_body
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_async(self, http_client_mock_async):
         expected_body = '{"id": "acc_123"}'
         http_client_mock_async.stub_request(
@@ -98,7 +98,7 @@ class TestPreview(object):
 
         assert resp.body == expected_body
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_post_async(self, http_client_mock_async):
         expected_body = '{"id": "acc_123"}'
         http_client_mock_async.stub_request(
@@ -124,7 +124,7 @@ class TestPreview(object):
 
         assert resp.body == expected_body
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_delete_async(self, http_client_mock_async):
         expected_body = '{"id": "acc_123"}'
         http_client_mock_async.stub_request(

--- a/tests/test_raw_request.py
+++ b/tests/test_raw_request.py
@@ -148,7 +148,7 @@ class TestRawRequest(object):
             is_json=True,
         )
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_form_request_get_async(self, http_client_mock_async):
         http_client_mock_async.stub_request(
             "get",


### PR DESCRIPTION
## Changelog
  * Fixes support for `trio` on HttpClientAsync.

## Details
Acts on suggestions by @zac-hd on https://github.com/stripe/stripe-python/issues/327#issuecomment-1907298722.
  * Requires that the `anyio` module be available alongside `httpx` as a prerequisite for using the async HTTPX client. HTTPX has a dependency on anyio anyway, so there is no downside to this.
  * Changes the usage of `asyncio.sleep` to `anyio.sleep` -- this means that users of `trio` and `asyncio` will both be able to use the httpx client without any additional configuration.
  * Starts running all the async test cases with against both `asyncio` and `trio` backends. This is accomplished by adding the `pytest.mark.anyio` marker on all the asynchronous tests (where previously I was using the pytest-asyncio marker). The pytest integration comes bundled in with `anyio` (which I have added to the test dependencies), and is described at https://anyio.readthedocs.io/en/stable/testing.html. The default behavior of this marker is to run everything on all supported backends (so both asyncio and trio). I can confirm that tests are indeed running with trio, because I had errors when I only did `pip install anyio` instead of `pip install anyio[trio]`.

##
 
