### PR TITLE
Refactors for beta

### DIFF
--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -366,18 +366,17 @@ class _APIRequestor(object):
 
         return headers
 
-    def request_raw(
+    def _args_for_request_with_retries(
         self,
         method: str,
         url: str,
         params: Optional[Mapping[str, Any]] = None,
         options: Optional[RequestOptions] = None,
-        is_streaming: bool = False,
         *,
         base_address: BaseAddress,
         api_mode: ApiMode,
         _usage: Optional[List[str]] = None,
-    ) -> Tuple[object, int, Mapping[str, str]]:
+    ):
         """
         Mechanism for issuing an API call
         """
@@ -453,6 +452,57 @@ class _APIRequestor(object):
             api_version=request_options.get("stripe_version"),
         )
 
+        max_network_retries = request_options.get("max_network_retries")
+
+        return (
+            # Actual args
+            method,
+            abs_url,
+            headers,
+            post_data,
+            max_network_retries,
+            _usage,
+            # For logging
+            encoded_params,
+            request_options.get("stripe_version"),
+        )
+
+    def request_raw(
+        self,
+        method: str,
+        url: str,
+        params: Optional[Mapping[str, Any]] = None,
+        options: Optional[RequestOptions] = None,
+        is_streaming: bool = False,
+        *,
+        base_address: BaseAddress,
+        api_mode: ApiMode,
+        _usage: Optional[List[str]] = None,
+    ) -> Tuple[object, int, Mapping[str, str]]:
+        (
+            method,
+            abs_url,
+            headers,
+            post_data,
+            max_network_retries,
+            _usage,
+            encoded_params,
+            api_version,
+        ) = self._args_for_request_with_retries(
+            method,
+            url,
+            params,
+            options,
+            base_address=base_address,
+            api_mode=api_mode,
+            _usage=_usage,
+        )
+
+        log_info("Request to Stripe api", method=method, url=abs_url)
+        log_debug(
+            "Post details", post_data=encoded_params, api_version=api_version
+        )
+
         if is_streaming:
             (
                 rcontent,
@@ -460,10 +510,10 @@ class _APIRequestor(object):
                 rheaders,
             ) = self._get_http_client().request_stream_with_retries(
                 method,
-                abs_url,
+                url,
                 headers,
-                post_data,
-                max_network_retries=request_options.get("max_network_retries"),
+                post_data=post_data,
+                max_network_retries=max_network_retries,
                 _usage=_usage,
             )
         else:
@@ -473,10 +523,10 @@ class _APIRequestor(object):
                 rheaders,
             ) = self._get_http_client().request_with_retries(
                 method,
-                abs_url,
+                url,
                 headers,
-                post_data,
-                max_network_retries=request_options.get("max_network_retries"),
+                post_data=post_data,
+                max_network_retries=max_network_retries,
                 _usage=_usage,
             )
 

--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -445,13 +445,6 @@ class _APIRequestor(object):
             for key, value in supplied_headers.items():
                 headers[key] = value
 
-        log_info("Request to Stripe api", method=method, url=abs_url)
-        log_debug(
-            "Post details",
-            post_data=encoded_params,
-            api_version=request_options.get("stripe_version"),
-        )
-
         max_network_retries = request_options.get("max_network_retries")
 
         return (
@@ -510,9 +503,9 @@ class _APIRequestor(object):
                 rheaders,
             ) = self._get_http_client().request_stream_with_retries(
                 method,
-                url,
+                abs_url,
                 headers,
-                post_data=post_data,
+                post_data,
                 max_network_retries=max_network_retries,
                 _usage=_usage,
             )
@@ -523,9 +516,9 @@ class _APIRequestor(object):
                 rheaders,
             ) = self._get_http_client().request_with_retries(
                 method,
-                url,
+                abs_url,
                 headers,
-                post_data=post_data,
+                post_data,
                 max_network_retries=max_network_retries,
                 _usage=_usage,
             )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -20,7 +20,7 @@ else:
     from http.server import BaseHTTPRequestHandler, HTTPServer
 
 
-class TestHandler(BaseHTTPRequestHandler):
+class MyTestHandler(BaseHTTPRequestHandler):
     num_requests = 0
 
     requests = defaultdict(Queue)
@@ -118,7 +118,7 @@ class TestIntegration(object):
         self.mock_server_thread.start()
 
     def test_hits_api_base(self):
-        class MockServerRequestHandler(TestHandler):
+        class MockServerRequestHandler(MyTestHandler):
             pass
 
         self.setup_mock_server(MockServerRequestHandler)
@@ -129,7 +129,7 @@ class TestIntegration(object):
         assert reqs[0].path == "/v1/balance"
 
     def test_hits_proxy_through_default_http_client(self):
-        class MockServerRequestHandler(TestHandler):
+        class MockServerRequestHandler(MyTestHandler):
             pass
 
         self.setup_mock_server(MockServerRequestHandler)
@@ -150,7 +150,7 @@ class TestIntegration(object):
         assert MockServerRequestHandler.num_requests == 2
 
     def test_hits_proxy_through_custom_client(self):
-        class MockServerRequestHandler(TestHandler):
+        class MockServerRequestHandler(MyTestHandler):
             pass
 
         self.setup_mock_server(MockServerRequestHandler)
@@ -164,7 +164,7 @@ class TestIntegration(object):
         assert MockServerRequestHandler.num_requests == 1
 
     def test_hits_proxy_through_stripe_client_proxy(self):
-        class MockServerRequestHandler(TestHandler):
+        class MockServerRequestHandler(MyTestHandler):
             pass
 
         self.setup_mock_server(MockServerRequestHandler)
@@ -179,7 +179,7 @@ class TestIntegration(object):
         assert MockServerRequestHandler.num_requests == 1
 
     def test_hits_proxy_through_stripe_client_http_client(self):
-        class MockServerRequestHandler(TestHandler):
+        class MockServerRequestHandler(MyTestHandler):
             pass
 
         self.setup_mock_server(MockServerRequestHandler)
@@ -196,7 +196,7 @@ class TestIntegration(object):
         assert MockServerRequestHandler.num_requests == 1
 
     def test_passes_client_telemetry_when_enabled(self):
-        class MockServerRequestHandler(TestHandler):
+        class MockServerRequestHandler(MyTestHandler):
             def do_request(self, req_num):
                 if req_num == 0:
                     time.sleep(31 / 1000)  # 31 ms
@@ -248,7 +248,7 @@ class TestIntegration(object):
         assert "usage" not in metrics
 
     def test_uses_thread_local_client_telemetry(self):
-        class MockServerRequestHandler(TestHandler):
+        class MockServerRequestHandler(MyTestHandler):
             local_num_requests = 0
             seen_metrics = set()
             stats_lock = Lock()


### PR DESCRIPTION
When merging master into beta today (https://github.com/stripe/stripe-python/pull/1211) @anniel-stripe and I encountered some merge conflicts because `beta` branch had some refactoring that `master` branch did not. 

- Inside a test there is a `TestHandler` helper class. Python doesn't like that this begins with `Test` so in the beta branch this was renamed to `MyTestHandler`.
- There is a lot of code duplication between `APIRequestor.request_raw` and `APIRequestor.request_raw_async`. In the beta branch, a lot of the common logic was factored out. We undid this when resolving the merge conflict, but here is the same factoring out. You can see the full effect in the [beta branch](https://github.com/stripe/stripe-python/pull/new/richardm-refactors-for-beta-in-beta).