### PR TITLE
Standardize method implementations: sanitize_id

### DIFF
--- a/stripe/_account.py
+++ b/stripe/_account.py
@@ -21,7 +21,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._bank_account import BankAccount
@@ -3644,7 +3643,7 @@ class Account(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -3659,10 +3658,14 @@ class Account(
 
         If you want to delete your own account, use the [account information tab in your account settings](https://dashboard.stripe.com/settings/account) instead.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
         return cast(
             "Account",
-            cls._static_request("delete", url, params=params),
+            cls._static_request(
+                "delete",
+                url,
+                params=params,
+            ),
         )
 
     @overload
@@ -3863,7 +3866,7 @@ class Account(
         if not sid:
             return "/v1/account"
         base = cls.class_url()
-        extn = quote_plus(sid)
+        extn = _util.sanitize_id(sid)
         return "%s/%s" % (base, extn)
 
     def instance_url(self):

--- a/stripe/_account.py
+++ b/stripe/_account.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._expandable_field import ExpandableField
@@ -12,7 +11,7 @@ from stripe._person import Person
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, Union, cast, overload
 from typing_extensions import (
     Literal,
@@ -3658,7 +3657,7 @@ class Account(
 
         If you want to delete your own account, use the [account information tab in your account settings](https://dashboard.stripe.com/settings/account) instead.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(sid))
         return cast(
             "Account",
             cls._static_request(
@@ -3743,7 +3742,7 @@ class Account(
             cls._static_request(
                 "get",
                 "/v1/accounts/{account}/persons".format(
-                    account=_util.sanitize_id(account)
+                    account=sanitize_id(account)
                 ),
                 params=params,
             ),
@@ -3780,7 +3779,7 @@ class Account(
             self._request(
                 "get",
                 "/v1/accounts/{account}/persons".format(
-                    account=_util.sanitize_id(self.get("id"))
+                    account=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -3800,7 +3799,7 @@ class Account(
             cls._static_request(
                 "post",
                 "/v1/accounts/{account}/reject".format(
-                    account=_util.sanitize_id(account)
+                    account=sanitize_id(account)
                 ),
                 params=params,
             ),
@@ -3841,7 +3840,7 @@ class Account(
             self._request(
                 "post",
                 "/v1/accounts/{account}/reject".format(
-                    account=_util.sanitize_id(self.get("id"))
+                    account=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -3866,7 +3865,7 @@ class Account(
         if not sid:
             return "/v1/account"
         base = cls.class_url()
-        extn = _util.sanitize_id(sid)
+        extn = sanitize_id(sid)
         return "%s/%s" % (base, extn)
 
     def instance_url(self):
@@ -3901,8 +3900,8 @@ class Account(
             cls._static_request(
                 "get",
                 "/v1/accounts/{account}/capabilities/{capability}".format(
-                    account=_util.sanitize_id(account),
-                    capability=_util.sanitize_id(capability),
+                    account=sanitize_id(account),
+                    capability=sanitize_id(capability),
                 ),
                 params=params,
             ),
@@ -3923,8 +3922,8 @@ class Account(
             cls._static_request(
                 "post",
                 "/v1/accounts/{account}/capabilities/{capability}".format(
-                    account=_util.sanitize_id(account),
-                    capability=_util.sanitize_id(capability),
+                    account=sanitize_id(account),
+                    capability=sanitize_id(capability),
                 ),
                 params=params,
             ),
@@ -3942,7 +3941,7 @@ class Account(
             cls._static_request(
                 "get",
                 "/v1/accounts/{account}/capabilities".format(
-                    account=_util.sanitize_id(account)
+                    account=sanitize_id(account)
                 ),
                 params=params,
             ),
@@ -3962,7 +3961,7 @@ class Account(
             cls._static_request(
                 "post",
                 "/v1/accounts/{account}/external_accounts".format(
-                    account=_util.sanitize_id(account)
+                    account=sanitize_id(account)
                 ),
                 params=params,
             ),
@@ -3983,8 +3982,7 @@ class Account(
             cls._static_request(
                 "get",
                 "/v1/accounts/{account}/external_accounts/{id}".format(
-                    account=_util.sanitize_id(account),
-                    id=_util.sanitize_id(id),
+                    account=sanitize_id(account), id=sanitize_id(id)
                 ),
                 params=params,
             ),
@@ -4007,8 +4005,7 @@ class Account(
             cls._static_request(
                 "post",
                 "/v1/accounts/{account}/external_accounts/{id}".format(
-                    account=_util.sanitize_id(account),
-                    id=_util.sanitize_id(id),
+                    account=sanitize_id(account), id=sanitize_id(id)
                 ),
                 params=params,
             ),
@@ -4029,8 +4026,7 @@ class Account(
             cls._static_request(
                 "delete",
                 "/v1/accounts/{account}/external_accounts/{id}".format(
-                    account=_util.sanitize_id(account),
-                    id=_util.sanitize_id(id),
+                    account=sanitize_id(account), id=sanitize_id(id)
                 ),
                 params=params,
             ),
@@ -4050,7 +4046,7 @@ class Account(
             cls._static_request(
                 "get",
                 "/v1/accounts/{account}/external_accounts".format(
-                    account=_util.sanitize_id(account)
+                    account=sanitize_id(account)
                 ),
                 params=params,
             ),
@@ -4070,7 +4066,7 @@ class Account(
             cls._static_request(
                 "post",
                 "/v1/accounts/{account}/login_links".format(
-                    account=_util.sanitize_id(account)
+                    account=sanitize_id(account)
                 ),
                 params=params,
             ),
@@ -4088,7 +4084,7 @@ class Account(
             cls._static_request(
                 "post",
                 "/v1/accounts/{account}/persons".format(
-                    account=_util.sanitize_id(account)
+                    account=sanitize_id(account)
                 ),
                 params=params,
             ),
@@ -4109,8 +4105,7 @@ class Account(
             cls._static_request(
                 "get",
                 "/v1/accounts/{account}/persons/{person}".format(
-                    account=_util.sanitize_id(account),
-                    person=_util.sanitize_id(person),
+                    account=sanitize_id(account), person=sanitize_id(person)
                 ),
                 params=params,
             ),
@@ -4131,8 +4126,7 @@ class Account(
             cls._static_request(
                 "post",
                 "/v1/accounts/{account}/persons/{person}".format(
-                    account=_util.sanitize_id(account),
-                    person=_util.sanitize_id(person),
+                    account=sanitize_id(account), person=sanitize_id(person)
                 ),
                 params=params,
             ),
@@ -4153,8 +4147,7 @@ class Account(
             cls._static_request(
                 "delete",
                 "/v1/accounts/{account}/persons/{person}".format(
-                    account=_util.sanitize_id(account),
-                    person=_util.sanitize_id(person),
+                    account=sanitize_id(account), person=sanitize_id(person)
                 ),
                 params=params,
             ),
@@ -4172,7 +4165,7 @@ class Account(
             cls._static_request(
                 "get",
                 "/v1/accounts/{account}/persons".format(
-                    account=_util.sanitize_id(account)
+                    account=sanitize_id(account)
                 ),
                 params=params,
             ),

--- a/stripe/_account_capability_service.py
+++ b/stripe/_account_capability_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._capability import Capability
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -48,7 +48,7 @@ class AccountCapabilityService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/accounts/{account}/capabilities".format(
-                    account=_util.sanitize_id(account),
+                    account=sanitize_id(account),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -72,8 +72,8 @@ class AccountCapabilityService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/accounts/{account}/capabilities/{capability}".format(
-                    account=_util.sanitize_id(account),
-                    capability=_util.sanitize_id(capability),
+                    account=sanitize_id(account),
+                    capability=sanitize_id(capability),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -97,8 +97,8 @@ class AccountCapabilityService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/accounts/{account}/capabilities/{capability}".format(
-                    account=_util.sanitize_id(account),
-                    capability=_util.sanitize_id(capability),
+                    account=sanitize_id(account),
+                    capability=sanitize_id(capability),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_account_external_account_service.py
+++ b/stripe/_account_external_account_service.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._bank_account import BankAccount
 from stripe._card import Card
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, Union, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -217,8 +217,8 @@ class AccountExternalAccountService(StripeService):
             self._requestor.request(
                 "delete",
                 "/v1/accounts/{account}/external_accounts/{id}".format(
-                    account=_util.sanitize_id(account),
-                    id=_util.sanitize_id(id),
+                    account=sanitize_id(account),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -242,8 +242,8 @@ class AccountExternalAccountService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/accounts/{account}/external_accounts/{id}".format(
-                    account=_util.sanitize_id(account),
-                    id=_util.sanitize_id(id),
+                    account=sanitize_id(account),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -269,8 +269,8 @@ class AccountExternalAccountService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/accounts/{account}/external_accounts/{id}".format(
-                    account=_util.sanitize_id(account),
-                    id=_util.sanitize_id(id),
+                    account=sanitize_id(account),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -293,7 +293,7 @@ class AccountExternalAccountService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/accounts/{account}/external_accounts".format(
-                    account=_util.sanitize_id(account),
+                    account=sanitize_id(account),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -316,7 +316,7 @@ class AccountExternalAccountService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/accounts/{account}/external_accounts".format(
-                    account=_util.sanitize_id(account),
+                    account=sanitize_id(account),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_account_link.py
+++ b/stripe/_account_link.py
@@ -87,6 +87,6 @@ class AccountLink(CreateableAPIResource["AccountLink"]):
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )

--- a/stripe/_account_login_link_service.py
+++ b/stripe/_account_login_link_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._login_link import LoginLink
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -31,7 +31,7 @@ class AccountLoginLinkService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/accounts/{account}/login_links".format(
-                    account=_util.sanitize_id(account),
+                    account=sanitize_id(account),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_account_person_service.py
+++ b/stripe/_account_person_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._person import Person
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -828,8 +828,8 @@ class AccountPersonService(StripeService):
             self._requestor.request(
                 "delete",
                 "/v1/accounts/{account}/persons/{person}".format(
-                    account=_util.sanitize_id(account),
-                    person=_util.sanitize_id(person),
+                    account=sanitize_id(account),
+                    person=sanitize_id(person),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -853,8 +853,8 @@ class AccountPersonService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/accounts/{account}/persons/{person}".format(
-                    account=_util.sanitize_id(account),
-                    person=_util.sanitize_id(person),
+                    account=sanitize_id(account),
+                    person=sanitize_id(person),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -878,8 +878,8 @@ class AccountPersonService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/accounts/{account}/persons/{person}".format(
-                    account=_util.sanitize_id(account),
-                    person=_util.sanitize_id(person),
+                    account=sanitize_id(account),
+                    person=sanitize_id(person),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -902,7 +902,7 @@ class AccountPersonService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/accounts/{account}/persons".format(
-                    account=_util.sanitize_id(account),
+                    account=sanitize_id(account),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -925,7 +925,7 @@ class AccountPersonService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/accounts/{account}/persons".format(
-                    account=_util.sanitize_id(account),
+                    account=sanitize_id(account),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_account_service.py
+++ b/stripe/_account_service.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._account import Account
 from stripe._account_capability_service import AccountCapabilityService
 from stripe._account_external_account_service import (
@@ -11,6 +10,7 @@ from stripe._account_person_service import AccountPersonService
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -2958,9 +2958,7 @@ class AccountService(StripeService):
             Account,
             self._requestor.request(
                 "delete",
-                "/v1/accounts/{account}".format(
-                    account=_util.sanitize_id(account),
-                ),
+                "/v1/accounts/{account}".format(account=sanitize_id(account)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -2981,9 +2979,7 @@ class AccountService(StripeService):
             Account,
             self._requestor.request(
                 "get",
-                "/v1/accounts/{account}".format(
-                    account=_util.sanitize_id(account),
-                ),
+                "/v1/accounts/{account}".format(account=sanitize_id(account)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -3012,9 +3008,7 @@ class AccountService(StripeService):
             Account,
             self._requestor.request(
                 "post",
-                "/v1/accounts/{account}".format(
-                    account=_util.sanitize_id(account),
-                ),
+                "/v1/accounts/{account}".format(account=sanitize_id(account)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -3103,7 +3097,7 @@ class AccountService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/accounts/{account}/reject".format(
-                    account=_util.sanitize_id(account),
+                    account=sanitize_id(account),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_account_session.py
+++ b/stripe/_account_session.py
@@ -276,7 +276,7 @@ class AccountSession(CreateableAPIResource["AccountSession"]):
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 

--- a/stripe/_apple_pay_domain.py
+++ b/stripe/_apple_pay_domain.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._list_object import ListObject
@@ -8,7 +9,6 @@ from stripe._request_options import RequestOptions
 from stripe._util import class_method_variant
 from typing import ClassVar, List, Optional, cast, overload
 from typing_extensions import Literal, NotRequired, Unpack
-from urllib.parse import quote_plus
 
 
 class ApplePayDomain(
@@ -87,7 +87,7 @@ class ApplePayDomain(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -98,10 +98,14 @@ class ApplePayDomain(
         """
         Delete an apple pay domain.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
         return cast(
             "ApplePayDomain",
-            cls._static_request("delete", url, params=params),
+            cls._static_request(
+                "delete",
+                url,
+                params=params,
+            ),
         )
 
     @overload

--- a/stripe/_apple_pay_domain.py
+++ b/stripe/_apple_pay_domain.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, List, Optional, cast, overload
 from typing_extensions import Literal, NotRequired, Unpack
 
@@ -98,7 +97,7 @@ class ApplePayDomain(
         """
         Delete an apple pay domain.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(sid))
         return cast(
             "ApplePayDomain",
             cls._static_request(

--- a/stripe/_apple_pay_domain_service.py
+++ b/stripe/_apple_pay_domain_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._apple_pay_domain import ApplePayDomain
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -59,7 +59,7 @@ class ApplePayDomainService(StripeService):
             self._requestor.request(
                 "delete",
                 "/v1/apple_pay/domains/{domain}".format(
-                    domain=_util.sanitize_id(domain),
+                    domain=sanitize_id(domain),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -82,7 +82,7 @@ class ApplePayDomainService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/apple_pay/domains/{domain}".format(
-                    domain=_util.sanitize_id(domain),
+                    domain=sanitize_id(domain),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_application_fee.py
+++ b/stripe/_application_fee.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
 from stripe._nested_resource_class_methods import nested_resource_class_methods
 from stripe._request_options import RequestOptions
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -234,9 +233,7 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
             "ApplicationFeeRefund",
             cls._static_request(
                 "post",
-                "/v1/application_fees/{id}/refunds".format(
-                    id=_util.sanitize_id(id)
-                ),
+                "/v1/application_fees/{id}/refunds".format(id=sanitize_id(id)),
                 params=params,
             ),
         )
@@ -296,7 +293,7 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
             self._request(
                 "post",
                 "/v1/application_fees/{id}/refunds".format(
-                    id=_util.sanitize_id(self.get("id"))
+                    id=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -332,9 +329,7 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
             "ApplicationFeeRefund",
             cls._static_request(
                 "post",
-                "/v1/application_fees/{id}/refunds".format(
-                    id=_util.sanitize_id(id)
-                ),
+                "/v1/application_fees/{id}/refunds".format(id=sanitize_id(id)),
                 params=params,
             ),
         )
@@ -354,7 +349,7 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
             cls._static_request(
                 "get",
                 "/v1/application_fees/{fee}/refunds/{id}".format(
-                    fee=_util.sanitize_id(fee), id=_util.sanitize_id(id)
+                    fee=sanitize_id(fee), id=sanitize_id(id)
                 ),
                 params=params,
             ),
@@ -377,7 +372,7 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
             cls._static_request(
                 "post",
                 "/v1/application_fees/{fee}/refunds/{id}".format(
-                    fee=_util.sanitize_id(fee), id=_util.sanitize_id(id)
+                    fee=sanitize_id(fee), id=sanitize_id(id)
                 ),
                 params=params,
             ),
@@ -394,9 +389,7 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
             ListObject["ApplicationFeeRefund"],
             cls._static_request(
                 "get",
-                "/v1/application_fees/{id}/refunds".format(
-                    id=_util.sanitize_id(id)
-                ),
+                "/v1/application_fees/{id}/refunds".format(id=sanitize_id(id)),
                 params=params,
             ),
         )

--- a/stripe/_application_fee_refund.py
+++ b/stripe/_application_fee_refund.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._application_fee import ApplicationFee
 from stripe._expandable_field import ExpandableField
 from stripe._updateable_api_resource import UpdateableAPIResource
+from stripe._util import sanitize_id
 from typing import ClassVar, Dict, Optional, cast
 from typing_extensions import Literal, TYPE_CHECKING
 
@@ -57,8 +57,8 @@ class ApplicationFeeRefund(UpdateableAPIResource["ApplicationFeeRefund"]):
     @classmethod
     def _build_instance_url(cls, fee, sid):
         base = ApplicationFee.class_url()
-        cust_extn = _util.sanitize_id(fee)
-        extn = _util.sanitize_id(sid)
+        cust_extn = sanitize_id(fee)
+        extn = sanitize_id(sid)
         return "%s/%s/refunds/%s" % (base, cust_extn, extn)
 
     @classmethod

--- a/stripe/_application_fee_refund.py
+++ b/stripe/_application_fee_refund.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._application_fee import ApplicationFee
 from stripe._expandable_field import ExpandableField
 from stripe._updateable_api_resource import UpdateableAPIResource
 from typing import ClassVar, Dict, Optional, cast
 from typing_extensions import Literal, TYPE_CHECKING
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._balance_transaction import BalanceTransaction
@@ -57,8 +57,8 @@ class ApplicationFeeRefund(UpdateableAPIResource["ApplicationFeeRefund"]):
     @classmethod
     def _build_instance_url(cls, fee, sid):
         base = ApplicationFee.class_url()
-        cust_extn = quote_plus(fee)
-        extn = quote_plus(sid)
+        cust_extn = _util.sanitize_id(fee)
+        extn = _util.sanitize_id(sid)
         return "%s/%s/refunds/%s" % (base, cust_extn, extn)
 
     @classmethod

--- a/stripe/_application_fee_refund_service.py
+++ b/stripe/_application_fee_refund_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._application_fee_refund import ApplicationFeeRefund
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -73,8 +73,8 @@ class ApplicationFeeRefundService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/application_fees/{fee}/refunds/{id}".format(
-                    fee=_util.sanitize_id(fee),
-                    id=_util.sanitize_id(id),
+                    fee=sanitize_id(fee),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -100,8 +100,8 @@ class ApplicationFeeRefundService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/application_fees/{fee}/refunds/{id}".format(
-                    fee=_util.sanitize_id(fee),
-                    id=_util.sanitize_id(id),
+                    fee=sanitize_id(fee),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -123,9 +123,7 @@ class ApplicationFeeRefundService(StripeService):
             ListObject[ApplicationFeeRefund],
             self._requestor.request(
                 "get",
-                "/v1/application_fees/{id}/refunds".format(
-                    id=_util.sanitize_id(id),
-                ),
+                "/v1/application_fees/{id}/refunds".format(id=sanitize_id(id)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -154,9 +152,7 @@ class ApplicationFeeRefundService(StripeService):
             ApplicationFeeRefund,
             self._requestor.request(
                 "post",
-                "/v1/application_fees/{id}/refunds".format(
-                    id=_util.sanitize_id(id),
-                ),
+                "/v1/application_fees/{id}/refunds".format(id=sanitize_id(id)),
                 api_mode="V1",
                 base_address="api",
                 params=params,

--- a/stripe/_application_fee_service.py
+++ b/stripe/_application_fee_service.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._application_fee import ApplicationFee
 from stripe._application_fee_refund_service import ApplicationFeeRefundService
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -95,7 +95,7 @@ class ApplicationFeeService(StripeService):
             ApplicationFee,
             self._requestor.request(
                 "get",
-                "/v1/application_fees/{id}".format(id=_util.sanitize_id(id)),
+                "/v1/application_fees/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",
                 base_address="api",
                 params=params,

--- a/stripe/_balance_transaction_service.py
+++ b/stripe/_balance_transaction_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._balance_transaction import BalanceTransaction
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -106,9 +106,7 @@ class BalanceTransactionService(StripeService):
             BalanceTransaction,
             self._requestor.request(
                 "get",
-                "/v1/balance_transactions/{id}".format(
-                    id=_util.sanitize_id(id),
-                ),
+                "/v1/balance_transactions/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",
                 base_address="api",
                 params=params,

--- a/stripe/_bank_account.py
+++ b/stripe/_bank_account.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._account import Account
 from stripe._customer import Customer
 from stripe._deletable_api_resource import DeletableAPIResource
@@ -12,7 +13,6 @@ from stripe._util import class_method_variant
 from stripe._verify_mixin import VerifyMixin
 from typing import ClassVar, Dict, List, Optional, Union, cast, overload
 from typing_extensions import Literal, Unpack, TYPE_CHECKING
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._card import Card
@@ -370,10 +370,14 @@ class BankAccount(
         """
         Delete a specified external account for a given account.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
         return cast(
             Union["BankAccount", "Card"],
-            cls._static_request("delete", url, params=params),
+            cls._static_request(
+                "delete",
+                url,
+                params=params,
+            ),
         )
 
     @overload
@@ -410,7 +414,7 @@ class BankAccount(
 
     def instance_url(self):
         token = self.id
-        extn = quote_plus(token)
+        extn = _util.sanitize_id(token)
         if hasattr(self, "customer"):
             customer = self.customer
 
@@ -418,7 +422,7 @@ class BankAccount(
             assert customer is not None
             if isinstance(customer, Customer):
                 customer = customer.id
-            owner_extn = quote_plus(customer)
+            owner_extn = _util.sanitize_id(customer)
             class_base = "sources"
 
         elif hasattr(self, "account"):
@@ -428,7 +432,7 @@ class BankAccount(
             assert account is not None
             if isinstance(account, Account):
                 account = account.id
-            owner_extn = quote_plus(account)
+            owner_extn = _util.sanitize_id(account)
             class_base = "external_accounts"
 
         else:

--- a/stripe/_bank_account.py
+++ b/stripe/_bank_account.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._account import Account
 from stripe._customer import Customer
 from stripe._deletable_api_resource import DeletableAPIResource
@@ -9,7 +8,7 @@ from stripe._expandable_field import ExpandableField
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from stripe._verify_mixin import VerifyMixin
 from typing import ClassVar, Dict, List, Optional, Union, cast, overload
 from typing_extensions import Literal, Unpack, TYPE_CHECKING
@@ -370,7 +369,7 @@ class BankAccount(
         """
         Delete a specified external account for a given account.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(sid))
         return cast(
             Union["BankAccount", "Card"],
             cls._static_request(
@@ -414,7 +413,7 @@ class BankAccount(
 
     def instance_url(self):
         token = self.id
-        extn = _util.sanitize_id(token)
+        extn = sanitize_id(token)
         if hasattr(self, "customer"):
             customer = self.customer
 
@@ -422,7 +421,7 @@ class BankAccount(
             assert customer is not None
             if isinstance(customer, Customer):
                 customer = customer.id
-            owner_extn = _util.sanitize_id(customer)
+            owner_extn = sanitize_id(customer)
             class_base = "sources"
 
         elif hasattr(self, "account"):
@@ -432,7 +431,7 @@ class BankAccount(
             assert account is not None
             if isinstance(account, Account):
                 account = account.id
-            owner_extn = _util.sanitize_id(account)
+            owner_extn = sanitize_id(account)
             class_base = "external_accounts"
 
         else:

--- a/stripe/_capability.py
+++ b/stripe/_capability.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._account import Account
 from stripe._expandable_field import ExpandableField
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
 from typing import ClassVar, List, Optional
 from typing_extensions import Literal
-from urllib.parse import quote_plus
 
 
 class Capability(UpdateableAPIResource["Capability"]):
@@ -351,8 +351,8 @@ class Capability(UpdateableAPIResource["Capability"]):
         base = Account.class_url()
         if isinstance(account, Account):
             account = account.id
-        acct_extn = quote_plus(account)
-        extn = quote_plus(token)
+        acct_extn = _util.sanitize_id(account)
+        extn = _util.sanitize_id(token)
         return "%s/%s/capabilities/%s" % (base, acct_extn, extn)
 
     @classmethod

--- a/stripe/_capability.py
+++ b/stripe/_capability.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._account import Account
 from stripe._expandable_field import ExpandableField
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
+from stripe._util import sanitize_id
 from typing import ClassVar, List, Optional
 from typing_extensions import Literal
 
@@ -351,8 +351,8 @@ class Capability(UpdateableAPIResource["Capability"]):
         base = Account.class_url()
         if isinstance(account, Account):
             account = account.id
-        acct_extn = _util.sanitize_id(account)
-        extn = _util.sanitize_id(token)
+        acct_extn = sanitize_id(account)
+        extn = sanitize_id(token)
         return "%s/%s/capabilities/%s" % (base, acct_extn, extn)
 
     @classmethod

--- a/stripe/_card.py
+++ b/stripe/_card.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._account import Account
 from stripe._customer import Customer
 from stripe._deletable_api_resource import DeletableAPIResource
@@ -10,7 +11,6 @@ from stripe._updateable_api_resource import UpdateableAPIResource
 from stripe._util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, Union, cast, overload
 from typing_extensions import Literal, Unpack, TYPE_CHECKING
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._bank_account import BankAccount
@@ -168,10 +168,14 @@ class Card(DeletableAPIResource["Card"], UpdateableAPIResource["Card"]):
         """
         Delete a specified external account for a given account.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
         return cast(
             Union["BankAccount", "Card"],
-            cls._static_request("delete", url, params=params),
+            cls._static_request(
+                "delete",
+                url,
+                params=params,
+            ),
         )
 
     @overload
@@ -208,7 +212,7 @@ class Card(DeletableAPIResource["Card"], UpdateableAPIResource["Card"]):
 
     def instance_url(self):
         token = self.id
-        extn = quote_plus(token)
+        extn = _util.sanitize_id(token)
         if hasattr(self, "customer"):
             customer = self.customer
 
@@ -216,7 +220,7 @@ class Card(DeletableAPIResource["Card"], UpdateableAPIResource["Card"]):
             assert customer is not None
             if isinstance(customer, Customer):
                 customer = customer.id
-            owner_extn = quote_plus(customer)
+            owner_extn = _util.sanitize_id(customer)
             class_base = "sources"
 
         elif hasattr(self, "account"):
@@ -226,7 +230,7 @@ class Card(DeletableAPIResource["Card"], UpdateableAPIResource["Card"]):
             assert account is not None
             if isinstance(account, Account):
                 account = account.id
-            owner_extn = quote_plus(account)
+            owner_extn = _util.sanitize_id(account)
             class_base = "external_accounts"
 
         else:

--- a/stripe/_card.py
+++ b/stripe/_card.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._account import Account
 from stripe._customer import Customer
 from stripe._deletable_api_resource import DeletableAPIResource
@@ -8,7 +7,7 @@ from stripe._error import InvalidRequestError
 from stripe._expandable_field import ExpandableField
 from stripe._request_options import RequestOptions
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, Union, cast, overload
 from typing_extensions import Literal, Unpack, TYPE_CHECKING
 
@@ -168,7 +167,7 @@ class Card(DeletableAPIResource["Card"], UpdateableAPIResource["Card"]):
         """
         Delete a specified external account for a given account.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(sid))
         return cast(
             Union["BankAccount", "Card"],
             cls._static_request(
@@ -212,7 +211,7 @@ class Card(DeletableAPIResource["Card"], UpdateableAPIResource["Card"]):
 
     def instance_url(self):
         token = self.id
-        extn = _util.sanitize_id(token)
+        extn = sanitize_id(token)
         if hasattr(self, "customer"):
             customer = self.customer
 
@@ -220,7 +219,7 @@ class Card(DeletableAPIResource["Card"], UpdateableAPIResource["Card"]):
             assert customer is not None
             if isinstance(customer, Customer):
                 customer = customer.id
-            owner_extn = _util.sanitize_id(customer)
+            owner_extn = sanitize_id(customer)
             class_base = "sources"
 
         elif hasattr(self, "account"):
@@ -230,7 +229,7 @@ class Card(DeletableAPIResource["Card"], UpdateableAPIResource["Card"]):
             assert account is not None
             if isinstance(account, Account):
                 account = account.id
-            owner_extn = _util.sanitize_id(account)
+            owner_extn = sanitize_id(account)
             class_base = "external_accounts"
 
         else:

--- a/stripe/_cash_balance.py
+++ b/stripe/_cash_balance.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._customer import Customer
 from stripe._stripe_object import StripeObject
 from typing import ClassVar, Dict, Optional
 from typing_extensions import Literal
-from urllib.parse import quote_plus
 
 
 class CashBalance(StripeObject):
@@ -45,7 +45,7 @@ class CashBalance(StripeObject):
     def instance_url(self):
         customer = self.customer
         base = Customer.class_url()
-        cust_extn = quote_plus(customer)
+        cust_extn = _util.sanitize_id(customer)
         return "%s/%s/cash_balance" % (base, cust_extn)
 
     @classmethod

--- a/stripe/_cash_balance.py
+++ b/stripe/_cash_balance.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._customer import Customer
 from stripe._stripe_object import StripeObject
+from stripe._util import sanitize_id
 from typing import ClassVar, Dict, Optional
 from typing_extensions import Literal
 
@@ -45,7 +45,7 @@ class CashBalance(StripeObject):
     def instance_url(self):
         customer = self.customer
         base = Customer.class_url()
-        cust_extn = _util.sanitize_id(customer)
+        cust_extn = sanitize_id(customer)
         return "%s/%s/cash_balance" % (base, cust_extn)
 
     @classmethod

--- a/stripe/_charge.py
+++ b/stripe/_charge.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -10,7 +9,7 @@ from stripe._search_result_object import SearchResultObject
 from stripe._searchable_api_resource import SearchableAPIResource
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import (
     ClassVar,
     Dict,
@@ -2225,7 +2224,7 @@ class Charge(
             cls._static_request(
                 "post",
                 "/v1/charges/{charge}/capture".format(
-                    charge=_util.sanitize_id(charge)
+                    charge=sanitize_id(charge)
                 ),
                 params=params,
             ),
@@ -2272,7 +2271,7 @@ class Charge(
             self._request(
                 "post",
                 "/v1/charges/{charge}/capture".format(
-                    charge=_util.sanitize_id(self.get("id"))
+                    charge=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -2322,7 +2321,7 @@ class Charge(
         """
         Updates the specified charge by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Charge",
             cls._static_request(

--- a/stripe/_charge.py
+++ b/stripe/_charge.py
@@ -28,7 +28,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._account import Account
@@ -2291,7 +2290,7 @@ class Charge(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -2323,10 +2322,14 @@ class Charge(
         """
         Updates the specified charge by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Charge",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_charge_service.py
+++ b/stripe/_charge_service.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._charge import Charge
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._search_result_object import SearchResultObject
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, Union, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -417,9 +417,7 @@ class ChargeService(StripeService):
             Charge,
             self._requestor.request(
                 "get",
-                "/v1/charges/{charge}".format(
-                    charge=_util.sanitize_id(charge)
-                ),
+                "/v1/charges/{charge}".format(charge=sanitize_id(charge)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -440,9 +438,7 @@ class ChargeService(StripeService):
             Charge,
             self._requestor.request(
                 "post",
-                "/v1/charges/{charge}".format(
-                    charge=_util.sanitize_id(charge)
-                ),
+                "/v1/charges/{charge}".format(charge=sanitize_id(charge)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -491,7 +487,7 @@ class ChargeService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/charges/{charge}/capture".format(
-                    charge=_util.sanitize_id(charge),
+                    charge=sanitize_id(charge),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_country_spec_service.py
+++ b/stripe/_country_spec_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._country_spec import CountrySpec
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -68,7 +68,7 @@ class CountrySpecService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/country_specs/{country}".format(
-                    country=_util.sanitize_id(country),
+                    country=sanitize_id(country),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_coupon.py
+++ b/stripe/_coupon.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._list_object import ListObject
@@ -10,7 +11,6 @@ from stripe._updateable_api_resource import UpdateableAPIResource
 from stripe._util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import Literal, NotRequired, TypedDict, Unpack
-from urllib.parse import quote_plus
 
 
 class Coupon(
@@ -264,7 +264,7 @@ class Coupon(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -275,10 +275,14 @@ class Coupon(
         """
         You can delete coupons via the [coupon management](https://dashboard.stripe.com/coupons) page of the Stripe dashboard. However, deleting a coupon does not affect any customers who have already applied the coupon; it means that new customers can't redeem the coupon. You can also delete coupons via the API.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
         return cast(
             "Coupon",
-            cls._static_request("delete", url, params=params),
+            cls._static_request(
+                "delete",
+                url,
+                params=params,
+            ),
         )
 
     @overload
@@ -337,10 +341,14 @@ class Coupon(
         """
         Updates the metadata of a coupon. Other coupon details (currency, duration, amount_off) are, by design, not editable.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Coupon",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_coupon.py
+++ b/stripe/_coupon.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._list_object import ListObject
@@ -8,7 +7,7 @@ from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import Literal, NotRequired, TypedDict, Unpack
 
@@ -275,7 +274,7 @@ class Coupon(
         """
         You can delete coupons via the [coupon management](https://dashboard.stripe.com/coupons) page of the Stripe dashboard. However, deleting a coupon does not affect any customers who have already applied the coupon; it means that new customers can't redeem the coupon. You can also delete coupons via the API.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(sid))
         return cast(
             "Coupon",
             cls._static_request(
@@ -341,7 +340,7 @@ class Coupon(
         """
         Updates the metadata of a coupon. Other coupon details (currency, duration, amount_off) are, by design, not editable.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Coupon",
             cls._static_request(

--- a/stripe/_coupon_service.py
+++ b/stripe/_coupon_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._coupon import Coupon
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -166,9 +166,7 @@ class CouponService(StripeService):
             Coupon,
             self._requestor.request(
                 "delete",
-                "/v1/coupons/{coupon}".format(
-                    coupon=_util.sanitize_id(coupon)
-                ),
+                "/v1/coupons/{coupon}".format(coupon=sanitize_id(coupon)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -189,9 +187,7 @@ class CouponService(StripeService):
             Coupon,
             self._requestor.request(
                 "get",
-                "/v1/coupons/{coupon}".format(
-                    coupon=_util.sanitize_id(coupon)
-                ),
+                "/v1/coupons/{coupon}".format(coupon=sanitize_id(coupon)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -212,9 +208,7 @@ class CouponService(StripeService):
             Coupon,
             self._requestor.request(
                 "post",
-                "/v1/coupons/{coupon}".format(
-                    coupon=_util.sanitize_id(coupon)
-                ),
+                "/v1/coupons/{coupon}".format(coupon=sanitize_id(coupon)),
                 api_mode="V1",
                 base_address="api",
                 params=params,

--- a/stripe/_credit_note.py
+++ b/stripe/_credit_note.py
@@ -18,7 +18,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._credit_note_line_item import CreditNoteLineItem
@@ -738,7 +737,7 @@ class CreditNote(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -770,10 +769,14 @@ class CreditNote(
         """
         Updates an existing credit note.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "CreditNote",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_credit_note.py
+++ b/stripe/_credit_note.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -9,7 +8,7 @@ from stripe._nested_resource_class_methods import nested_resource_class_methods
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -769,7 +768,7 @@ class CreditNote(
         """
         Updates an existing credit note.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "CreditNote",
             cls._static_request(
@@ -833,7 +832,7 @@ class CreditNote(
             "CreditNote",
             cls._static_request(
                 "post",
-                "/v1/credit_notes/{id}/void".format(id=_util.sanitize_id(id)),
+                "/v1/credit_notes/{id}/void".format(id=sanitize_id(id)),
                 params=params,
             ),
         )
@@ -869,7 +868,7 @@ class CreditNote(
             self._request(
                 "post",
                 "/v1/credit_notes/{id}/void".format(
-                    id=_util.sanitize_id(self.get("id"))
+                    id=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -887,7 +886,7 @@ class CreditNote(
             cls._static_request(
                 "get",
                 "/v1/credit_notes/{credit_note}/lines".format(
-                    credit_note=_util.sanitize_id(credit_note)
+                    credit_note=sanitize_id(credit_note)
                 ),
                 params=params,
             ),

--- a/stripe/_credit_note_line_item_service.py
+++ b/stripe/_credit_note_line_item_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._credit_note_line_item import CreditNoteLineItem
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -42,7 +42,7 @@ class CreditNoteLineItemService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/credit_notes/{credit_note}/lines".format(
-                    credit_note=_util.sanitize_id(credit_note),
+                    credit_note=sanitize_id(credit_note),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_credit_note_service.py
+++ b/stripe/_credit_note_service.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._credit_note import CreditNote
 from stripe._credit_note_line_item_service import CreditNoteLineItemService
 from stripe._credit_note_preview_lines_service import (
@@ -9,6 +8,7 @@ from stripe._credit_note_preview_lines_service import (
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -373,7 +373,7 @@ class CreditNoteService(StripeService):
             CreditNote,
             self._requestor.request(
                 "get",
-                "/v1/credit_notes/{id}".format(id=_util.sanitize_id(id)),
+                "/v1/credit_notes/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -394,7 +394,7 @@ class CreditNoteService(StripeService):
             CreditNote,
             self._requestor.request(
                 "post",
-                "/v1/credit_notes/{id}".format(id=_util.sanitize_id(id)),
+                "/v1/credit_notes/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -435,7 +435,7 @@ class CreditNoteService(StripeService):
             CreditNote,
             self._requestor.request(
                 "post",
-                "/v1/credit_notes/{id}/void".format(id=_util.sanitize_id(id)),
+                "/v1/credit_notes/{id}/void".format(id=sanitize_id(id)),
                 api_mode="V1",
                 base_address="api",
                 params=params,

--- a/stripe/_customer.py
+++ b/stripe/_customer.py
@@ -32,7 +32,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._account import Account
@@ -1391,7 +1390,7 @@ class Customer(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -1468,10 +1467,14 @@ class Customer(
         """
         Permanently deletes a customer. It cannot be undone. Also immediately cancels any active subscriptions on the customer.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
         return cast(
             "Customer",
-            cls._static_request("delete", url, params=params),
+            cls._static_request(
+                "delete",
+                url,
+                params=params,
+            ),
         )
 
     @overload
@@ -1646,10 +1649,14 @@ class Customer(
 
         This request accepts mostly the same arguments as the customer creation call.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Customer",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_customer.py
+++ b/stripe/_customer.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._expandable_field import ExpandableField
@@ -13,7 +12,7 @@ from stripe._searchable_api_resource import SearchableAPIResource
 from stripe._stripe_object import StripeObject
 from stripe._test_helpers import APIResourceTestHelpers
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import (
     ClassVar,
     Dict,
@@ -1410,7 +1409,7 @@ class Customer(
             cls._static_request(
                 "post",
                 "/v1/customers/{customer}/funding_instructions".format(
-                    customer=_util.sanitize_id(customer)
+                    customer=sanitize_id(customer)
                 ),
                 params=params,
             ),
@@ -1454,7 +1453,7 @@ class Customer(
             self._request(
                 "post",
                 "/v1/customers/{customer}/funding_instructions".format(
-                    customer=_util.sanitize_id(self.get("id"))
+                    customer=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -1467,7 +1466,7 @@ class Customer(
         """
         Permanently deletes a customer. It cannot be undone. Also immediately cancels any active subscriptions on the customer.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(sid))
         return cast(
             "Customer",
             cls._static_request(
@@ -1519,7 +1518,7 @@ class Customer(
             cls._static_request(
                 "delete",
                 "/v1/customers/{customer}/discount".format(
-                    customer=_util.sanitize_id(customer)
+                    customer=sanitize_id(customer)
                 ),
                 params=params,
             ),
@@ -1556,7 +1555,7 @@ class Customer(
             self._request(
                 "delete",
                 "/v1/customers/{customer}/discount".format(
-                    customer=_util.sanitize_id(self.get("id"))
+                    customer=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -1597,7 +1596,7 @@ class Customer(
             cls._static_request(
                 "get",
                 "/v1/customers/{customer}/payment_methods".format(
-                    customer=_util.sanitize_id(customer)
+                    customer=sanitize_id(customer)
                 ),
                 params=params,
             ),
@@ -1634,7 +1633,7 @@ class Customer(
             self._request(
                 "get",
                 "/v1/customers/{customer}/payment_methods".format(
-                    customer=_util.sanitize_id(self.get("id"))
+                    customer=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -1649,7 +1648,7 @@ class Customer(
 
         This request accepts mostly the same arguments as the customer creation call.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Customer",
             cls._static_request(
@@ -1685,8 +1684,8 @@ class Customer(
             cls._static_request(
                 "get",
                 "/v1/customers/{customer}/payment_methods/{payment_method}".format(
-                    customer=_util.sanitize_id(customer),
-                    payment_method=_util.sanitize_id(payment_method),
+                    customer=sanitize_id(customer),
+                    payment_method=sanitize_id(payment_method),
                 ),
                 params=params,
             ),
@@ -1729,8 +1728,8 @@ class Customer(
             self._request(
                 "get",
                 "/v1/customers/{customer}/payment_methods/{payment_method}".format(
-                    customer=_util.sanitize_id(self.get("id")),
-                    payment_method=_util.sanitize_id(payment_method),
+                    customer=sanitize_id(self.get("id")),
+                    payment_method=sanitize_id(payment_method),
                 ),
                 params=params,
             ),
@@ -1768,7 +1767,7 @@ class Customer(
             cls._static_request(
                 "post",
                 "/v1/customers/{customer}/balance_transactions".format(
-                    customer=_util.sanitize_id(customer)
+                    customer=sanitize_id(customer)
                 ),
                 params=params,
             ),
@@ -1789,8 +1788,8 @@ class Customer(
             cls._static_request(
                 "get",
                 "/v1/customers/{customer}/balance_transactions/{transaction}".format(
-                    customer=_util.sanitize_id(customer),
-                    transaction=_util.sanitize_id(transaction),
+                    customer=sanitize_id(customer),
+                    transaction=sanitize_id(transaction),
                 ),
                 params=params,
             ),
@@ -1811,8 +1810,8 @@ class Customer(
             cls._static_request(
                 "post",
                 "/v1/customers/{customer}/balance_transactions/{transaction}".format(
-                    customer=_util.sanitize_id(customer),
-                    transaction=_util.sanitize_id(transaction),
+                    customer=sanitize_id(customer),
+                    transaction=sanitize_id(transaction),
                 ),
                 params=params,
             ),
@@ -1832,7 +1831,7 @@ class Customer(
             cls._static_request(
                 "get",
                 "/v1/customers/{customer}/balance_transactions".format(
-                    customer=_util.sanitize_id(customer)
+                    customer=sanitize_id(customer)
                 ),
                 params=params,
             ),
@@ -1853,8 +1852,8 @@ class Customer(
             cls._static_request(
                 "get",
                 "/v1/customers/{customer}/cash_balance_transactions/{transaction}".format(
-                    customer=_util.sanitize_id(customer),
-                    transaction=_util.sanitize_id(transaction),
+                    customer=sanitize_id(customer),
+                    transaction=sanitize_id(transaction),
                 ),
                 params=params,
             ),
@@ -1874,7 +1873,7 @@ class Customer(
             cls._static_request(
                 "get",
                 "/v1/customers/{customer}/cash_balance_transactions".format(
-                    customer=_util.sanitize_id(customer)
+                    customer=sanitize_id(customer)
                 ),
                 params=params,
             ),
@@ -1896,7 +1895,7 @@ class Customer(
             cls._static_request(
                 "post",
                 "/v1/customers/{customer}/sources".format(
-                    customer=_util.sanitize_id(customer)
+                    customer=sanitize_id(customer)
                 ),
                 params=params,
             ),
@@ -1917,8 +1916,7 @@ class Customer(
             cls._static_request(
                 "get",
                 "/v1/customers/{customer}/sources/{id}".format(
-                    customer=_util.sanitize_id(customer),
-                    id=_util.sanitize_id(id),
+                    customer=sanitize_id(customer), id=sanitize_id(id)
                 ),
                 params=params,
             ),
@@ -1939,8 +1937,7 @@ class Customer(
             cls._static_request(
                 "post",
                 "/v1/customers/{customer}/sources/{id}".format(
-                    customer=_util.sanitize_id(customer),
-                    id=_util.sanitize_id(id),
+                    customer=sanitize_id(customer), id=sanitize_id(id)
                 ),
                 params=params,
             ),
@@ -1961,8 +1958,7 @@ class Customer(
             cls._static_request(
                 "delete",
                 "/v1/customers/{customer}/sources/{id}".format(
-                    customer=_util.sanitize_id(customer),
-                    id=_util.sanitize_id(id),
+                    customer=sanitize_id(customer), id=sanitize_id(id)
                 ),
                 params=params,
             ),
@@ -1980,7 +1976,7 @@ class Customer(
             cls._static_request(
                 "get",
                 "/v1/customers/{customer}/sources".format(
-                    customer=_util.sanitize_id(customer)
+                    customer=sanitize_id(customer)
                 ),
                 params=params,
             ),
@@ -1998,7 +1994,7 @@ class Customer(
             cls._static_request(
                 "post",
                 "/v1/customers/{customer}/tax_ids".format(
-                    customer=_util.sanitize_id(customer)
+                    customer=sanitize_id(customer)
                 ),
                 params=params,
             ),
@@ -2019,8 +2015,7 @@ class Customer(
             cls._static_request(
                 "get",
                 "/v1/customers/{customer}/tax_ids/{id}".format(
-                    customer=_util.sanitize_id(customer),
-                    id=_util.sanitize_id(id),
+                    customer=sanitize_id(customer), id=sanitize_id(id)
                 ),
                 params=params,
             ),
@@ -2041,8 +2036,7 @@ class Customer(
             cls._static_request(
                 "delete",
                 "/v1/customers/{customer}/tax_ids/{id}".format(
-                    customer=_util.sanitize_id(customer),
-                    id=_util.sanitize_id(id),
+                    customer=sanitize_id(customer), id=sanitize_id(id)
                 ),
                 params=params,
             ),
@@ -2060,7 +2054,7 @@ class Customer(
             cls._static_request(
                 "get",
                 "/v1/customers/{customer}/tax_ids".format(
-                    customer=_util.sanitize_id(customer)
+                    customer=sanitize_id(customer)
                 ),
                 params=params,
             ),
@@ -2080,7 +2074,7 @@ class Customer(
             cls._static_request(
                 "post",
                 "/v1/customers/{customer}/cash_balance".format(
-                    customer=_util.sanitize_id(customer)
+                    customer=sanitize_id(customer)
                 ),
                 params=params,
             ),
@@ -2100,7 +2094,7 @@ class Customer(
             cls._static_request(
                 "get",
                 "/v1/customers/{customer}/cash_balance".format(
-                    customer=_util.sanitize_id(customer)
+                    customer=sanitize_id(customer)
                 ),
                 params=params,
             ),
@@ -2123,7 +2117,7 @@ class Customer(
                 cls._static_request(
                     "post",
                     "/v1/test_helpers/customers/{customer}/fund_cash_balance".format(
-                        customer=_util.sanitize_id(customer)
+                        customer=sanitize_id(customer)
                     ),
                     params=params,
                 ),
@@ -2160,7 +2154,7 @@ class Customer(
                 self.resource._request(
                     "post",
                     "/v1/test_helpers/customers/{customer}/fund_cash_balance".format(
-                        customer=_util.sanitize_id(self.resource.get("id"))
+                        customer=sanitize_id(self.resource.get("id"))
                     ),
                     params=params,
                 ),

--- a/stripe/_customer_balance_transaction.py
+++ b/stripe/_customer_balance_transaction.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._api_resource import APIResource
 from stripe._customer import Customer
 from stripe._expandable_field import ExpandableField
 from typing import ClassVar, Dict, Optional
 from typing_extensions import Literal, TYPE_CHECKING
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._credit_note import CreditNote
@@ -95,8 +95,8 @@ class CustomerBalanceTransaction(APIResource["CustomerBalanceTransaction"]):
         if isinstance(customer, Customer):
             customer = customer.id
         base = Customer.class_url()
-        cust_extn = quote_plus(customer)
-        extn = quote_plus(token)
+        cust_extn = _util.sanitize_id(customer)
+        extn = _util.sanitize_id(token)
         return "%s/%s/balance_transactions/%s" % (base, cust_extn, extn)
 
     @classmethod

--- a/stripe/_customer_balance_transaction.py
+++ b/stripe/_customer_balance_transaction.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._api_resource import APIResource
 from stripe._customer import Customer
 from stripe._expandable_field import ExpandableField
+from stripe._util import sanitize_id
 from typing import ClassVar, Dict, Optional
 from typing_extensions import Literal, TYPE_CHECKING
 
@@ -95,8 +95,8 @@ class CustomerBalanceTransaction(APIResource["CustomerBalanceTransaction"]):
         if isinstance(customer, Customer):
             customer = customer.id
         base = Customer.class_url()
-        cust_extn = _util.sanitize_id(customer)
-        extn = _util.sanitize_id(token)
+        cust_extn = sanitize_id(customer)
+        extn = sanitize_id(token)
         return "%s/%s/balance_transactions/%s" % (base, cust_extn, extn)
 
     @classmethod

--- a/stripe/_customer_balance_transaction_service.py
+++ b/stripe/_customer_balance_transaction_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._customer_balance_transaction import CustomerBalanceTransaction
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -84,7 +84,7 @@ class CustomerBalanceTransactionService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/customers/{customer}/balance_transactions".format(
-                    customer=_util.sanitize_id(customer),
+                    customer=sanitize_id(customer),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -107,7 +107,7 @@ class CustomerBalanceTransactionService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/customers/{customer}/balance_transactions".format(
-                    customer=_util.sanitize_id(customer),
+                    customer=sanitize_id(customer),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -131,8 +131,8 @@ class CustomerBalanceTransactionService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/customers/{customer}/balance_transactions/{transaction}".format(
-                    customer=_util.sanitize_id(customer),
-                    transaction=_util.sanitize_id(transaction),
+                    customer=sanitize_id(customer),
+                    transaction=sanitize_id(transaction),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -156,8 +156,8 @@ class CustomerBalanceTransactionService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/customers/{customer}/balance_transactions/{transaction}".format(
-                    customer=_util.sanitize_id(customer),
-                    transaction=_util.sanitize_id(transaction),
+                    customer=sanitize_id(customer),
+                    transaction=sanitize_id(transaction),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_customer_cash_balance_service.py
+++ b/stripe/_customer_cash_balance_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._cash_balance import CashBalance
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -49,7 +49,7 @@ class CustomerCashBalanceService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/customers/{customer}/cash_balance".format(
-                    customer=_util.sanitize_id(customer),
+                    customer=sanitize_id(customer),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -72,7 +72,7 @@ class CustomerCashBalanceService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/customers/{customer}/cash_balance".format(
-                    customer=_util.sanitize_id(customer),
+                    customer=sanitize_id(customer),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_customer_cash_balance_transaction_service.py
+++ b/stripe/_customer_cash_balance_transaction_service.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._customer_cash_balance_transaction import (
     CustomerCashBalanceTransaction,
 )
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -50,7 +50,7 @@ class CustomerCashBalanceTransactionService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/customers/{customer}/cash_balance_transactions".format(
-                    customer=_util.sanitize_id(customer),
+                    customer=sanitize_id(customer),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -74,8 +74,8 @@ class CustomerCashBalanceTransactionService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/customers/{customer}/cash_balance_transactions/{transaction}".format(
-                    customer=_util.sanitize_id(customer),
-                    transaction=_util.sanitize_id(transaction),
+                    customer=sanitize_id(customer),
+                    transaction=sanitize_id(transaction),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_customer_funding_instructions_service.py
+++ b/stripe/_customer_funding_instructions_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._funding_instructions import FundingInstructions
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -75,7 +75,7 @@ class CustomerFundingInstructionsService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/customers/{customer}/funding_instructions".format(
-                    customer=_util.sanitize_id(customer),
+                    customer=sanitize_id(customer),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_customer_payment_method_service.py
+++ b/stripe/_customer_payment_method_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._payment_method import PaymentMethod
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -54,7 +54,7 @@ class CustomerPaymentMethodService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/customers/{customer}/payment_methods".format(
-                    customer=_util.sanitize_id(customer),
+                    customer=sanitize_id(customer),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -78,8 +78,8 @@ class CustomerPaymentMethodService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/customers/{customer}/payment_methods/{payment_method}".format(
-                    customer=_util.sanitize_id(customer),
-                    payment_method=_util.sanitize_id(payment_method),
+                    customer=sanitize_id(customer),
+                    payment_method=sanitize_id(payment_method),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_customer_payment_source_service.py
+++ b/stripe/_customer_payment_source_service.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._account import Account
 from stripe._bank_account import BankAccount
 from stripe._card import Card
@@ -8,6 +7,7 @@ from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._source import Source
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, Union, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -187,7 +187,7 @@ class CustomerPaymentSourceService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/customers/{customer}/sources".format(
-                    customer=_util.sanitize_id(customer),
+                    customer=sanitize_id(customer),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -214,7 +214,7 @@ class CustomerPaymentSourceService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/customers/{customer}/sources".format(
-                    customer=_util.sanitize_id(customer),
+                    customer=sanitize_id(customer),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -238,8 +238,8 @@ class CustomerPaymentSourceService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/customers/{customer}/sources/{id}".format(
-                    customer=_util.sanitize_id(customer),
-                    id=_util.sanitize_id(id),
+                    customer=sanitize_id(customer),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -263,8 +263,8 @@ class CustomerPaymentSourceService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/customers/{customer}/sources/{id}".format(
-                    customer=_util.sanitize_id(customer),
-                    id=_util.sanitize_id(id),
+                    customer=sanitize_id(customer),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -288,8 +288,8 @@ class CustomerPaymentSourceService(StripeService):
             self._requestor.request(
                 "delete",
                 "/v1/customers/{customer}/sources/{id}".format(
-                    customer=_util.sanitize_id(customer),
-                    id=_util.sanitize_id(id),
+                    customer=sanitize_id(customer),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -313,8 +313,8 @@ class CustomerPaymentSourceService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/customers/{customer}/sources/{id}/verify".format(
-                    customer=_util.sanitize_id(customer),
-                    id=_util.sanitize_id(id),
+                    customer=sanitize_id(customer),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_customer_service.py
+++ b/stripe/_customer_service.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._customer import Customer
 from stripe._customer_balance_transaction_service import (
     CustomerBalanceTransactionService,
@@ -24,6 +23,7 @@ from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._search_result_object import SearchResultObject
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -654,7 +654,7 @@ class CustomerService(StripeService):
             self._requestor.request(
                 "delete",
                 "/v1/customers/{customer}".format(
-                    customer=_util.sanitize_id(customer),
+                    customer=sanitize_id(customer),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -677,7 +677,7 @@ class CustomerService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/customers/{customer}".format(
-                    customer=_util.sanitize_id(customer),
+                    customer=sanitize_id(customer),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -702,7 +702,7 @@ class CustomerService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/customers/{customer}".format(
-                    customer=_util.sanitize_id(customer),
+                    customer=sanitize_id(customer),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -725,7 +725,7 @@ class CustomerService(StripeService):
             self._requestor.request(
                 "delete",
                 "/v1/customers/{customer}/discount".format(
-                    customer=_util.sanitize_id(customer),
+                    customer=sanitize_id(customer),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_customer_session.py
+++ b/stripe/_customer_session.py
@@ -134,7 +134,7 @@ class CustomerSession(CreateableAPIResource["CustomerSession"]):
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 

--- a/stripe/_customer_tax_id_service.py
+++ b/stripe/_customer_tax_id_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
 from stripe._tax_id import TaxId
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -133,8 +133,8 @@ class CustomerTaxIdService(StripeService):
             self._requestor.request(
                 "delete",
                 "/v1/customers/{customer}/tax_ids/{id}".format(
-                    customer=_util.sanitize_id(customer),
-                    id=_util.sanitize_id(id),
+                    customer=sanitize_id(customer),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -158,8 +158,8 @@ class CustomerTaxIdService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/customers/{customer}/tax_ids/{id}".format(
-                    customer=_util.sanitize_id(customer),
-                    id=_util.sanitize_id(id),
+                    customer=sanitize_id(customer),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -182,7 +182,7 @@ class CustomerTaxIdService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/customers/{customer}/tax_ids".format(
-                    customer=_util.sanitize_id(customer),
+                    customer=sanitize_id(customer),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -205,7 +205,7 @@ class CustomerTaxIdService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/customers/{customer}/tax_ids".format(
-                    customer=_util.sanitize_id(customer),
+                    customer=sanitize_id(customer),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_dispute.py
+++ b/stripe/_dispute.py
@@ -16,7 +16,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._balance_transaction import BalanceTransaction
@@ -531,10 +530,14 @@ class Dispute(
 
         Depending on your dispute type, different evidence fields will give you a better chance of winning your dispute. To figure out which evidence fields to provide, see our [guide to dispute types](https://stripe.com/docs/disputes/categories).
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Dispute",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_dispute.py
+++ b/stripe/_dispute.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -453,7 +452,7 @@ class Dispute(
             cls._static_request(
                 "post",
                 "/v1/disputes/{dispute}/close".format(
-                    dispute=_util.sanitize_id(dispute)
+                    dispute=sanitize_id(dispute)
                 ),
                 params=params,
             ),
@@ -494,7 +493,7 @@ class Dispute(
             self._request(
                 "post",
                 "/v1/disputes/{dispute}/close".format(
-                    dispute=_util.sanitize_id(self.get("id"))
+                    dispute=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -530,7 +529,7 @@ class Dispute(
 
         Depending on your dispute type, different evidence fields will give you a better chance of winning your dispute. To figure out which evidence fields to provide, see our [guide to dispute types](https://stripe.com/docs/disputes/categories).
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Dispute",
             cls._static_request(

--- a/stripe/_dispute_service.py
+++ b/stripe/_dispute_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._dispute import Dispute
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -228,9 +228,7 @@ class DisputeService(StripeService):
             Dispute,
             self._requestor.request(
                 "get",
-                "/v1/disputes/{dispute}".format(
-                    dispute=_util.sanitize_id(dispute),
-                ),
+                "/v1/disputes/{dispute}".format(dispute=sanitize_id(dispute)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -253,9 +251,7 @@ class DisputeService(StripeService):
             Dispute,
             self._requestor.request(
                 "post",
-                "/v1/disputes/{dispute}".format(
-                    dispute=_util.sanitize_id(dispute),
-                ),
+                "/v1/disputes/{dispute}".format(dispute=sanitize_id(dispute)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -279,7 +275,7 @@ class DisputeService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/disputes/{dispute}/close".format(
-                    dispute=_util.sanitize_id(dispute),
+                    dispute=sanitize_id(dispute),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_ephemeral_key.py
+++ b/stripe/_ephemeral_key.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._request_options import RequestOptions
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, List, Optional, cast, overload
 from typing_extensions import Literal, NotRequired, Unpack
 
@@ -49,7 +48,7 @@ class EphemeralKey(DeletableAPIResource["EphemeralKey"]):
         """
         Invalidates a short-lived API key for a given resource.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(sid))
         return cast(
             "EphemeralKey",
             cls._static_request(

--- a/stripe/_ephemeral_key.py
+++ b/stripe/_ephemeral_key.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._util import class_method_variant
 from typing import ClassVar, List, Optional, cast, overload
 from typing_extensions import Literal, NotRequired, Unpack
-from urllib.parse import quote_plus
 
 
 class EphemeralKey(DeletableAPIResource["EphemeralKey"]):
@@ -49,10 +49,14 @@ class EphemeralKey(DeletableAPIResource["EphemeralKey"]):
         """
         Invalidates a short-lived API key for a given resource.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
         return cast(
             "EphemeralKey",
-            cls._static_request("delete", url, params=params),
+            cls._static_request(
+                "delete",
+                url,
+                params=params,
+            ),
         )
 
     @overload

--- a/stripe/_ephemeral_key_service.py
+++ b/stripe/_ephemeral_key_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._ephemeral_key import EphemeralKey
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -50,7 +50,7 @@ class EphemeralKeyService(StripeService):
             EphemeralKey,
             self._requestor.request(
                 "delete",
-                "/v1/ephemeral_keys/{key}".format(key=_util.sanitize_id(key)),
+                "/v1/ephemeral_keys/{key}".format(key=sanitize_id(key)),
                 api_mode="V1",
                 base_address="api",
                 params=params,

--- a/stripe/_event_service.py
+++ b/stripe/_event_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._event import Event
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -98,7 +98,7 @@ class EventService(StripeService):
             Event,
             self._requestor.request(
                 "get",
-                "/v1/events/{id}".format(id=_util.sanitize_id(id)),
+                "/v1/events/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",
                 base_address="api",
                 params=params,

--- a/stripe/_exchange_rate_service.py
+++ b/stripe/_exchange_rate_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._exchange_rate import ExchangeRate
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -68,7 +68,7 @@ class ExchangeRateService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/exchange_rates/{rate_id}".format(
-                    rate_id=_util.sanitize_id(rate_id),
+                    rate_id=sanitize_id(rate_id),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_file.py
+++ b/stripe/_file.py
@@ -195,7 +195,7 @@ class File(CreateableAPIResource["File"], ListableAPIResource["File"]):
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
                 base_address="files",
                 api_mode="V1FILES",
             ),

--- a/stripe/_file_link.py
+++ b/stripe/_file_link.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -14,7 +15,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._file import File
@@ -163,7 +163,7 @@ class FileLink(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -195,10 +195,14 @@ class FileLink(
         """
         Updates an existing file link object. Expired links can no longer be updated.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "FileLink",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_file_link.py
+++ b/stripe/_file_link.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._updateable_api_resource import UpdateableAPIResource
+from stripe._util import sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
@@ -195,7 +195,7 @@ class FileLink(
         """
         Updates an existing file link object. Expired links can no longer be updated.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "FileLink",
             cls._static_request(

--- a/stripe/_file_link_service.py
+++ b/stripe/_file_link_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._file_link import FileLink
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -146,7 +146,7 @@ class FileLinkService(StripeService):
             FileLink,
             self._requestor.request(
                 "get",
-                "/v1/file_links/{link}".format(link=_util.sanitize_id(link)),
+                "/v1/file_links/{link}".format(link=sanitize_id(link)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -167,7 +167,7 @@ class FileLinkService(StripeService):
             FileLink,
             self._requestor.request(
                 "post",
-                "/v1/file_links/{link}".format(link=_util.sanitize_id(link)),
+                "/v1/file_links/{link}".format(link=sanitize_id(link)),
                 api_mode="V1",
                 base_address="api",
                 params=params,

--- a/stripe/_file_service.py
+++ b/stripe/_file_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._file import File
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Any, Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -155,7 +155,7 @@ class FileService(StripeService):
             File,
             self._requestor.request(
                 "get",
-                "/v1/files/{file}".format(file=_util.sanitize_id(file)),
+                "/v1/files/{file}".format(file=sanitize_id(file)),
                 api_mode="V1",
                 base_address="api",
                 params=params,

--- a/stripe/_invoice.py
+++ b/stripe/_invoice.py
@@ -29,7 +29,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._account import Account
@@ -3738,7 +3737,7 @@ class Invoice(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -3749,10 +3748,14 @@ class Invoice(
         """
         Permanently deletes a one-off invoice draft. This cannot be undone. Attempts to delete invoices that are no longer in a draft state will fail; once an invoice has been finalized or if an invoice is for a subscription, it must be [voided](https://stripe.com/docs/api#void_invoice).
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
         return cast(
             "Invoice",
-            cls._static_request("delete", url, params=params),
+            cls._static_request(
+                "delete",
+                url,
+                params=params,
+            ),
         )
 
     @overload
@@ -3928,10 +3931,14 @@ class Invoice(
         sending reminders for, or [automatically reconciling](https://stripe.com/docs/billing/invoices/reconciliation) invoices, pass
         auto_advance=false.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Invoice",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_invoice.py
+++ b/stripe/_invoice.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._expandable_field import ExpandableField
@@ -11,7 +10,7 @@ from stripe._search_result_object import SearchResultObject
 from stripe._searchable_api_resource import SearchableAPIResource
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import (
     ClassVar,
     Dict,
@@ -3748,7 +3747,7 @@ class Invoice(
         """
         Permanently deletes a one-off invoice draft. This cannot be undone. Attempts to delete invoices that are no longer in a draft state will fail; once an invoice has been finalized or if an invoice is for a subscription, it must be [voided](https://stripe.com/docs/api#void_invoice).
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(sid))
         return cast(
             "Invoice",
             cls._static_request(
@@ -3800,7 +3799,7 @@ class Invoice(
             cls._static_request(
                 "post",
                 "/v1/invoices/{invoice}/finalize".format(
-                    invoice=_util.sanitize_id(invoice)
+                    invoice=sanitize_id(invoice)
                 ),
                 params=params,
             ),
@@ -3837,7 +3836,7 @@ class Invoice(
             self._request(
                 "post",
                 "/v1/invoices/{invoice}/finalize".format(
-                    invoice=_util.sanitize_id(self.get("id"))
+                    invoice=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -3876,7 +3875,7 @@ class Invoice(
             cls._static_request(
                 "post",
                 "/v1/invoices/{invoice}/mark_uncollectible".format(
-                    invoice=_util.sanitize_id(invoice)
+                    invoice=sanitize_id(invoice)
                 ),
                 params=params,
             ),
@@ -3913,7 +3912,7 @@ class Invoice(
             self._request(
                 "post",
                 "/v1/invoices/{invoice}/mark_uncollectible".format(
-                    invoice=_util.sanitize_id(self.get("id"))
+                    invoice=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -3931,7 +3930,7 @@ class Invoice(
         sending reminders for, or [automatically reconciling](https://stripe.com/docs/billing/invoices/reconciliation) invoices, pass
         auto_advance=false.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Invoice",
             cls._static_request(
@@ -3953,7 +3952,7 @@ class Invoice(
             cls._static_request(
                 "post",
                 "/v1/invoices/{invoice}/pay".format(
-                    invoice=_util.sanitize_id(invoice)
+                    invoice=sanitize_id(invoice)
                 ),
                 params=params,
             ),
@@ -3986,7 +3985,7 @@ class Invoice(
             self._request(
                 "post",
                 "/v1/invoices/{invoice}/pay".format(
-                    invoice=_util.sanitize_id(self.get("id"))
+                    invoice=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -4017,7 +4016,7 @@ class Invoice(
             cls._static_request(
                 "post",
                 "/v1/invoices/{invoice}/send".format(
-                    invoice=_util.sanitize_id(invoice)
+                    invoice=sanitize_id(invoice)
                 ),
                 params=params,
             ),
@@ -4060,7 +4059,7 @@ class Invoice(
             self._request(
                 "post",
                 "/v1/invoices/{invoice}/send".format(
-                    invoice=_util.sanitize_id(self.get("id"))
+                    invoice=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -4112,7 +4111,7 @@ class Invoice(
             cls._static_request(
                 "post",
                 "/v1/invoices/{invoice}/void".format(
-                    invoice=_util.sanitize_id(invoice)
+                    invoice=sanitize_id(invoice)
                 ),
                 params=params,
             ),
@@ -4149,7 +4148,7 @@ class Invoice(
             self._request(
                 "post",
                 "/v1/invoices/{invoice}/void".format(
-                    invoice=_util.sanitize_id(self.get("id"))
+                    invoice=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),

--- a/stripe/_invoice_item.py
+++ b/stripe/_invoice_item.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._expandable_field import ExpandableField
@@ -17,7 +18,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._customer import Customer
@@ -462,7 +462,7 @@ class InvoiceItem(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -473,10 +473,14 @@ class InvoiceItem(
         """
         Deletes an invoice item, removing it from an invoice. Deleting invoice items is only possible when they're not attached to invoices, or if it's attached to a draft invoice.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
         return cast(
             "InvoiceItem",
-            cls._static_request("delete", url, params=params),
+            cls._static_request(
+                "delete",
+                url,
+                params=params,
+            ),
         )
 
     @overload
@@ -539,10 +543,14 @@ class InvoiceItem(
         """
         Updates the amount or description of an invoice item on an upcoming invoice. Updating an invoice item is only possible before the invoice it's attached to is closed.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "InvoiceItem",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_invoice_item.py
+++ b/stripe/_invoice_item.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._expandable_field import ExpandableField
@@ -9,7 +8,7 @@ from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -473,7 +472,7 @@ class InvoiceItem(
         """
         Deletes an invoice item, removing it from an invoice. Deleting invoice items is only possible when they're not attached to invoices, or if it's attached to a draft invoice.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(sid))
         return cast(
             "InvoiceItem",
             cls._static_request(
@@ -543,7 +542,7 @@ class InvoiceItem(
         """
         Updates the amount or description of an invoice item on an upcoming invoice. Updating an invoice item is only possible before the invoice it's attached to is closed.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "InvoiceItem",
             cls._static_request(

--- a/stripe/_invoice_item_service.py
+++ b/stripe/_invoice_item_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._invoice_item import InvoiceItem
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -318,7 +318,7 @@ class InvoiceItemService(StripeService):
             self._requestor.request(
                 "delete",
                 "/v1/invoiceitems/{invoiceitem}".format(
-                    invoiceitem=_util.sanitize_id(invoiceitem),
+                    invoiceitem=sanitize_id(invoiceitem),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -341,7 +341,7 @@ class InvoiceItemService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/invoiceitems/{invoiceitem}".format(
-                    invoiceitem=_util.sanitize_id(invoiceitem),
+                    invoiceitem=sanitize_id(invoiceitem),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -364,7 +364,7 @@ class InvoiceItemService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/invoiceitems/{invoiceitem}".format(
-                    invoiceitem=_util.sanitize_id(invoiceitem),
+                    invoiceitem=sanitize_id(invoiceitem),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_invoice_line_item_service.py
+++ b/stripe/_invoice_line_item_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._invoice_line_item import InvoiceLineItem
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -42,7 +42,7 @@ class InvoiceLineItemService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/invoices/{invoice}/lines".format(
-                    invoice=_util.sanitize_id(invoice),
+                    invoice=sanitize_id(invoice),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_invoice_service.py
+++ b/stripe/_invoice_service.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._invoice import Invoice
 from stripe._invoice_line_item_service import InvoiceLineItemService
 from stripe._invoice_upcoming_lines_service import InvoiceUpcomingLinesService
@@ -8,6 +7,7 @@ from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._search_result_object import SearchResultObject
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -1905,9 +1905,7 @@ class InvoiceService(StripeService):
             Invoice,
             self._requestor.request(
                 "delete",
-                "/v1/invoices/{invoice}".format(
-                    invoice=_util.sanitize_id(invoice),
-                ),
+                "/v1/invoices/{invoice}".format(invoice=sanitize_id(invoice)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -1928,9 +1926,7 @@ class InvoiceService(StripeService):
             Invoice,
             self._requestor.request(
                 "get",
-                "/v1/invoices/{invoice}".format(
-                    invoice=_util.sanitize_id(invoice),
-                ),
+                "/v1/invoices/{invoice}".format(invoice=sanitize_id(invoice)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -1956,9 +1952,7 @@ class InvoiceService(StripeService):
             Invoice,
             self._requestor.request(
                 "post",
-                "/v1/invoices/{invoice}".format(
-                    invoice=_util.sanitize_id(invoice),
-                ),
+                "/v1/invoices/{invoice}".format(invoice=sanitize_id(invoice)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -2067,7 +2061,7 @@ class InvoiceService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/invoices/{invoice}/finalize".format(
-                    invoice=_util.sanitize_id(invoice),
+                    invoice=sanitize_id(invoice),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -2090,7 +2084,7 @@ class InvoiceService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/invoices/{invoice}/mark_uncollectible".format(
-                    invoice=_util.sanitize_id(invoice),
+                    invoice=sanitize_id(invoice),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -2113,7 +2107,7 @@ class InvoiceService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/invoices/{invoice}/pay".format(
-                    invoice=_util.sanitize_id(invoice),
+                    invoice=sanitize_id(invoice),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -2138,7 +2132,7 @@ class InvoiceService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/invoices/{invoice}/send".format(
-                    invoice=_util.sanitize_id(invoice),
+                    invoice=sanitize_id(invoice),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -2161,7 +2155,7 @@ class InvoiceService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/invoices/{invoice}/void".format(
-                    invoice=_util.sanitize_id(invoice),
+                    invoice=sanitize_id(invoice),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_mandate_service.py
+++ b/stripe/_mandate_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._mandate import Mandate
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -28,9 +28,7 @@ class MandateService(StripeService):
             Mandate,
             self._requestor.request(
                 "get",
-                "/v1/mandates/{mandate}".format(
-                    mandate=_util.sanitize_id(mandate),
-                ),
+                "/v1/mandates/{mandate}".format(mandate=sanitize_id(mandate)),
                 api_mode="V1",
                 base_address="api",
                 params=params,

--- a/stripe/_payment_intent.py
+++ b/stripe/_payment_intent.py
@@ -29,7 +29,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._account import Account
@@ -8035,7 +8034,7 @@ class PaymentIntent(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -8223,10 +8222,14 @@ class PaymentIntent(
         update and confirm at the same time, we recommend updating properties through
         the [confirm API](https://stripe.com/docs/api/payment_intents/confirm) instead.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "PaymentIntent",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_payment_intent.py
+++ b/stripe/_payment_intent.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -10,7 +9,7 @@ from stripe._search_result_object import SearchResultObject
 from stripe._searchable_api_resource import SearchableAPIResource
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import (
     Any,
     ClassVar,
@@ -7684,7 +7683,7 @@ class PaymentIntent(
             cls._static_request(
                 "post",
                 "/v1/payment_intents/{intent}/apply_customer_balance".format(
-                    intent=_util.sanitize_id(intent)
+                    intent=sanitize_id(intent)
                 ),
                 params=params,
             ),
@@ -7722,7 +7721,7 @@ class PaymentIntent(
             self._request(
                 "post",
                 "/v1/payment_intents/{intent}/apply_customer_balance".format(
-                    intent=_util.sanitize_id(self.get("id"))
+                    intent=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -7744,7 +7743,7 @@ class PaymentIntent(
             cls._static_request(
                 "post",
                 "/v1/payment_intents/{intent}/cancel".format(
-                    intent=_util.sanitize_id(intent)
+                    intent=sanitize_id(intent)
                 ),
                 params=params,
             ),
@@ -7793,7 +7792,7 @@ class PaymentIntent(
             self._request(
                 "post",
                 "/v1/payment_intents/{intent}/cancel".format(
-                    intent=_util.sanitize_id(self.get("id"))
+                    intent=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -7815,7 +7814,7 @@ class PaymentIntent(
             cls._static_request(
                 "post",
                 "/v1/payment_intents/{intent}/capture".format(
-                    intent=_util.sanitize_id(intent)
+                    intent=sanitize_id(intent)
                 ),
                 params=params,
             ),
@@ -7864,7 +7863,7 @@ class PaymentIntent(
             self._request(
                 "post",
                 "/v1/payment_intents/{intent}/capture".format(
-                    intent=_util.sanitize_id(self.get("id"))
+                    intent=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -7904,7 +7903,7 @@ class PaymentIntent(
             cls._static_request(
                 "post",
                 "/v1/payment_intents/{intent}/confirm".format(
-                    intent=_util.sanitize_id(intent)
+                    intent=sanitize_id(intent)
                 ),
                 params=params,
             ),
@@ -8007,7 +8006,7 @@ class PaymentIntent(
             self._request(
                 "post",
                 "/v1/payment_intents/{intent}/confirm".format(
-                    intent=_util.sanitize_id(self.get("id"))
+                    intent=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -8075,7 +8074,7 @@ class PaymentIntent(
             cls._static_request(
                 "post",
                 "/v1/payment_intents/{intent}/increment_authorization".format(
-                    intent=_util.sanitize_id(intent)
+                    intent=sanitize_id(intent)
                 ),
                 params=params,
             ),
@@ -8182,7 +8181,7 @@ class PaymentIntent(
             self._request(
                 "post",
                 "/v1/payment_intents/{intent}/increment_authorization".format(
-                    intent=_util.sanitize_id(self.get("id"))
+                    intent=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -8222,7 +8221,7 @@ class PaymentIntent(
         update and confirm at the same time, we recommend updating properties through
         the [confirm API](https://stripe.com/docs/api/payment_intents/confirm) instead.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "PaymentIntent",
             cls._static_request(
@@ -8261,7 +8260,7 @@ class PaymentIntent(
             cls._static_request(
                 "post",
                 "/v1/payment_intents/{intent}/verify_microdeposits".format(
-                    intent=_util.sanitize_id(intent)
+                    intent=sanitize_id(intent)
                 ),
                 params=params,
             ),
@@ -8299,7 +8298,7 @@ class PaymentIntent(
             self._request(
                 "post",
                 "/v1/payment_intents/{intent}/verify_microdeposits".format(
-                    intent=_util.sanitize_id(self.get("id"))
+                    intent=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),

--- a/stripe/_payment_intent_service.py
+++ b/stripe/_payment_intent_service.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._payment_intent import PaymentIntent
 from stripe._request_options import RequestOptions
 from stripe._search_result_object import SearchResultObject
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -5850,7 +5850,7 @@ class PaymentIntentService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/payment_intents/{intent}".format(
-                    intent=_util.sanitize_id(intent),
+                    intent=sanitize_id(intent),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -5879,7 +5879,7 @@ class PaymentIntentService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/payment_intents/{intent}".format(
-                    intent=_util.sanitize_id(intent),
+                    intent=sanitize_id(intent),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -5925,7 +5925,7 @@ class PaymentIntentService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/payment_intents/{intent}/apply_customer_balance".format(
-                    intent=_util.sanitize_id(intent),
+                    intent=sanitize_id(intent),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -5952,7 +5952,7 @@ class PaymentIntentService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/payment_intents/{intent}/cancel".format(
-                    intent=_util.sanitize_id(intent),
+                    intent=sanitize_id(intent),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -5979,7 +5979,7 @@ class PaymentIntentService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/payment_intents/{intent}/capture".format(
-                    intent=_util.sanitize_id(intent),
+                    intent=sanitize_id(intent),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -6024,7 +6024,7 @@ class PaymentIntentService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/payment_intents/{intent}/confirm".format(
-                    intent=_util.sanitize_id(intent),
+                    intent=sanitize_id(intent),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -6070,7 +6070,7 @@ class PaymentIntentService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/payment_intents/{intent}/increment_authorization".format(
-                    intent=_util.sanitize_id(intent),
+                    intent=sanitize_id(intent),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -6093,7 +6093,7 @@ class PaymentIntentService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/payment_intents/{intent}/verify_microdeposits".format(
-                    intent=_util.sanitize_id(intent),
+                    intent=sanitize_id(intent),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_payment_link.py
+++ b/stripe/_payment_link.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -8,7 +7,7 @@ from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -2475,7 +2474,7 @@ class PaymentLink(
             cls._static_request(
                 "get",
                 "/v1/payment_links/{payment_link}/line_items".format(
-                    payment_link=_util.sanitize_id(payment_link)
+                    payment_link=sanitize_id(payment_link)
                 ),
                 params=params,
             ),
@@ -2512,7 +2511,7 @@ class PaymentLink(
             self._request(
                 "get",
                 "/v1/payment_links/{payment_link}/line_items".format(
-                    payment_link=_util.sanitize_id(self.get("id"))
+                    payment_link=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -2525,7 +2524,7 @@ class PaymentLink(
         """
         Updates a payment link.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "PaymentLink",
             cls._static_request(

--- a/stripe/_payment_link.py
+++ b/stripe/_payment_link.py
@@ -17,7 +17,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._account import Account
@@ -2437,7 +2436,7 @@ class PaymentLink(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -2526,10 +2525,14 @@ class PaymentLink(
         """
         Updates a payment link.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "PaymentLink",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_payment_link_line_item_service.py
+++ b/stripe/_payment_link_line_item_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._line_item import LineItem
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -42,7 +42,7 @@ class PaymentLinkLineItemService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/payment_links/{payment_link}/line_items".format(
-                    payment_link=_util.sanitize_id(payment_link),
+                    payment_link=sanitize_id(payment_link),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_payment_link_service.py
+++ b/stripe/_payment_link_service.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._payment_link import PaymentLink
 from stripe._payment_link_line_item_service import PaymentLinkLineItemService
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -1674,7 +1674,7 @@ class PaymentLinkService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/payment_links/{payment_link}".format(
-                    payment_link=_util.sanitize_id(payment_link),
+                    payment_link=sanitize_id(payment_link),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -1697,7 +1697,7 @@ class PaymentLinkService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/payment_links/{payment_link}".format(
-                    payment_link=_util.sanitize_id(payment_link),
+                    payment_link=sanitize_id(payment_link),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_payment_method.py
+++ b/stripe/_payment_method.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -8,7 +7,7 @@ from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -1712,7 +1711,7 @@ class PaymentMethod(
             cls._static_request(
                 "post",
                 "/v1/payment_methods/{payment_method}/attach".format(
-                    payment_method=_util.sanitize_id(payment_method)
+                    payment_method=sanitize_id(payment_method)
                 ),
                 params=params,
             ),
@@ -1785,7 +1784,7 @@ class PaymentMethod(
             self._request(
                 "post",
                 "/v1/payment_methods/{payment_method}/attach".format(
-                    payment_method=_util.sanitize_id(self.get("id"))
+                    payment_method=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -1823,7 +1822,7 @@ class PaymentMethod(
             cls._static_request(
                 "post",
                 "/v1/payment_methods/{payment_method}/detach".format(
-                    payment_method=_util.sanitize_id(payment_method)
+                    payment_method=sanitize_id(payment_method)
                 ),
                 params=params,
             ),
@@ -1860,7 +1859,7 @@ class PaymentMethod(
             self._request(
                 "post",
                 "/v1/payment_methods/{payment_method}/detach".format(
-                    payment_method=_util.sanitize_id(self.get("id"))
+                    payment_method=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -1894,7 +1893,7 @@ class PaymentMethod(
         """
         Updates a PaymentMethod object. A PaymentMethod must be attached a customer to be updated.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "PaymentMethod",
             cls._static_request(

--- a/stripe/_payment_method.py
+++ b/stripe/_payment_method.py
@@ -17,7 +17,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._charge import Charge
@@ -1806,7 +1805,7 @@ class PaymentMethod(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -1895,10 +1894,14 @@ class PaymentMethod(
         """
         Updates a PaymentMethod object. A PaymentMethod must be attached a customer to be updated.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "PaymentMethod",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_payment_method_configuration.py
+++ b/stripe/_payment_method_configuration.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
+from stripe._util import sanitize_id
 from typing import ClassVar, List, Optional, cast
 from typing_extensions import Literal, NotRequired, TypedDict, Unpack
 
@@ -2377,7 +2377,7 @@ class PaymentMethodConfiguration(
         """
         Update payment method configuration
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "PaymentMethodConfiguration",
             cls._static_request(

--- a/stripe/_payment_method_configuration.py
+++ b/stripe/_payment_method_configuration.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
@@ -8,7 +9,6 @@ from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
 from typing import ClassVar, List, Optional, cast
 from typing_extensions import Literal, NotRequired, TypedDict, Unpack
-from urllib.parse import quote_plus
 
 
 class PaymentMethodConfiguration(
@@ -2343,7 +2343,7 @@ class PaymentMethodConfiguration(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -2377,10 +2377,14 @@ class PaymentMethodConfiguration(
         """
         Update payment method configuration
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "PaymentMethodConfiguration",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_payment_method_configuration_service.py
+++ b/stripe/_payment_method_configuration_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._payment_method_configuration import PaymentMethodConfiguration
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -1476,7 +1476,7 @@ class PaymentMethodConfigurationService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/payment_method_configurations/{configuration}".format(
-                    configuration=_util.sanitize_id(configuration),
+                    configuration=sanitize_id(configuration),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -1499,7 +1499,7 @@ class PaymentMethodConfigurationService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/payment_method_configurations/{configuration}".format(
-                    configuration=_util.sanitize_id(configuration),
+                    configuration=sanitize_id(configuration),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_payment_method_domain.py
+++ b/stripe/_payment_method_domain.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, List, Optional, cast, overload
 from typing_extensions import Literal, NotRequired, Unpack
 
@@ -243,7 +242,7 @@ class PaymentMethodDomain(
         """
         Updates an existing payment method domain.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "PaymentMethodDomain",
             cls._static_request(
@@ -283,9 +282,7 @@ class PaymentMethodDomain(
             cls._static_request(
                 "post",
                 "/v1/payment_method_domains/{payment_method_domain}/validate".format(
-                    payment_method_domain=_util.sanitize_id(
-                        payment_method_domain
-                    )
+                    payment_method_domain=sanitize_id(payment_method_domain)
                 ),
                 params=params,
             ),
@@ -338,7 +335,7 @@ class PaymentMethodDomain(
             self._request(
                 "post",
                 "/v1/payment_method_domains/{payment_method_domain}/validate".format(
-                    payment_method_domain=_util.sanitize_id(self.get("id"))
+                    payment_method_domain=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),

--- a/stripe/_payment_method_domain.py
+++ b/stripe/_payment_method_domain.py
@@ -10,7 +10,6 @@ from stripe._updateable_api_resource import UpdateableAPIResource
 from stripe._util import class_method_variant
 from typing import ClassVar, List, Optional, cast, overload
 from typing_extensions import Literal, NotRequired, Unpack
-from urllib.parse import quote_plus
 
 
 class PaymentMethodDomain(
@@ -212,7 +211,7 @@ class PaymentMethodDomain(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -244,10 +243,14 @@ class PaymentMethodDomain(
         """
         Updates an existing payment method domain.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "PaymentMethodDomain",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_payment_method_domain_service.py
+++ b/stripe/_payment_method_domain_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._payment_method_domain import PaymentMethodDomain
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -126,9 +126,7 @@ class PaymentMethodDomainService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/payment_method_domains/{payment_method_domain}".format(
-                    payment_method_domain=_util.sanitize_id(
-                        payment_method_domain
-                    ),
+                    payment_method_domain=sanitize_id(payment_method_domain),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -151,9 +149,7 @@ class PaymentMethodDomainService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/payment_method_domains/{payment_method_domain}".format(
-                    payment_method_domain=_util.sanitize_id(
-                        payment_method_domain
-                    ),
+                    payment_method_domain=sanitize_id(payment_method_domain),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -181,9 +177,7 @@ class PaymentMethodDomainService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/payment_method_domains/{payment_method_domain}/validate".format(
-                    payment_method_domain=_util.sanitize_id(
-                        payment_method_domain
-                    ),
+                    payment_method_domain=sanitize_id(payment_method_domain),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_payment_method_service.py
+++ b/stripe/_payment_method_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._payment_method import PaymentMethod
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -678,7 +678,7 @@ class PaymentMethodService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/payment_methods/{payment_method}".format(
-                    payment_method=_util.sanitize_id(payment_method),
+                    payment_method=sanitize_id(payment_method),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -701,7 +701,7 @@ class PaymentMethodService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/payment_methods/{payment_method}".format(
-                    payment_method=_util.sanitize_id(payment_method),
+                    payment_method=sanitize_id(payment_method),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -736,7 +736,7 @@ class PaymentMethodService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/payment_methods/{payment_method}/attach".format(
-                    payment_method=_util.sanitize_id(payment_method),
+                    payment_method=sanitize_id(payment_method),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -759,7 +759,7 @@ class PaymentMethodService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/payment_methods/{payment_method}/detach".format(
-                    payment_method=_util.sanitize_id(payment_method),
+                    payment_method=sanitize_id(payment_method),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_payout.py
+++ b/stripe/_payout.py
@@ -16,7 +16,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._balance_transaction import BalanceTransaction
@@ -340,7 +339,7 @@ class Payout(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -372,10 +371,14 @@ class Payout(
         """
         Updates the specified payout by setting the values of the parameters you pass. We don't change parameters that you don't provide. This request only accepts the metadata as arguments.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Payout",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_payout.py
+++ b/stripe/_payout.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, Union, cast, overload
 from typing_extensions import (
     Literal,
@@ -284,7 +283,7 @@ class Payout(
             cls._static_request(
                 "post",
                 "/v1/payouts/{payout}/cancel".format(
-                    payout=_util.sanitize_id(payout)
+                    payout=sanitize_id(payout)
                 ),
                 params=params,
             ),
@@ -319,7 +318,7 @@ class Payout(
             self._request(
                 "post",
                 "/v1/payouts/{payout}/cancel".format(
-                    payout=_util.sanitize_id(self.get("id"))
+                    payout=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -371,7 +370,7 @@ class Payout(
         """
         Updates the specified payout by setting the values of the parameters you pass. We don't change parameters that you don't provide. This request only accepts the metadata as arguments.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Payout",
             cls._static_request(
@@ -406,7 +405,7 @@ class Payout(
             cls._static_request(
                 "post",
                 "/v1/payouts/{payout}/reverse".format(
-                    payout=_util.sanitize_id(payout)
+                    payout=sanitize_id(payout)
                 ),
                 params=params,
             ),
@@ -447,7 +446,7 @@ class Payout(
             self._request(
                 "post",
                 "/v1/payouts/{payout}/reverse".format(
-                    payout=_util.sanitize_id(self.get("id"))
+                    payout=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),

--- a/stripe/_payout_service.py
+++ b/stripe/_payout_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._payout import Payout
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -201,9 +201,7 @@ class PayoutService(StripeService):
             Payout,
             self._requestor.request(
                 "get",
-                "/v1/payouts/{payout}".format(
-                    payout=_util.sanitize_id(payout)
-                ),
+                "/v1/payouts/{payout}".format(payout=sanitize_id(payout)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -224,9 +222,7 @@ class PayoutService(StripeService):
             Payout,
             self._requestor.request(
                 "post",
-                "/v1/payouts/{payout}".format(
-                    payout=_util.sanitize_id(payout)
-                ),
+                "/v1/payouts/{payout}".format(payout=sanitize_id(payout)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -248,7 +244,7 @@ class PayoutService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/payouts/{payout}/cancel".format(
-                    payout=_util.sanitize_id(payout),
+                    payout=sanitize_id(payout),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -273,7 +269,7 @@ class PayoutService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/payouts/{payout}/reverse".format(
-                    payout=_util.sanitize_id(payout),
+                    payout=sanitize_id(payout),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_person.py
+++ b/stripe/_person.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 import stripe
+from stripe import _util
 from stripe._expandable_field import ExpandableField
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
 from typing import ClassVar, Dict, List, Optional
 from typing_extensions import Literal, TYPE_CHECKING
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._file import File
@@ -651,8 +651,8 @@ class Person(UpdateableAPIResource["Person"]):
         account = self.account
         base = stripe.Account.class_url()
         assert account is not None
-        acct_extn = quote_plus(account)
-        extn = quote_plus(token)
+        acct_extn = _util.sanitize_id(account)
+        extn = _util.sanitize_id(token)
         return "%s/%s/persons/%s" % (base, acct_extn, extn)
 
     @classmethod

--- a/stripe/_person.py
+++ b/stripe/_person.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 import stripe
-from stripe import _util
 from stripe._expandable_field import ExpandableField
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
+from stripe._util import sanitize_id
 from typing import ClassVar, Dict, List, Optional
 from typing_extensions import Literal, TYPE_CHECKING
 
@@ -651,8 +651,8 @@ class Person(UpdateableAPIResource["Person"]):
         account = self.account
         base = stripe.Account.class_url()
         assert account is not None
-        acct_extn = _util.sanitize_id(account)
-        extn = _util.sanitize_id(token)
+        acct_extn = sanitize_id(account)
+        extn = sanitize_id(token)
         return "%s/%s/persons/%s" % (base, acct_extn, extn)
 
     @classmethod

--- a/stripe/_plan.py
+++ b/stripe/_plan.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._expandable_field import ExpandableField
@@ -9,7 +8,7 @@ from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, Union, cast, overload
 from typing_extensions import (
     Literal,
@@ -402,7 +401,7 @@ class Plan(
         """
         Deleting plans means new subscribers can't be added. Existing subscribers aren't affected.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(sid))
         return cast(
             "Plan",
             cls._static_request(
@@ -464,7 +463,7 @@ class Plan(
         """
         Updates the specified plan by setting the values of the parameters passed. Any parameters not provided are left unchanged. By design, you cannot change a plan's ID, amount, currency, or billing cycle.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Plan",
             cls._static_request(

--- a/stripe/_plan.py
+++ b/stripe/_plan.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._expandable_field import ExpandableField
@@ -17,7 +18,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._product import Product
@@ -391,7 +391,7 @@ class Plan(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -402,10 +402,14 @@ class Plan(
         """
         Deleting plans means new subscribers can't be added. Existing subscribers aren't affected.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
         return cast(
             "Plan",
-            cls._static_request("delete", url, params=params),
+            cls._static_request(
+                "delete",
+                url,
+                params=params,
+            ),
         )
 
     @overload
@@ -460,10 +464,14 @@ class Plan(
         """
         Updates the specified plan by setting the values of the parameters passed. Any parameters not provided are left unchanged. By design, you cannot change a plan's ID, amount, currency, or billing cycle.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Plan",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_plan_service.py
+++ b/stripe/_plan_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._plan import Plan
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, Union, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -243,7 +243,7 @@ class PlanService(StripeService):
             Plan,
             self._requestor.request(
                 "delete",
-                "/v1/plans/{plan}".format(plan=_util.sanitize_id(plan)),
+                "/v1/plans/{plan}".format(plan=sanitize_id(plan)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -264,7 +264,7 @@ class PlanService(StripeService):
             Plan,
             self._requestor.request(
                 "get",
-                "/v1/plans/{plan}".format(plan=_util.sanitize_id(plan)),
+                "/v1/plans/{plan}".format(plan=sanitize_id(plan)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -285,7 +285,7 @@ class PlanService(StripeService):
             Plan,
             self._requestor.request(
                 "post",
-                "/v1/plans/{plan}".format(plan=_util.sanitize_id(plan)),
+                "/v1/plans/{plan}".format(plan=sanitize_id(plan)),
                 api_mode="V1",
                 base_address="api",
                 params=params,

--- a/stripe/_price.py
+++ b/stripe/_price.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -10,6 +9,7 @@ from stripe._search_result_object import SearchResultObject
 from stripe._searchable_api_resource import SearchableAPIResource
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
+from stripe._util import sanitize_id
 from typing import ClassVar, Dict, Iterator, List, Optional, Union, cast
 from typing_extensions import (
     Literal,
@@ -759,7 +759,7 @@ class Price(
         """
         Updates the specified price by setting the values of the parameters passed. Any parameters not provided are left unchanged.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Price",
             cls._static_request(

--- a/stripe/_price.py
+++ b/stripe/_price.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -17,7 +18,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._product import Product
@@ -729,7 +729,7 @@ class Price(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -759,10 +759,14 @@ class Price(
         """
         Updates the specified price by setting the values of the parameters passed. Any parameters not provided are left unchanged.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Price",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_price_service.py
+++ b/stripe/_price_service.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._price import Price
 from stripe._request_options import RequestOptions
 from stripe._search_result_object import SearchResultObject
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, Union, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -526,7 +526,7 @@ class PriceService(StripeService):
             Price,
             self._requestor.request(
                 "get",
-                "/v1/prices/{price}".format(price=_util.sanitize_id(price)),
+                "/v1/prices/{price}".format(price=sanitize_id(price)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -547,7 +547,7 @@ class PriceService(StripeService):
             Price,
             self._requestor.request(
                 "post",
-                "/v1/prices/{price}".format(price=_util.sanitize_id(price)),
+                "/v1/prices/{price}".format(price=sanitize_id(price)),
                 api_mode="V1",
                 base_address="api",
                 params=params,

--- a/stripe/_product.py
+++ b/stripe/_product.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._expandable_field import ExpandableField
@@ -11,7 +10,7 @@ from stripe._search_result_object import SearchResultObject
 from stripe._searchable_api_resource import SearchableAPIResource
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import (
     ClassVar,
     Dict,
@@ -560,7 +559,7 @@ class Product(
         """
         Delete a product. Deleting a product is only possible if it has no prices associated with it. Additionally, deleting a product with type=good is only possible if it has no SKUs associated with it.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(sid))
         return cast(
             "Product",
             cls._static_request(
@@ -628,7 +627,7 @@ class Product(
         """
         Updates the specific product by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Product",
             cls._static_request(

--- a/stripe/_product.py
+++ b/stripe/_product.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._expandable_field import ExpandableField
@@ -28,7 +29,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._price import Price
@@ -549,7 +549,7 @@ class Product(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -560,10 +560,14 @@ class Product(
         """
         Delete a product. Deleting a product is only possible if it has no prices associated with it. Additionally, deleting a product with type=good is only possible if it has no SKUs associated with it.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
         return cast(
             "Product",
-            cls._static_request("delete", url, params=params),
+            cls._static_request(
+                "delete",
+                url,
+                params=params,
+            ),
         )
 
     @overload
@@ -624,10 +628,14 @@ class Product(
         """
         Updates the specific product by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Product",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_product_service.py
+++ b/stripe/_product_service.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._product import Product
 from stripe._request_options import RequestOptions
 from stripe._search_result_object import SearchResultObject
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, Union, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -409,7 +409,7 @@ class ProductService(StripeService):
             Product,
             self._requestor.request(
                 "delete",
-                "/v1/products/{id}".format(id=_util.sanitize_id(id)),
+                "/v1/products/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -430,7 +430,7 @@ class ProductService(StripeService):
             Product,
             self._requestor.request(
                 "get",
-                "/v1/products/{id}".format(id=_util.sanitize_id(id)),
+                "/v1/products/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -451,7 +451,7 @@ class ProductService(StripeService):
             Product,
             self._requestor.request(
                 "post",
-                "/v1/products/{id}".format(id=_util.sanitize_id(id)),
+                "/v1/products/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",
                 base_address="api",
                 params=params,

--- a/stripe/_promotion_code.py
+++ b/stripe/_promotion_code.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -8,6 +7,7 @@ from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
+from stripe._util import sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
@@ -314,7 +314,7 @@ class PromotionCode(
         """
         Updates the specified promotion code by setting the values of the parameters passed. Most fields are, by design, not editable.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "PromotionCode",
             cls._static_request(

--- a/stripe/_promotion_code.py
+++ b/stripe/_promotion_code.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -15,7 +16,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._coupon import Coupon
@@ -282,7 +282,7 @@ class PromotionCode(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -314,10 +314,14 @@ class PromotionCode(
         """
         Updates the specified promotion code by setting the values of the parameters passed. Most fields are, by design, not editable.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "PromotionCode",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_promotion_code_service.py
+++ b/stripe/_promotion_code_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._promotion_code import PromotionCode
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -226,7 +226,7 @@ class PromotionCodeService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/promotion_codes/{promotion_code}".format(
-                    promotion_code=_util.sanitize_id(promotion_code),
+                    promotion_code=sanitize_id(promotion_code),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -249,7 +249,7 @@ class PromotionCodeService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/promotion_codes/{promotion_code}".format(
-                    promotion_code=_util.sanitize_id(promotion_code),
+                    promotion_code=sanitize_id(promotion_code),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_quote.py
+++ b/stripe/_quote.py
@@ -17,7 +17,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._account import Account
@@ -1216,7 +1215,7 @@ class Quote(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -1414,10 +1413,14 @@ class Quote(
         """
         A quote models prices and services for a customer.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Quote",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_quote.py
+++ b/stripe/_quote.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -8,7 +7,7 @@ from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import Any, ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -1114,9 +1113,7 @@ class Quote(
             "Quote",
             cls._static_request(
                 "post",
-                "/v1/quotes/{quote}/accept".format(
-                    quote=_util.sanitize_id(quote)
-                ),
+                "/v1/quotes/{quote}/accept".format(quote=sanitize_id(quote)),
                 params=params,
             ),
         )
@@ -1148,7 +1145,7 @@ class Quote(
             self._request(
                 "post",
                 "/v1/quotes/{quote}/accept".format(
-                    quote=_util.sanitize_id(self.get("id"))
+                    quote=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -1165,9 +1162,7 @@ class Quote(
             "Quote",
             cls._static_request(
                 "post",
-                "/v1/quotes/{quote}/cancel".format(
-                    quote=_util.sanitize_id(quote)
-                ),
+                "/v1/quotes/{quote}/cancel".format(quote=sanitize_id(quote)),
                 params=params,
             ),
         )
@@ -1199,7 +1194,7 @@ class Quote(
             self._request(
                 "post",
                 "/v1/quotes/{quote}/cancel".format(
-                    quote=_util.sanitize_id(self.get("id"))
+                    quote=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -1230,9 +1225,7 @@ class Quote(
             "Quote",
             cls._static_request(
                 "post",
-                "/v1/quotes/{quote}/finalize".format(
-                    quote=_util.sanitize_id(quote)
-                ),
+                "/v1/quotes/{quote}/finalize".format(quote=sanitize_id(quote)),
                 params=params,
             ),
         )
@@ -1268,7 +1261,7 @@ class Quote(
             self._request(
                 "post",
                 "/v1/quotes/{quote}/finalize".format(
-                    quote=_util.sanitize_id(self.get("id"))
+                    quote=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -1307,7 +1300,7 @@ class Quote(
             cls._static_request(
                 "get",
                 "/v1/quotes/{quote}/computed_upfront_line_items".format(
-                    quote=_util.sanitize_id(quote)
+                    quote=sanitize_id(quote)
                 ),
                 params=params,
             ),
@@ -1345,7 +1338,7 @@ class Quote(
             self._request(
                 "get",
                 "/v1/quotes/{quote}/computed_upfront_line_items".format(
-                    quote=_util.sanitize_id(self.get("id"))
+                    quote=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -1363,7 +1356,7 @@ class Quote(
             cls._static_request(
                 "get",
                 "/v1/quotes/{quote}/line_items".format(
-                    quote=_util.sanitize_id(quote)
+                    quote=sanitize_id(quote)
                 ),
                 params=params,
             ),
@@ -1400,7 +1393,7 @@ class Quote(
             self._request(
                 "get",
                 "/v1/quotes/{quote}/line_items".format(
-                    quote=_util.sanitize_id(self.get("id"))
+                    quote=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -1413,7 +1406,7 @@ class Quote(
         """
         A quote models prices and services for a customer.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Quote",
             cls._static_request(
@@ -1432,9 +1425,7 @@ class Quote(
             Any,
             cls._static_request_stream(
                 "get",
-                "/v1/quotes/{quote}/pdf".format(
-                    quote=_util.sanitize_id(quote)
-                ),
+                "/v1/quotes/{quote}/pdf".format(quote=sanitize_id(quote)),
                 params=params,
                 base_address="files",
             ),
@@ -1467,7 +1458,7 @@ class Quote(
             self._request_stream(
                 "get",
                 "/v1/quotes/{quote}/pdf".format(
-                    quote=_util.sanitize_id(self.get("id"))
+                    quote=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),

--- a/stripe/_quote_computed_upfront_line_items_service.py
+++ b/stripe/_quote_computed_upfront_line_items_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._line_item import LineItem
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -42,7 +42,7 @@ class QuoteComputedUpfrontLineItemsService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/quotes/{quote}/computed_upfront_line_items".format(
-                    quote=_util.sanitize_id(quote),
+                    quote=sanitize_id(quote),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_quote_line_item_service.py
+++ b/stripe/_quote_line_item_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._line_item import LineItem
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -42,7 +42,7 @@ class QuoteLineItemService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/quotes/{quote}/line_items".format(
-                    quote=_util.sanitize_id(quote),
+                    quote=sanitize_id(quote),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_quote_service.py
+++ b/stripe/_quote_service.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._quote import Quote
 from stripe._quote_computed_upfront_line_items_service import (
@@ -9,6 +8,7 @@ from stripe._quote_computed_upfront_line_items_service import (
 from stripe._quote_line_item_service import QuoteLineItemService
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Any, Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -618,7 +618,7 @@ class QuoteService(StripeService):
             Quote,
             self._requestor.request(
                 "get",
-                "/v1/quotes/{quote}".format(quote=_util.sanitize_id(quote)),
+                "/v1/quotes/{quote}".format(quote=sanitize_id(quote)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -639,7 +639,7 @@ class QuoteService(StripeService):
             Quote,
             self._requestor.request(
                 "post",
-                "/v1/quotes/{quote}".format(quote=_util.sanitize_id(quote)),
+                "/v1/quotes/{quote}".format(quote=sanitize_id(quote)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -660,9 +660,7 @@ class QuoteService(StripeService):
             Quote,
             self._requestor.request(
                 "post",
-                "/v1/quotes/{quote}/accept".format(
-                    quote=_util.sanitize_id(quote),
-                ),
+                "/v1/quotes/{quote}/accept".format(quote=sanitize_id(quote)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -683,9 +681,7 @@ class QuoteService(StripeService):
             Quote,
             self._requestor.request(
                 "post",
-                "/v1/quotes/{quote}/cancel".format(
-                    quote=_util.sanitize_id(quote),
-                ),
+                "/v1/quotes/{quote}/cancel".format(quote=sanitize_id(quote)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -706,9 +702,7 @@ class QuoteService(StripeService):
             Quote,
             self._requestor.request(
                 "post",
-                "/v1/quotes/{quote}/finalize".format(
-                    quote=_util.sanitize_id(quote),
-                ),
+                "/v1/quotes/{quote}/finalize".format(quote=sanitize_id(quote)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -729,9 +723,7 @@ class QuoteService(StripeService):
             Any,
             self._requestor.request_stream(
                 "get",
-                "/v1/quotes/{quote}/pdf".format(
-                    quote=_util.sanitize_id(quote)
-                ),
+                "/v1/quotes/{quote}/pdf".format(quote=sanitize_id(quote)),
                 api_mode="V1",
                 base_address="files",
                 params=params,

--- a/stripe/_refund.py
+++ b/stripe/_refund.py
@@ -12,7 +12,6 @@ from stripe._updateable_api_resource import UpdateableAPIResource
 from stripe._util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import Literal, NotRequired, Type, Unpack, TYPE_CHECKING
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._balance_transaction import BalanceTransaction
@@ -548,7 +547,7 @@ class Refund(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -582,10 +581,14 @@ class Refund(
 
         This request only accepts metadata as an argument.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Refund",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_refund.py
+++ b/stripe/_refund.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -9,7 +8,7 @@ from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._test_helpers import APIResourceTestHelpers
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import Literal, NotRequired, Type, Unpack, TYPE_CHECKING
 
@@ -480,7 +479,7 @@ class Refund(
             cls._static_request(
                 "post",
                 "/v1/refunds/{refund}/cancel".format(
-                    refund=_util.sanitize_id(refund)
+                    refund=sanitize_id(refund)
                 ),
                 params=params,
             ),
@@ -521,7 +520,7 @@ class Refund(
             self._request(
                 "post",
                 "/v1/refunds/{refund}/cancel".format(
-                    refund=_util.sanitize_id(self.get("id"))
+                    refund=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -581,7 +580,7 @@ class Refund(
 
         This request only accepts metadata as an argument.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Refund",
             cls._static_request(
@@ -617,7 +616,7 @@ class Refund(
                 cls._static_request(
                     "post",
                     "/v1/test_helpers/refunds/{refund}/expire".format(
-                        refund=_util.sanitize_id(refund)
+                        refund=sanitize_id(refund)
                     ),
                     params=params,
                 ),
@@ -652,7 +651,7 @@ class Refund(
                 self.resource._request(
                     "post",
                     "/v1/test_helpers/refunds/{refund}/expire".format(
-                        refund=_util.sanitize_id(self.resource.get("id"))
+                        refund=sanitize_id(self.resource.get("id"))
                     ),
                     params=params,
                 ),

--- a/stripe/_refund_service.py
+++ b/stripe/_refund_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._refund import Refund
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -191,9 +191,7 @@ class RefundService(StripeService):
             Refund,
             self._requestor.request(
                 "get",
-                "/v1/refunds/{refund}".format(
-                    refund=_util.sanitize_id(refund)
-                ),
+                "/v1/refunds/{refund}".format(refund=sanitize_id(refund)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -216,9 +214,7 @@ class RefundService(StripeService):
             Refund,
             self._requestor.request(
                 "post",
-                "/v1/refunds/{refund}".format(
-                    refund=_util.sanitize_id(refund)
-                ),
+                "/v1/refunds/{refund}".format(refund=sanitize_id(refund)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -242,7 +238,7 @@ class RefundService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/refunds/{refund}/cancel".format(
-                    refund=_util.sanitize_id(refund),
+                    refund=sanitize_id(refund),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_reversal.py
+++ b/stripe/_reversal.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._expandable_field import ExpandableField
 from stripe._transfer import Transfer
 from stripe._updateable_api_resource import UpdateableAPIResource
+from stripe._util import sanitize_id
 from typing import ClassVar, Dict, Optional
 from typing_extensions import Literal, TYPE_CHECKING
 
@@ -77,8 +77,8 @@ class Reversal(UpdateableAPIResource["Reversal"]):
         if isinstance(transfer, Transfer):
             transfer = transfer.id
         base = Transfer.class_url()
-        cust_extn = _util.sanitize_id(transfer)
-        extn = _util.sanitize_id(token)
+        cust_extn = sanitize_id(transfer)
+        extn = sanitize_id(token)
         return "%s/%s/reversals/%s" % (base, cust_extn, extn)
 
     @classmethod

--- a/stripe/_reversal.py
+++ b/stripe/_reversal.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._expandable_field import ExpandableField
 from stripe._transfer import Transfer
 from stripe._updateable_api_resource import UpdateableAPIResource
 from typing import ClassVar, Dict, Optional
 from typing_extensions import Literal, TYPE_CHECKING
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._balance_transaction import BalanceTransaction
@@ -77,8 +77,8 @@ class Reversal(UpdateableAPIResource["Reversal"]):
         if isinstance(transfer, Transfer):
             transfer = transfer.id
         base = Transfer.class_url()
-        cust_extn = quote_plus(transfer)
-        extn = quote_plus(token)
+        cust_extn = _util.sanitize_id(transfer)
+        extn = _util.sanitize_id(token)
         return "%s/%s/reversals/%s" % (base, cust_extn, extn)
 
     @classmethod

--- a/stripe/_review.py
+++ b/stripe/_review.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -193,7 +192,7 @@ class Review(ListableAPIResource["Review"]):
             cls._static_request(
                 "post",
                 "/v1/reviews/{review}/approve".format(
-                    review=_util.sanitize_id(review)
+                    review=sanitize_id(review)
                 ),
                 params=params,
             ),
@@ -228,7 +227,7 @@ class Review(ListableAPIResource["Review"]):
             self._request(
                 "post",
                 "/v1/reviews/{review}/approve".format(
-                    review=_util.sanitize_id(self.get("id"))
+                    review=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),

--- a/stripe/_review_service.py
+++ b/stripe/_review_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._review import Review
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -92,9 +92,7 @@ class ReviewService(StripeService):
             Review,
             self._requestor.request(
                 "get",
-                "/v1/reviews/{review}".format(
-                    review=_util.sanitize_id(review)
-                ),
+                "/v1/reviews/{review}".format(review=sanitize_id(review)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -116,7 +114,7 @@ class ReviewService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/reviews/{review}/approve".format(
-                    review=_util.sanitize_id(review),
+                    review=sanitize_id(review),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_setup_intent.py
+++ b/stripe/_setup_intent.py
@@ -17,7 +17,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._account import Account
@@ -3652,7 +3651,7 @@ class SetupIntent(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -3684,10 +3683,14 @@ class SetupIntent(
         """
         Updates a SetupIntent object.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "SetupIntent",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_setup_intent.py
+++ b/stripe/_setup_intent.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -8,7 +7,7 @@ from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import Any, ClassVar, Dict, List, Optional, Union, cast, overload
 from typing_extensions import (
     Literal,
@@ -3480,7 +3479,7 @@ class SetupIntent(
             cls._static_request(
                 "post",
                 "/v1/setup_intents/{intent}/cancel".format(
-                    intent=_util.sanitize_id(intent)
+                    intent=sanitize_id(intent)
                 ),
                 params=params,
             ),
@@ -3523,7 +3522,7 @@ class SetupIntent(
             self._request(
                 "post",
                 "/v1/setup_intents/{intent}/cancel".format(
-                    intent=_util.sanitize_id(self.get("id"))
+                    intent=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -3554,7 +3553,7 @@ class SetupIntent(
             cls._static_request(
                 "post",
                 "/v1/setup_intents/{intent}/confirm".format(
-                    intent=_util.sanitize_id(intent)
+                    intent=sanitize_id(intent)
                 ),
                 params=params,
             ),
@@ -3630,7 +3629,7 @@ class SetupIntent(
             self._request(
                 "post",
                 "/v1/setup_intents/{intent}/confirm".format(
-                    intent=_util.sanitize_id(self.get("id"))
+                    intent=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -3683,7 +3682,7 @@ class SetupIntent(
         """
         Updates a SetupIntent object.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "SetupIntent",
             cls._static_request(
@@ -3722,7 +3721,7 @@ class SetupIntent(
             cls._static_request(
                 "post",
                 "/v1/setup_intents/{intent}/verify_microdeposits".format(
-                    intent=_util.sanitize_id(intent)
+                    intent=sanitize_id(intent)
                 ),
                 params=params,
             ),
@@ -3759,7 +3758,7 @@ class SetupIntent(
             self._request(
                 "post",
                 "/v1/setup_intents/{intent}/verify_microdeposits".format(
-                    intent=_util.sanitize_id(self.get("id"))
+                    intent=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),

--- a/stripe/_setup_intent_service.py
+++ b/stripe/_setup_intent_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._setup_intent import SetupIntent
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -2908,7 +2908,7 @@ class SetupIntentService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/setup_intents/{intent}".format(
-                    intent=_util.sanitize_id(intent),
+                    intent=sanitize_id(intent)
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -2931,7 +2931,7 @@ class SetupIntentService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/setup_intents/{intent}".format(
-                    intent=_util.sanitize_id(intent),
+                    intent=sanitize_id(intent)
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -2956,7 +2956,7 @@ class SetupIntentService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/setup_intents/{intent}/cancel".format(
-                    intent=_util.sanitize_id(intent),
+                    intent=sanitize_id(intent),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -2992,7 +2992,7 @@ class SetupIntentService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/setup_intents/{intent}/confirm".format(
-                    intent=_util.sanitize_id(intent),
+                    intent=sanitize_id(intent),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -3015,7 +3015,7 @@ class SetupIntentService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/setup_intents/{intent}/verify_microdeposits".format(
-                    intent=_util.sanitize_id(intent),
+                    intent=sanitize_id(intent),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_shipping_rate.py
+++ b/stripe/_shipping_rate.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -8,6 +7,7 @@ from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
+from stripe._util import sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
@@ -378,7 +378,7 @@ class ShippingRate(
         """
         Updates an existing shipping rate object.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "ShippingRate",
             cls._static_request(

--- a/stripe/_shipping_rate.py
+++ b/stripe/_shipping_rate.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -15,7 +16,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._tax_code import TaxCode
@@ -346,7 +346,7 @@ class ShippingRate(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -378,10 +378,14 @@ class ShippingRate(
         """
         Updates an existing shipping rate object.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "ShippingRate",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_shipping_rate_service.py
+++ b/stripe/_shipping_rate_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._shipping_rate import ShippingRate
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -266,7 +266,7 @@ class ShippingRateService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/shipping_rates/{shipping_rate_token}".format(
-                    shipping_rate_token=_util.sanitize_id(shipping_rate_token),
+                    shipping_rate_token=sanitize_id(shipping_rate_token),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -289,7 +289,7 @@ class ShippingRateService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/shipping_rates/{shipping_rate_token}".format(
-                    shipping_rate_token=_util.sanitize_id(shipping_rate_token),
+                    shipping_rate_token=sanitize_id(shipping_rate_token),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_source.py
+++ b/stripe/_source.py
@@ -17,7 +17,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._source_transaction import SourceTransaction
@@ -1121,7 +1120,7 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -1191,10 +1190,14 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
 
         This request accepts the metadata and owner as arguments. It is also possible to update type specific information for selected payment methods. Please refer to our [payment method guides](https://stripe.com/docs/sources) for more detail.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Source",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod
@@ -1265,10 +1268,10 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
         token = self.id
 
         if hasattr(self, "customer") and self.customer:
-            extn = quote_plus(token)
+            extn = _util.sanitize_id(token)
             customer = self.customer
             base = Customer.class_url()
-            owner_extn = quote_plus(customer)
+            owner_extn = _util.sanitize_id(customer)
             url = "%s/%s/sources/%s" % (base, owner_extn, extn)
 
             self._request_and_refresh("delete", url, params)

--- a/stripe/_source.py
+++ b/stripe/_source.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._customer import Customer
 from stripe._error import InvalidRequestError
@@ -8,7 +7,7 @@ from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -1138,7 +1137,7 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
             cls._static_request(
                 "get",
                 "/v1/sources/{source}/source_transactions".format(
-                    source=_util.sanitize_id(source)
+                    source=sanitize_id(source)
                 ),
                 params=params,
             ),
@@ -1175,7 +1174,7 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
             self._request(
                 "get",
                 "/v1/sources/{source}/source_transactions".format(
-                    source=_util.sanitize_id(self.get("id"))
+                    source=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -1190,7 +1189,7 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
 
         This request accepts the metadata and owner as arguments. It is also possible to update type specific information for selected payment methods. Please refer to our [payment method guides](https://stripe.com/docs/sources) for more detail.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Source",
             cls._static_request(
@@ -1223,7 +1222,7 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
             cls._static_request(
                 "post",
                 "/v1/sources/{source}/verify".format(
-                    source=_util.sanitize_id(source)
+                    source=sanitize_id(source)
                 ),
                 params=params,
             ),
@@ -1258,7 +1257,7 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
             self._request(
                 "post",
                 "/v1/sources/{source}/verify".format(
-                    source=_util.sanitize_id(self.get("id"))
+                    source=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -1268,10 +1267,10 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
         token = self.id
 
         if hasattr(self, "customer") and self.customer:
-            extn = _util.sanitize_id(token)
+            extn = sanitize_id(token)
             customer = self.customer
             base = Customer.class_url()
-            owner_extn = _util.sanitize_id(customer)
+            owner_extn = sanitize_id(customer)
             url = "%s/%s/sources/%s" % (base, owner_extn, extn)
 
             self._request_and_refresh("delete", url, params)

--- a/stripe/_source_service.py
+++ b/stripe/_source_service.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._account import Account
 from stripe._bank_account import BankAccount
 from stripe._card import Card
@@ -8,6 +7,7 @@ from stripe._request_options import RequestOptions
 from stripe._source import Source
 from stripe._source_transaction_service import SourceTransactionService
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, Union, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -548,8 +548,8 @@ class SourceService(StripeService):
             self._requestor.request(
                 "delete",
                 "/v1/customers/{customer}/sources/{id}".format(
-                    customer=_util.sanitize_id(customer),
-                    id=_util.sanitize_id(id),
+                    customer=sanitize_id(customer),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -571,9 +571,7 @@ class SourceService(StripeService):
             Source,
             self._requestor.request(
                 "get",
-                "/v1/sources/{source}".format(
-                    source=_util.sanitize_id(source)
-                ),
+                "/v1/sources/{source}".format(source=sanitize_id(source)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -596,9 +594,7 @@ class SourceService(StripeService):
             Source,
             self._requestor.request(
                 "post",
-                "/v1/sources/{source}".format(
-                    source=_util.sanitize_id(source)
-                ),
+                "/v1/sources/{source}".format(source=sanitize_id(source)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -640,7 +636,7 @@ class SourceService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/sources/{source}/verify".format(
-                    source=_util.sanitize_id(source),
+                    source=sanitize_id(source),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_source_transaction_service.py
+++ b/stripe/_source_transaction_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._source_transaction import SourceTransaction
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -42,7 +42,7 @@ class SourceTransactionService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/sources/{source}/source_transactions".format(
-                    source=_util.sanitize_id(source),
+                    source=sanitize_id(source),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_subscription.py
+++ b/stripe/_subscription.py
@@ -29,7 +29,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._account import Account
@@ -2060,7 +2059,7 @@ class Subscription(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -2172,10 +2171,14 @@ class Subscription(
 
         Updating the quantity on a subscription many times in an hour may result in [rate limiting. If you need to bill for a frequently changing quantity, consider integrating <a href="/docs/billing/subscriptions/usage-based">usage-based billing](https://stripe.com/docs/rate-limits) instead.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Subscription",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_subscription.py
+++ b/stripe/_subscription.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._expandable_field import ExpandableField
@@ -11,7 +10,7 @@ from stripe._search_result_object import SearchResultObject
 from stripe._searchable_api_resource import SearchableAPIResource
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import (
     ClassVar,
     Dict,
@@ -1983,7 +1982,7 @@ class Subscription(
             cls._static_request(
                 "delete",
                 "/v1/subscriptions/{subscription_exposed_id}".format(
-                    subscription_exposed_id=_util.sanitize_id(
+                    subscription_exposed_id=sanitize_id(
                         subscription_exposed_id
                     )
                 ),
@@ -2035,7 +2034,7 @@ class Subscription(
             self._request(
                 "delete",
                 "/v1/subscriptions/{subscription_exposed_id}".format(
-                    subscription_exposed_id=_util.sanitize_id(self.get("id"))
+                    subscription_exposed_id=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -2077,7 +2076,7 @@ class Subscription(
             cls._static_request(
                 "delete",
                 "/v1/subscriptions/{subscription_exposed_id}/discount".format(
-                    subscription_exposed_id=_util.sanitize_id(
+                    subscription_exposed_id=sanitize_id(
                         subscription_exposed_id
                     )
                 ),
@@ -2117,7 +2116,7 @@ class Subscription(
             self._request(
                 "delete",
                 "/v1/subscriptions/{subscription_exposed_id}/discount".format(
-                    subscription_exposed_id=_util.sanitize_id(self.get("id"))
+                    subscription_exposed_id=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -2171,7 +2170,7 @@ class Subscription(
 
         Updating the quantity on a subscription many times in an hour may result in [rate limiting. If you need to bill for a frequently changing quantity, consider integrating <a href="/docs/billing/subscriptions/usage-based">usage-based billing](https://stripe.com/docs/rate-limits) instead.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Subscription",
             cls._static_request(
@@ -2193,7 +2192,7 @@ class Subscription(
             cls._static_request(
                 "post",
                 "/v1/subscriptions/{subscription}/resume".format(
-                    subscription=_util.sanitize_id(subscription)
+                    subscription=sanitize_id(subscription)
                 ),
                 params=params,
             ),
@@ -2230,7 +2229,7 @@ class Subscription(
             self._request(
                 "post",
                 "/v1/subscriptions/{subscription}/resume".format(
-                    subscription=_util.sanitize_id(self.get("id"))
+                    subscription=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),

--- a/stripe/_subscription_item.py
+++ b/stripe/_subscription_item.py
@@ -18,7 +18,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._plan import Plan
@@ -410,7 +409,7 @@ class SubscriptionItem(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -421,10 +420,14 @@ class SubscriptionItem(
         """
         Deletes an item from the subscription. Removing a subscription item from a subscription will not cancel the subscription.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
         return cast(
             "SubscriptionItem",
-            cls._static_request("delete", url, params=params),
+            cls._static_request(
+                "delete",
+                url,
+                params=params,
+            ),
         )
 
     @overload
@@ -487,10 +490,14 @@ class SubscriptionItem(
         """
         Updates the plan or quantity of an item on a current subscription.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "SubscriptionItem",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_subscription_item.py
+++ b/stripe/_subscription_item.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._list_object import ListObject
@@ -9,7 +8,7 @@ from stripe._nested_resource_class_methods import nested_resource_class_methods
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -420,7 +419,7 @@ class SubscriptionItem(
         """
         Deletes an item from the subscription. Removing a subscription item from a subscription will not cancel the subscription.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(sid))
         return cast(
             "SubscriptionItem",
             cls._static_request(
@@ -490,7 +489,7 @@ class SubscriptionItem(
         """
         Updates the plan or quantity of an item on a current subscription.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "SubscriptionItem",
             cls._static_request(
@@ -531,7 +530,7 @@ class SubscriptionItem(
             cls._static_request(
                 "post",
                 "/v1/subscription_items/{subscription_item}/usage_records".format(
-                    subscription_item=_util.sanitize_id(subscription_item)
+                    subscription_item=sanitize_id(subscription_item)
                 ),
                 params=params,
             ),
@@ -553,7 +552,7 @@ class SubscriptionItem(
             cls._static_request(
                 "get",
                 "/v1/subscription_items/{subscription_item}/usage_record_summaries".format(
-                    subscription_item=_util.sanitize_id(subscription_item)
+                    subscription_item=sanitize_id(subscription_item)
                 ),
                 params=params,
             ),

--- a/stripe/_subscription_item_service.py
+++ b/stripe/_subscription_item_service.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
@@ -11,6 +10,7 @@ from stripe._subscription_item_usage_record_service import (
 from stripe._subscription_item_usage_record_summary_service import (
     SubscriptionItemUsageRecordSummaryService,
 )
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -300,9 +300,7 @@ class SubscriptionItemService(StripeService):
             SubscriptionItem,
             self._requestor.request(
                 "delete",
-                "/v1/subscription_items/{item}".format(
-                    item=_util.sanitize_id(item),
-                ),
+                "/v1/subscription_items/{item}".format(item=sanitize_id(item)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -323,9 +321,7 @@ class SubscriptionItemService(StripeService):
             SubscriptionItem,
             self._requestor.request(
                 "get",
-                "/v1/subscription_items/{item}".format(
-                    item=_util.sanitize_id(item),
-                ),
+                "/v1/subscription_items/{item}".format(item=sanitize_id(item)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -346,9 +342,7 @@ class SubscriptionItemService(StripeService):
             SubscriptionItem,
             self._requestor.request(
                 "post",
-                "/v1/subscription_items/{item}".format(
-                    item=_util.sanitize_id(item),
-                ),
+                "/v1/subscription_items/{item}".format(item=sanitize_id(item)),
                 api_mode="V1",
                 base_address="api",
                 params=params,

--- a/stripe/_subscription_item_usage_record_service.py
+++ b/stripe/_subscription_item_usage_record_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
 from stripe._usage_record import UsageRecord
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -47,7 +47,7 @@ class SubscriptionItemUsageRecordService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/subscription_items/{subscription_item}/usage_records".format(
-                    subscription_item=_util.sanitize_id(subscription_item),
+                    subscription_item=sanitize_id(subscription_item),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_subscription_item_usage_record_summary_service.py
+++ b/stripe/_subscription_item_usage_record_summary_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
 from stripe._usage_record_summary import UsageRecordSummary
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -44,7 +44,7 @@ class SubscriptionItemUsageRecordSummaryService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/subscription_items/{subscription_item}/usage_record_summaries".format(
-                    subscription_item=_util.sanitize_id(subscription_item),
+                    subscription_item=sanitize_id(subscription_item),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_subscription_schedule.py
+++ b/stripe/_subscription_schedule.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -8,7 +7,7 @@ from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -1481,7 +1480,7 @@ class SubscriptionSchedule(
             cls._static_request(
                 "post",
                 "/v1/subscription_schedules/{schedule}/cancel".format(
-                    schedule=_util.sanitize_id(schedule)
+                    schedule=sanitize_id(schedule)
                 ),
                 params=params,
             ),
@@ -1518,7 +1517,7 @@ class SubscriptionSchedule(
             self._request(
                 "post",
                 "/v1/subscription_schedules/{schedule}/cancel".format(
-                    schedule=_util.sanitize_id(self.get("id"))
+                    schedule=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -1568,7 +1567,7 @@ class SubscriptionSchedule(
         """
         Updates an existing subscription schedule.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "SubscriptionSchedule",
             cls._static_request(
@@ -1592,7 +1591,7 @@ class SubscriptionSchedule(
             cls._static_request(
                 "post",
                 "/v1/subscription_schedules/{schedule}/release".format(
-                    schedule=_util.sanitize_id(schedule)
+                    schedule=sanitize_id(schedule)
                 ),
                 params=params,
             ),
@@ -1629,7 +1628,7 @@ class SubscriptionSchedule(
             self._request(
                 "post",
                 "/v1/subscription_schedules/{schedule}/release".format(
-                    schedule=_util.sanitize_id(self.get("id"))
+                    schedule=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),

--- a/stripe/_subscription_schedule.py
+++ b/stripe/_subscription_schedule.py
@@ -17,7 +17,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._account import Account
@@ -1537,7 +1536,7 @@ class SubscriptionSchedule(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -1569,10 +1568,14 @@ class SubscriptionSchedule(
         """
         Updates an existing subscription schedule.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "SubscriptionSchedule",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_subscription_schedule_service.py
+++ b/stripe/_subscription_schedule_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
 from stripe._subscription_schedule import SubscriptionSchedule
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -1106,7 +1106,7 @@ class SubscriptionScheduleService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/subscription_schedules/{schedule}".format(
-                    schedule=_util.sanitize_id(schedule),
+                    schedule=sanitize_id(schedule),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -1129,7 +1129,7 @@ class SubscriptionScheduleService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/subscription_schedules/{schedule}".format(
-                    schedule=_util.sanitize_id(schedule),
+                    schedule=sanitize_id(schedule),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -1152,7 +1152,7 @@ class SubscriptionScheduleService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/subscription_schedules/{schedule}/cancel".format(
-                    schedule=_util.sanitize_id(schedule),
+                    schedule=sanitize_id(schedule),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -1175,7 +1175,7 @@ class SubscriptionScheduleService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/subscription_schedules/{schedule}/release".format(
-                    schedule=_util.sanitize_id(schedule),
+                    schedule=sanitize_id(schedule),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_subscription_service.py
+++ b/stripe/_subscription_service.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._discount import Discount
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._search_result_object import SearchResultObject
 from stripe._stripe_service import StripeService
 from stripe._subscription import Subscription
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -1408,7 +1408,7 @@ class SubscriptionService(StripeService):
             self._requestor.request(
                 "delete",
                 "/v1/subscriptions/{subscription_exposed_id}".format(
-                    subscription_exposed_id=_util.sanitize_id(
+                    subscription_exposed_id=sanitize_id(
                         subscription_exposed_id
                     ),
                 ),
@@ -1433,7 +1433,7 @@ class SubscriptionService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/subscriptions/{subscription_exposed_id}".format(
-                    subscription_exposed_id=_util.sanitize_id(
+                    subscription_exposed_id=sanitize_id(
                         subscription_exposed_id
                     ),
                 ),
@@ -1478,7 +1478,7 @@ class SubscriptionService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/subscriptions/{subscription_exposed_id}".format(
-                    subscription_exposed_id=_util.sanitize_id(
+                    subscription_exposed_id=sanitize_id(
                         subscription_exposed_id
                     ),
                 ),
@@ -1503,7 +1503,7 @@ class SubscriptionService(StripeService):
             self._requestor.request(
                 "delete",
                 "/v1/subscriptions/{subscription_exposed_id}/discount".format(
-                    subscription_exposed_id=_util.sanitize_id(
+                    subscription_exposed_id=sanitize_id(
                         subscription_exposed_id
                     ),
                 ),
@@ -1597,7 +1597,7 @@ class SubscriptionService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/subscriptions/{subscription}/resume".format(
-                    subscription=_util.sanitize_id(subscription),
+                    subscription=sanitize_id(subscription),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_tax_code_service.py
+++ b/stripe/_tax_code_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
 from stripe._tax_code import TaxCode
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -67,7 +67,7 @@ class TaxCodeService(StripeService):
             TaxCode,
             self._requestor.request(
                 "get",
-                "/v1/tax_codes/{id}".format(id=_util.sanitize_id(id)),
+                "/v1/tax_codes/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",
                 base_address="api",
                 params=params,

--- a/stripe/_tax_id.py
+++ b/stripe/_tax_id.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._api_resource import APIResource
 from stripe._customer import Customer
 from stripe._expandable_field import ExpandableField
 from stripe._stripe_object import StripeObject
+from stripe._util import sanitize_id
 from typing import ClassVar, Optional
 from typing_extensions import Literal
 
@@ -149,8 +149,8 @@ class TaxId(APIResource["TaxId"]):
         assert customer is not None
         if isinstance(customer, Customer):
             customer = customer.id
-        cust_extn = _util.sanitize_id(customer)
-        extn = _util.sanitize_id(token)
+        cust_extn = sanitize_id(customer)
+        extn = sanitize_id(token)
         return "%s/%s/tax_ids/%s" % (base, cust_extn, extn)
 
     @classmethod

--- a/stripe/_tax_id.py
+++ b/stripe/_tax_id.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._api_resource import APIResource
 from stripe._customer import Customer
 from stripe._expandable_field import ExpandableField
 from stripe._stripe_object import StripeObject
 from typing import ClassVar, Optional
 from typing_extensions import Literal
-from urllib.parse import quote_plus
 
 
 class TaxId(APIResource["TaxId"]):
@@ -149,8 +149,8 @@ class TaxId(APIResource["TaxId"]):
         assert customer is not None
         if isinstance(customer, Customer):
             customer = customer.id
-        cust_extn = quote_plus(customer)
-        extn = quote_plus(token)
+        cust_extn = _util.sanitize_id(customer)
+        extn = _util.sanitize_id(token)
         return "%s/%s/tax_ids/%s" % (base, cust_extn, extn)
 
     @classmethod

--- a/stripe/_tax_rate.py
+++ b/stripe/_tax_rate.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._updateable_api_resource import UpdateableAPIResource
+from stripe._util import sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import Literal, NotRequired, TypedDict, Unpack
 
@@ -286,7 +286,7 @@ class TaxRate(
         """
         Updates an existing tax rate.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "TaxRate",
             cls._static_request(

--- a/stripe/_tax_rate.py
+++ b/stripe/_tax_rate.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
@@ -7,7 +8,6 @@ from stripe._request_options import RequestOptions
 from stripe._updateable_api_resource import UpdateableAPIResource
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import Literal, NotRequired, TypedDict, Unpack
-from urllib.parse import quote_plus
 
 
 class TaxRate(
@@ -254,7 +254,7 @@ class TaxRate(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -286,10 +286,14 @@ class TaxRate(
         """
         Updates an existing tax rate.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "TaxRate",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_tax_rate_service.py
+++ b/stripe/_tax_rate_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
 from stripe._tax_rate import TaxRate
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -206,7 +206,7 @@ class TaxRateService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/tax_rates/{tax_rate}".format(
-                    tax_rate=_util.sanitize_id(tax_rate),
+                    tax_rate=sanitize_id(tax_rate),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -229,7 +229,7 @@ class TaxRateService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/tax_rates/{tax_rate}".format(
-                    tax_rate=_util.sanitize_id(tax_rate),
+                    tax_rate=sanitize_id(tax_rate),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_token.py
+++ b/stripe/_token.py
@@ -1078,7 +1078,7 @@ class Token(CreateableAPIResource["Token"]):
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 

--- a/stripe/_token_service.py
+++ b/stripe/_token_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
 from stripe._token import Token
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -1014,7 +1014,7 @@ class TokenService(StripeService):
             Token,
             self._requestor.request(
                 "get",
-                "/v1/tokens/{token}".format(token=_util.sanitize_id(token)),
+                "/v1/tokens/{token}".format(token=sanitize_id(token)),
                 api_mode="V1",
                 base_address="api",
                 params=params,

--- a/stripe/_topup.py
+++ b/stripe/_topup.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -241,9 +240,7 @@ class Topup(
             "Topup",
             cls._static_request(
                 "post",
-                "/v1/topups/{topup}/cancel".format(
-                    topup=_util.sanitize_id(topup)
-                ),
+                "/v1/topups/{topup}/cancel".format(topup=sanitize_id(topup)),
                 params=params,
             ),
         )
@@ -275,7 +272,7 @@ class Topup(
             self._request(
                 "post",
                 "/v1/topups/{topup}/cancel".format(
-                    topup=_util.sanitize_id(self.get("id"))
+                    topup=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -321,7 +318,7 @@ class Topup(
         """
         Updates the metadata of a top-up. Other top-up details are not editable by design.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Topup",
             cls._static_request(

--- a/stripe/_topup.py
+++ b/stripe/_topup.py
@@ -16,7 +16,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._balance_transaction import BalanceTransaction
@@ -292,7 +291,7 @@ class Topup(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -322,10 +321,14 @@ class Topup(
         """
         Updates the metadata of a top-up. Other top-up details are not editable by design.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Topup",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_topup_service.py
+++ b/stripe/_topup_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
 from stripe._topup import Topup
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -189,7 +189,7 @@ class TopupService(StripeService):
             Topup,
             self._requestor.request(
                 "get",
-                "/v1/topups/{topup}".format(topup=_util.sanitize_id(topup)),
+                "/v1/topups/{topup}".format(topup=sanitize_id(topup)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -210,7 +210,7 @@ class TopupService(StripeService):
             Topup,
             self._requestor.request(
                 "post",
-                "/v1/topups/{topup}".format(topup=_util.sanitize_id(topup)),
+                "/v1/topups/{topup}".format(topup=sanitize_id(topup)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -231,9 +231,7 @@ class TopupService(StripeService):
             Topup,
             self._requestor.request(
                 "post",
-                "/v1/topups/{topup}/cancel".format(
-                    topup=_util.sanitize_id(topup),
-                ),
+                "/v1/topups/{topup}/cancel".format(topup=sanitize_id(topup)),
                 api_mode="V1",
                 base_address="api",
                 params=params,

--- a/stripe/_transfer.py
+++ b/stripe/_transfer.py
@@ -16,7 +16,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._account import Account
@@ -284,7 +283,7 @@ class Transfer(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -318,10 +317,14 @@ class Transfer(
 
         This request accepts only metadata as an argument.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Transfer",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_transfer.py
+++ b/stripe/_transfer.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -8,6 +7,7 @@ from stripe._listable_api_resource import ListableAPIResource
 from stripe._nested_resource_class_methods import nested_resource_class_methods
 from stripe._request_options import RequestOptions
 from stripe._updateable_api_resource import UpdateableAPIResource
+from stripe._util import sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
@@ -317,7 +317,7 @@ class Transfer(
 
         This request accepts only metadata as an argument.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Transfer",
             cls._static_request(
@@ -353,9 +353,7 @@ class Transfer(
             "Reversal",
             cls._static_request(
                 "post",
-                "/v1/transfers/{id}/reversals".format(
-                    id=_util.sanitize_id(id)
-                ),
+                "/v1/transfers/{id}/reversals".format(id=sanitize_id(id)),
                 params=params,
             ),
         )
@@ -375,8 +373,7 @@ class Transfer(
             cls._static_request(
                 "get",
                 "/v1/transfers/{transfer}/reversals/{id}".format(
-                    transfer=_util.sanitize_id(transfer),
-                    id=_util.sanitize_id(id),
+                    transfer=sanitize_id(transfer), id=sanitize_id(id)
                 ),
                 params=params,
             ),
@@ -399,8 +396,7 @@ class Transfer(
             cls._static_request(
                 "post",
                 "/v1/transfers/{transfer}/reversals/{id}".format(
-                    transfer=_util.sanitize_id(transfer),
-                    id=_util.sanitize_id(id),
+                    transfer=sanitize_id(transfer), id=sanitize_id(id)
                 ),
                 params=params,
             ),
@@ -417,9 +413,7 @@ class Transfer(
             ListObject["Reversal"],
             cls._static_request(
                 "get",
-                "/v1/transfers/{id}/reversals".format(
-                    id=_util.sanitize_id(id)
-                ),
+                "/v1/transfers/{id}/reversals".format(id=sanitize_id(id)),
                 params=params,
             ),
         )

--- a/stripe/_transfer_reversal_service.py
+++ b/stripe/_transfer_reversal_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._reversal import Reversal
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -79,9 +79,7 @@ class TransferReversalService(StripeService):
             ListObject[Reversal],
             self._requestor.request(
                 "get",
-                "/v1/transfers/{id}/reversals".format(
-                    id=_util.sanitize_id(id)
-                ),
+                "/v1/transfers/{id}/reversals".format(id=sanitize_id(id)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -106,9 +104,7 @@ class TransferReversalService(StripeService):
             Reversal,
             self._requestor.request(
                 "post",
-                "/v1/transfers/{id}/reversals".format(
-                    id=_util.sanitize_id(id)
-                ),
+                "/v1/transfers/{id}/reversals".format(id=sanitize_id(id)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -131,8 +127,8 @@ class TransferReversalService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/transfers/{transfer}/reversals/{id}".format(
-                    transfer=_util.sanitize_id(transfer),
-                    id=_util.sanitize_id(id),
+                    transfer=sanitize_id(transfer),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -158,8 +154,8 @@ class TransferReversalService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/transfers/{transfer}/reversals/{id}".format(
-                    transfer=_util.sanitize_id(transfer),
-                    id=_util.sanitize_id(id),
+                    transfer=sanitize_id(transfer),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_transfer_service.py
+++ b/stripe/_transfer_service.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
 from stripe._transfer import Transfer
 from stripe._transfer_reversal_service import TransferReversalService
+from stripe._util import sanitize_id
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -172,7 +172,7 @@ class TransferService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/transfers/{transfer}".format(
-                    transfer=_util.sanitize_id(transfer),
+                    transfer=sanitize_id(transfer),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -197,7 +197,7 @@ class TransferService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/transfers/{transfer}".format(
-                    transfer=_util.sanitize_id(transfer),
+                    transfer=sanitize_id(transfer),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/_webhook_endpoint.py
+++ b/stripe/_webhook_endpoint.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import Literal, NotRequired, Unpack
 
@@ -430,7 +429,7 @@ class WebhookEndpoint(
         """
         You can also delete webhook endpoints via the [webhook endpoint management](https://dashboard.stripe.com/account/webhooks) page of the Stripe dashboard.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(sid))
         return cast(
             "WebhookEndpoint",
             cls._static_request(
@@ -500,7 +499,7 @@ class WebhookEndpoint(
         """
         Updates the webhook endpoint. You may edit the url, the list of enabled_events, and the status of your endpoint.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "WebhookEndpoint",
             cls._static_request(

--- a/stripe/_webhook_endpoint.py
+++ b/stripe/_webhook_endpoint.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._list_object import ListObject
@@ -9,7 +10,6 @@ from stripe._updateable_api_resource import UpdateableAPIResource
 from stripe._util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import Literal, NotRequired, Unpack
-from urllib.parse import quote_plus
 
 
 class WebhookEndpoint(
@@ -419,7 +419,7 @@ class WebhookEndpoint(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -430,10 +430,14 @@ class WebhookEndpoint(
         """
         You can also delete webhook endpoints via the [webhook endpoint management](https://dashboard.stripe.com/account/webhooks) page of the Stripe dashboard.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
         return cast(
             "WebhookEndpoint",
-            cls._static_request("delete", url, params=params),
+            cls._static_request(
+                "delete",
+                url,
+                params=params,
+            ),
         )
 
     @overload
@@ -496,10 +500,14 @@ class WebhookEndpoint(
         """
         Updates the webhook endpoint. You may edit the url, the list of enabled_events, and the status of your endpoint.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "WebhookEndpoint",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/_webhook_endpoint_service.py
+++ b/stripe/_webhook_endpoint_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe._webhook_endpoint import WebhookEndpoint
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -348,7 +348,7 @@ class WebhookEndpointService(StripeService):
             self._requestor.request(
                 "delete",
                 "/v1/webhook_endpoints/{webhook_endpoint}".format(
-                    webhook_endpoint=_util.sanitize_id(webhook_endpoint),
+                    webhook_endpoint=sanitize_id(webhook_endpoint),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -371,7 +371,7 @@ class WebhookEndpointService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/webhook_endpoints/{webhook_endpoint}".format(
-                    webhook_endpoint=_util.sanitize_id(webhook_endpoint),
+                    webhook_endpoint=sanitize_id(webhook_endpoint),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -394,7 +394,7 @@ class WebhookEndpointService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/webhook_endpoints/{webhook_endpoint}".format(
-                    webhook_endpoint=_util.sanitize_id(webhook_endpoint),
+                    webhook_endpoint=sanitize_id(webhook_endpoint),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/apps/_secret.py
+++ b/stripe/apps/_secret.py
@@ -190,7 +190,7 @@ class Secret(CreateableAPIResource["Secret"], ListableAPIResource["Secret"]):
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 

--- a/stripe/billing_portal/_configuration.py
+++ b/stripe/billing_portal/_configuration.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -8,6 +7,7 @@ from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
+from stripe._util import sanitize_id
 from typing import ClassVar, Dict, List, Optional, Union, cast
 from typing_extensions import (
     Literal,
@@ -687,7 +687,7 @@ class Configuration(
         """
         Updates a configuration that describes the functionality of the customer portal.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Configuration",
             cls._static_request(

--- a/stripe/billing_portal/_configuration.py
+++ b/stripe/billing_portal/_configuration.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -15,7 +16,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._application import Application
@@ -655,7 +655,7 @@ class Configuration(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -687,10 +687,14 @@ class Configuration(
         """
         Updates a configuration that describes the functionality of the customer portal.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Configuration",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/billing_portal/_configuration_service.py
+++ b/stripe/billing_portal/_configuration_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.billing_portal._configuration import Configuration
 from typing import Dict, List, Union, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -483,7 +483,7 @@ class ConfigurationService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/billing_portal/configurations/{configuration}".format(
-                    configuration=_util.sanitize_id(configuration),
+                    configuration=sanitize_id(configuration),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -506,7 +506,7 @@ class ConfigurationService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/billing_portal/configurations/{configuration}".format(
-                    configuration=_util.sanitize_id(configuration),
+                    configuration=sanitize_id(configuration),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/billing_portal/_session.py
+++ b/stripe/billing_portal/_session.py
@@ -452,7 +452,7 @@ class Session(CreateableAPIResource["Session"]):
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 

--- a/stripe/checkout/_session.py
+++ b/stripe/checkout/_session.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -3730,7 +3729,7 @@ class Session(
             cls._static_request(
                 "post",
                 "/v1/checkout/sessions/{session}/expire".format(
-                    session=_util.sanitize_id(session)
+                    session=sanitize_id(session)
                 ),
                 params=params,
             ),
@@ -3771,7 +3770,7 @@ class Session(
             self._request(
                 "post",
                 "/v1/checkout/sessions/{session}/expire".format(
-                    session=_util.sanitize_id(self.get("id"))
+                    session=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -3810,7 +3809,7 @@ class Session(
             cls._static_request(
                 "get",
                 "/v1/checkout/sessions/{session}/line_items".format(
-                    session=_util.sanitize_id(session)
+                    session=sanitize_id(session)
                 ),
                 params=params,
             ),
@@ -3847,7 +3846,7 @@ class Session(
             self._request(
                 "get",
                 "/v1/checkout/sessions/{session}/line_items".format(
-                    session=_util.sanitize_id(self.get("id"))
+                    session=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),

--- a/stripe/checkout/_session.py
+++ b/stripe/checkout/_session.py
@@ -3712,7 +3712,7 @@ class Session(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 

--- a/stripe/checkout/_session_line_item_service.py
+++ b/stripe/checkout/_session_line_item_service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._line_item import LineItem
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -42,7 +42,7 @@ class SessionLineItemService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/checkout/sessions/{session}/line_items".format(
-                    session=_util.sanitize_id(session),
+                    session=sanitize_id(session),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/checkout/_session_service.py
+++ b/stripe/checkout/_session_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.checkout._session import Session
 from stripe.checkout._session_line_item_service import SessionLineItemService
 from typing import Dict, List, cast
@@ -2083,7 +2083,7 @@ class SessionService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/checkout/sessions/{session}".format(
-                    session=_util.sanitize_id(session),
+                    session=sanitize_id(session),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -2108,7 +2108,7 @@ class SessionService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/checkout/sessions/{session}/expire".format(
-                    session=_util.sanitize_id(session),
+                    session=sanitize_id(session),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/climate/_order.py
+++ b/stripe/climate/_order.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -8,7 +7,7 @@ from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, Union, cast, overload
 from typing_extensions import (
     Literal,
@@ -277,7 +276,7 @@ class Order(
             cls._static_request(
                 "post",
                 "/v1/climate/orders/{order}/cancel".format(
-                    order=_util.sanitize_id(order)
+                    order=sanitize_id(order)
                 ),
                 params=params,
             ),
@@ -319,7 +318,7 @@ class Order(
             self._request(
                 "post",
                 "/v1/climate/orders/{order}/cancel".format(
-                    order=_util.sanitize_id(self.get("id"))
+                    order=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -367,7 +366,7 @@ class Order(
         """
         Updates the specified order by setting the values of the parameters passed.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Order",
             cls._static_request(

--- a/stripe/climate/_order.py
+++ b/stripe/climate/_order.py
@@ -17,7 +17,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe.climate._product import Product
@@ -337,7 +336,7 @@ class Order(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -368,10 +367,14 @@ class Order(
         """
         Updates the specified order by setting the values of the parameters passed.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Order",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/climate/_order_service.py
+++ b/stripe/climate/_order_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.climate._order import Order
 from typing import Dict, List, Union, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -151,9 +151,7 @@ class OrderService(StripeService):
             Order,
             self._requestor.request(
                 "get",
-                "/v1/climate/orders/{order}".format(
-                    order=_util.sanitize_id(order),
-                ),
+                "/v1/climate/orders/{order}".format(order=sanitize_id(order)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -174,9 +172,7 @@ class OrderService(StripeService):
             Order,
             self._requestor.request(
                 "post",
-                "/v1/climate/orders/{order}".format(
-                    order=_util.sanitize_id(order),
-                ),
+                "/v1/climate/orders/{order}".format(order=sanitize_id(order)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -201,7 +197,7 @@ class OrderService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/climate/orders/{order}/cancel".format(
-                    order=_util.sanitize_id(order),
+                    order=sanitize_id(order),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/climate/_product_service.py
+++ b/stripe/climate/_product_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.climate._product import Product
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
@@ -68,7 +68,7 @@ class ProductService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/climate/products/{product}".format(
-                    product=_util.sanitize_id(product),
+                    product=sanitize_id(product),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/climate/_supplier_service.py
+++ b/stripe/climate/_supplier_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.climate._supplier import Supplier
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
@@ -68,7 +68,7 @@ class SupplierService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/climate/suppliers/{supplier}".format(
-                    supplier=_util.sanitize_id(supplier),
+                    supplier=sanitize_id(supplier),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/financial_connections/_account.py
+++ b/stripe/financial_connections/_account.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -344,7 +343,7 @@ class Account(ListableAPIResource["Account"]):
             cls._static_request(
                 "post",
                 "/v1/financial_connections/accounts/{account}/disconnect".format(
-                    account=_util.sanitize_id(account)
+                    account=sanitize_id(account)
                 ),
                 params=params,
             ),
@@ -381,7 +380,7 @@ class Account(ListableAPIResource["Account"]):
             self._request(
                 "post",
                 "/v1/financial_connections/accounts/{account}/disconnect".format(
-                    account=_util.sanitize_id(self.get("id"))
+                    account=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -420,7 +419,7 @@ class Account(ListableAPIResource["Account"]):
             cls._static_request(
                 "get",
                 "/v1/financial_connections/accounts/{account}/owners".format(
-                    account=_util.sanitize_id(account)
+                    account=sanitize_id(account)
                 ),
                 params=params,
             ),
@@ -457,7 +456,7 @@ class Account(ListableAPIResource["Account"]):
             self._request(
                 "get",
                 "/v1/financial_connections/accounts/{account}/owners".format(
-                    account=_util.sanitize_id(self.get("id"))
+                    account=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -475,7 +474,7 @@ class Account(ListableAPIResource["Account"]):
             cls._static_request(
                 "post",
                 "/v1/financial_connections/accounts/{account}/refresh".format(
-                    account=_util.sanitize_id(account)
+                    account=sanitize_id(account)
                 ),
                 params=params,
             ),
@@ -512,7 +511,7 @@ class Account(ListableAPIResource["Account"]):
             self._request(
                 "post",
                 "/v1/financial_connections/accounts/{account}/refresh".format(
-                    account=_util.sanitize_id(self.get("id"))
+                    account=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -541,7 +540,7 @@ class Account(ListableAPIResource["Account"]):
             cls._static_request(
                 "post",
                 "/v1/financial_connections/accounts/{account}/subscribe".format(
-                    account=_util.sanitize_id(account)
+                    account=sanitize_id(account)
                 ),
                 params=params,
             ),
@@ -578,7 +577,7 @@ class Account(ListableAPIResource["Account"]):
             self._request(
                 "post",
                 "/v1/financial_connections/accounts/{account}/subscribe".format(
-                    account=_util.sanitize_id(self.get("id"))
+                    account=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -596,7 +595,7 @@ class Account(ListableAPIResource["Account"]):
             cls._static_request(
                 "post",
                 "/v1/financial_connections/accounts/{account}/unsubscribe".format(
-                    account=_util.sanitize_id(account)
+                    account=sanitize_id(account)
                 ),
                 params=params,
             ),
@@ -633,7 +632,7 @@ class Account(ListableAPIResource["Account"]):
             self._request(
                 "post",
                 "/v1/financial_connections/accounts/{account}/unsubscribe".format(
-                    account=_util.sanitize_id(self.get("id"))
+                    account=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),

--- a/stripe/financial_connections/_account_owner_service.py
+++ b/stripe/financial_connections/_account_owner_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.financial_connections._account_owner import AccountOwner
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
@@ -46,7 +46,7 @@ class AccountOwnerService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/financial_connections/accounts/{account}/owners".format(
-                    account=_util.sanitize_id(account),
+                    account=sanitize_id(account),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/financial_connections/_account_service.py
+++ b/stripe/financial_connections/_account_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.financial_connections._account import Account
 from stripe.financial_connections._account_owner_service import (
     AccountOwnerService,
@@ -129,7 +129,7 @@ class AccountService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/financial_connections/accounts/{account}".format(
-                    account=_util.sanitize_id(account),
+                    account=sanitize_id(account),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -152,7 +152,7 @@ class AccountService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/financial_connections/accounts/{account}/disconnect".format(
-                    account=_util.sanitize_id(account),
+                    account=sanitize_id(account),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -175,7 +175,7 @@ class AccountService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/financial_connections/accounts/{account}/refresh".format(
-                    account=_util.sanitize_id(account),
+                    account=sanitize_id(account),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -198,7 +198,7 @@ class AccountService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/financial_connections/accounts/{account}/subscribe".format(
-                    account=_util.sanitize_id(account),
+                    account=sanitize_id(account),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -221,7 +221,7 @@ class AccountService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/financial_connections/accounts/{account}/unsubscribe".format(
-                    account=_util.sanitize_id(account),
+                    account=sanitize_id(account),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/financial_connections/_session.py
+++ b/stripe/financial_connections/_session.py
@@ -159,7 +159,7 @@ class Session(CreateableAPIResource["Session"]):
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 

--- a/stripe/financial_connections/_session_service.py
+++ b/stripe/financial_connections/_session_service.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.financial_connections._session import Session
 from typing import List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -81,7 +81,7 @@ class SessionService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/financial_connections/sessions/{session}".format(
-                    session=_util.sanitize_id(session),
+                    session=sanitize_id(session),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/financial_connections/_transaction_service.py
+++ b/stripe/financial_connections/_transaction_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.financial_connections._transaction import Transaction
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
@@ -108,7 +108,7 @@ class TransactionService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/financial_connections/transactions/{transaction}".format(
-                    transaction=_util.sanitize_id(transaction),
+                    transaction=sanitize_id(transaction),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/identity/_verification_report_service.py
+++ b/stripe/identity/_verification_report_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.identity._verification_report import VerificationReport
 from typing import List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -95,7 +95,7 @@ class VerificationReportService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/identity/verification_reports/{report}".format(
-                    report=_util.sanitize_id(report),
+                    report=sanitize_id(report),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/identity/_verification_session.py
+++ b/stripe/identity/_verification_session.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -8,7 +7,7 @@ from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -402,7 +401,7 @@ class VerificationSession(
             cls._static_request(
                 "post",
                 "/v1/identity/verification_sessions/{session}/cancel".format(
-                    session=_util.sanitize_id(session)
+                    session=sanitize_id(session)
                 ),
                 params=params,
             ),
@@ -445,7 +444,7 @@ class VerificationSession(
             self._request(
                 "post",
                 "/v1/identity/verification_sessions/{session}/cancel".format(
-                    session=_util.sanitize_id(self.get("id"))
+                    session=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -504,7 +503,7 @@ class VerificationSession(
         When the session status is requires_input, you can use this method to update the
         verification check and options.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "VerificationSession",
             cls._static_request(
@@ -544,7 +543,7 @@ class VerificationSession(
             cls._static_request(
                 "post",
                 "/v1/identity/verification_sessions/{session}/redact".format(
-                    session=_util.sanitize_id(session)
+                    session=sanitize_id(session)
                 ),
                 params=params,
             ),
@@ -635,7 +634,7 @@ class VerificationSession(
             self._request(
                 "post",
                 "/v1/identity/verification_sessions/{session}/redact".format(
-                    session=_util.sanitize_id(self.get("id"))
+                    session=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),

--- a/stripe/identity/_verification_session.py
+++ b/stripe/identity/_verification_session.py
@@ -17,7 +17,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe.identity._verification_report import VerificationReport
@@ -470,7 +469,7 @@ class VerificationSession(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -505,10 +504,14 @@ class VerificationSession(
         When the session status is requires_input, you can use this method to update the
         verification check and options.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "VerificationSession",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/identity/_verification_session_service.py
+++ b/stripe/identity/_verification_session_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.identity._verification_session import VerificationSession
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -232,7 +232,7 @@ class VerificationSessionService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/identity/verification_sessions/{session}".format(
-                    session=_util.sanitize_id(session),
+                    session=sanitize_id(session),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -258,7 +258,7 @@ class VerificationSessionService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/identity/verification_sessions/{session}".format(
-                    session=_util.sanitize_id(session),
+                    session=sanitize_id(session),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -283,7 +283,7 @@ class VerificationSessionService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/identity/verification_sessions/{session}/cancel".format(
-                    session=_util.sanitize_id(session),
+                    session=sanitize_id(session),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -324,7 +324,7 @@ class VerificationSessionService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/identity/verification_sessions/{session}/redact".format(
-                    session=_util.sanitize_id(session),
+                    session=sanitize_id(session),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/issuing/_authorization.py
+++ b/stripe/issuing/_authorization.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
@@ -8,7 +7,7 @@ from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._test_helpers import APIResourceTestHelpers
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -824,7 +823,7 @@ class Authorization(
             cls._static_request(
                 "post",
                 "/v1/issuing/authorizations/{authorization}/approve".format(
-                    authorization=_util.sanitize_id(authorization)
+                    authorization=sanitize_id(authorization)
                 ),
                 params=params,
             ),
@@ -864,7 +863,7 @@ class Authorization(
             self._request(
                 "post",
                 "/v1/issuing/authorizations/{authorization}/approve".format(
-                    authorization=_util.sanitize_id(self.get("id"))
+                    authorization=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -885,7 +884,7 @@ class Authorization(
             cls._static_request(
                 "post",
                 "/v1/issuing/authorizations/{authorization}/decline".format(
-                    authorization=_util.sanitize_id(authorization)
+                    authorization=sanitize_id(authorization)
                 ),
                 params=params,
             ),
@@ -925,7 +924,7 @@ class Authorization(
             self._request(
                 "post",
                 "/v1/issuing/authorizations/{authorization}/decline".format(
-                    authorization=_util.sanitize_id(self.get("id"))
+                    authorization=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -959,7 +958,7 @@ class Authorization(
         """
         Updates the specified Issuing Authorization object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Authorization",
             cls._static_request(
@@ -997,7 +996,7 @@ class Authorization(
                 cls._static_request(
                     "post",
                     "/v1/test_helpers/issuing/authorizations/{authorization}/capture".format(
-                        authorization=_util.sanitize_id(authorization)
+                        authorization=sanitize_id(authorization)
                     ),
                     params=params,
                 ),
@@ -1034,9 +1033,7 @@ class Authorization(
                 self.resource._request(
                     "post",
                     "/v1/test_helpers/issuing/authorizations/{authorization}/capture".format(
-                        authorization=_util.sanitize_id(
-                            self.resource.get("id")
-                        )
+                        authorization=sanitize_id(self.resource.get("id"))
                     ),
                     params=params,
                 ),
@@ -1072,7 +1069,7 @@ class Authorization(
                 cls._static_request(
                     "post",
                     "/v1/test_helpers/issuing/authorizations/{authorization}/expire".format(
-                        authorization=_util.sanitize_id(authorization)
+                        authorization=sanitize_id(authorization)
                     ),
                     params=params,
                 ),
@@ -1109,9 +1106,7 @@ class Authorization(
                 self.resource._request(
                     "post",
                     "/v1/test_helpers/issuing/authorizations/{authorization}/expire".format(
-                        authorization=_util.sanitize_id(
-                            self.resource.get("id")
-                        )
+                        authorization=sanitize_id(self.resource.get("id"))
                     ),
                     params=params,
                 ),
@@ -1131,7 +1126,7 @@ class Authorization(
                 cls._static_request(
                     "post",
                     "/v1/test_helpers/issuing/authorizations/{authorization}/increment".format(
-                        authorization=_util.sanitize_id(authorization)
+                        authorization=sanitize_id(authorization)
                     ),
                     params=params,
                 ),
@@ -1169,9 +1164,7 @@ class Authorization(
                 self.resource._request(
                     "post",
                     "/v1/test_helpers/issuing/authorizations/{authorization}/increment".format(
-                        authorization=_util.sanitize_id(
-                            self.resource.get("id")
-                        )
+                        authorization=sanitize_id(self.resource.get("id"))
                     ),
                     params=params,
                 ),
@@ -1191,7 +1184,7 @@ class Authorization(
                 cls._static_request(
                     "post",
                     "/v1/test_helpers/issuing/authorizations/{authorization}/reverse".format(
-                        authorization=_util.sanitize_id(authorization)
+                        authorization=sanitize_id(authorization)
                     ),
                     params=params,
                 ),
@@ -1228,9 +1221,7 @@ class Authorization(
                 self.resource._request(
                     "post",
                     "/v1/test_helpers/issuing/authorizations/{authorization}/reverse".format(
-                        authorization=_util.sanitize_id(
-                            self.resource.get("id")
-                        )
+                        authorization=sanitize_id(self.resource.get("id"))
                     ),
                     params=params,
                 ),

--- a/stripe/issuing/_authorization.py
+++ b/stripe/issuing/_authorization.py
@@ -18,7 +18,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._balance_transaction import BalanceTransaction
@@ -960,10 +959,14 @@ class Authorization(
         """
         Updates the specified Issuing Authorization object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Authorization",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/issuing/_authorization_service.py
+++ b/stripe/issuing/_authorization_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.issuing._authorization import Authorization
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -136,7 +136,7 @@ class AuthorizationService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/issuing/authorizations/{authorization}".format(
-                    authorization=_util.sanitize_id(authorization),
+                    authorization=sanitize_id(authorization),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -159,7 +159,7 @@ class AuthorizationService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/issuing/authorizations/{authorization}".format(
-                    authorization=_util.sanitize_id(authorization),
+                    authorization=sanitize_id(authorization),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -183,7 +183,7 @@ class AuthorizationService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/issuing/authorizations/{authorization}/approve".format(
-                    authorization=_util.sanitize_id(authorization),
+                    authorization=sanitize_id(authorization),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -207,7 +207,7 @@ class AuthorizationService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/issuing/authorizations/{authorization}/decline".format(
-                    authorization=_util.sanitize_id(authorization),
+                    authorization=sanitize_id(authorization),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/issuing/_card.py
+++ b/stripe/issuing/_card.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -9,7 +8,7 @@ from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._test_helpers import APIResourceTestHelpers
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -1566,7 +1565,7 @@ class Card(
         """
         Updates the specified Issuing Card object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Card",
             cls._static_request(
@@ -1602,7 +1601,7 @@ class Card(
                 cls._static_request(
                     "post",
                     "/v1/test_helpers/issuing/cards/{card}/shipping/deliver".format(
-                        card=_util.sanitize_id(card)
+                        card=sanitize_id(card)
                     ),
                     params=params,
                 ),
@@ -1639,7 +1638,7 @@ class Card(
                 self.resource._request(
                     "post",
                     "/v1/test_helpers/issuing/cards/{card}/shipping/deliver".format(
-                        card=_util.sanitize_id(self.resource.get("id"))
+                        card=sanitize_id(self.resource.get("id"))
                     ),
                     params=params,
                 ),
@@ -1657,7 +1656,7 @@ class Card(
                 cls._static_request(
                     "post",
                     "/v1/test_helpers/issuing/cards/{card}/shipping/fail".format(
-                        card=_util.sanitize_id(card)
+                        card=sanitize_id(card)
                     ),
                     params=params,
                 ),
@@ -1692,7 +1691,7 @@ class Card(
                 self.resource._request(
                     "post",
                     "/v1/test_helpers/issuing/cards/{card}/shipping/fail".format(
-                        card=_util.sanitize_id(self.resource.get("id"))
+                        card=sanitize_id(self.resource.get("id"))
                     ),
                     params=params,
                 ),
@@ -1710,7 +1709,7 @@ class Card(
                 cls._static_request(
                     "post",
                     "/v1/test_helpers/issuing/cards/{card}/shipping/return".format(
-                        card=_util.sanitize_id(card)
+                        card=sanitize_id(card)
                     ),
                     params=params,
                 ),
@@ -1747,7 +1746,7 @@ class Card(
                 self.resource._request(
                     "post",
                     "/v1/test_helpers/issuing/cards/{card}/shipping/return".format(
-                        card=_util.sanitize_id(self.resource.get("id"))
+                        card=sanitize_id(self.resource.get("id"))
                     ),
                     params=params,
                 ),
@@ -1765,7 +1764,7 @@ class Card(
                 cls._static_request(
                     "post",
                     "/v1/test_helpers/issuing/cards/{card}/shipping/ship".format(
-                        card=_util.sanitize_id(card)
+                        card=sanitize_id(card)
                     ),
                     params=params,
                 ),
@@ -1800,7 +1799,7 @@ class Card(
                 self.resource._request(
                     "post",
                     "/v1/test_helpers/issuing/cards/{card}/shipping/ship".format(
-                        card=_util.sanitize_id(self.resource.get("id"))
+                        card=sanitize_id(self.resource.get("id"))
                     ),
                     params=params,
                 ),

--- a/stripe/issuing/_card.py
+++ b/stripe/issuing/_card.py
@@ -19,7 +19,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe.issuing._cardholder import Cardholder
@@ -1539,7 +1538,7 @@ class Card(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -1567,10 +1566,14 @@ class Card(
         """
         Updates the specified Issuing Card object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Card",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/issuing/_card_service.py
+++ b/stripe/issuing/_card_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.issuing._card import Card
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -370,9 +370,7 @@ class CardService(StripeService):
             Card,
             self._requestor.request(
                 "get",
-                "/v1/issuing/cards/{card}".format(
-                    card=_util.sanitize_id(card)
-                ),
+                "/v1/issuing/cards/{card}".format(card=sanitize_id(card)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -393,9 +391,7 @@ class CardService(StripeService):
             Card,
             self._requestor.request(
                 "post",
-                "/v1/issuing/cards/{card}".format(
-                    card=_util.sanitize_id(card)
-                ),
+                "/v1/issuing/cards/{card}".format(card=sanitize_id(card)),
                 api_mode="V1",
                 base_address="api",
                 params=params,

--- a/stripe/issuing/_cardholder.py
+++ b/stripe/issuing/_cardholder.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -8,6 +7,7 @@ from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
+from stripe._util import sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast
 from typing_extensions import (
     Literal,
@@ -1718,7 +1718,7 @@ class Cardholder(
         """
         Updates the specified Issuing Cardholder object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Cardholder",
             cls._static_request(

--- a/stripe/issuing/_cardholder.py
+++ b/stripe/issuing/_cardholder.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -15,7 +16,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._file import File
@@ -1686,7 +1686,7 @@ class Cardholder(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -1718,10 +1718,14 @@ class Cardholder(
         """
         Updates the specified Issuing Cardholder object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Cardholder",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/issuing/_cardholder_service.py
+++ b/stripe/issuing/_cardholder_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.issuing._cardholder import Cardholder
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -558,7 +558,7 @@ class CardholderService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/issuing/cardholders/{cardholder}".format(
-                    cardholder=_util.sanitize_id(cardholder),
+                    cardholder=sanitize_id(cardholder),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -581,7 +581,7 @@ class CardholderService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/issuing/cardholders/{cardholder}".format(
-                    cardholder=_util.sanitize_id(cardholder),
+                    cardholder=sanitize_id(cardholder),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/issuing/_dispute.py
+++ b/stripe/issuing/_dispute.py
@@ -17,7 +17,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._balance_transaction import BalanceTransaction
@@ -864,7 +863,7 @@ class Dispute(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -896,10 +895,14 @@ class Dispute(
         """
         Updates the specified Issuing Dispute object by setting the values of the parameters passed. Any parameters not provided will be left unchanged. Properties on the evidence object can be unset by passing in an empty string.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Dispute",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/issuing/_dispute.py
+++ b/stripe/issuing/_dispute.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -8,7 +7,7 @@ from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -895,7 +894,7 @@ class Dispute(
         """
         Updates the specified Issuing Dispute object by setting the values of the parameters passed. Any parameters not provided will be left unchanged. Properties on the evidence object can be unset by passing in an empty string.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Dispute",
             cls._static_request(
@@ -928,7 +927,7 @@ class Dispute(
             cls._static_request(
                 "post",
                 "/v1/issuing/disputes/{dispute}/submit".format(
-                    dispute=_util.sanitize_id(dispute)
+                    dispute=sanitize_id(dispute)
                 ),
                 params=params,
             ),
@@ -963,7 +962,7 @@ class Dispute(
             self._request(
                 "post",
                 "/v1/issuing/disputes/{dispute}/submit".format(
-                    dispute=_util.sanitize_id(self.get("id"))
+                    dispute=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),

--- a/stripe/issuing/_dispute_service.py
+++ b/stripe/issuing/_dispute_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.issuing._dispute import Dispute
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -632,7 +632,7 @@ class DisputeService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/issuing/disputes/{dispute}".format(
-                    dispute=_util.sanitize_id(dispute),
+                    dispute=sanitize_id(dispute),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -655,7 +655,7 @@ class DisputeService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/issuing/disputes/{dispute}".format(
-                    dispute=_util.sanitize_id(dispute),
+                    dispute=sanitize_id(dispute),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -678,7 +678,7 @@ class DisputeService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/issuing/disputes/{dispute}/submit".format(
-                    dispute=_util.sanitize_id(dispute),
+                    dispute=sanitize_id(dispute),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/issuing/_token.py
+++ b/stripe/issuing/_token.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
+from stripe._util import sanitize_id
 from typing import ClassVar, List, Optional, cast
 from typing_extensions import (
     Literal,
@@ -332,7 +332,7 @@ class Token(ListableAPIResource["Token"], UpdateableAPIResource["Token"]):
         """
         Attempts to update the specified Issuing Token object to the status specified.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Token",
             cls._static_request(

--- a/stripe/issuing/_token.py
+++ b/stripe/issuing/_token.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
@@ -14,7 +15,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe.issuing._card import Card
@@ -332,10 +332,14 @@ class Token(ListableAPIResource["Token"], UpdateableAPIResource["Token"]):
         """
         Attempts to update the specified Issuing Token object to the status specified.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Token",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/issuing/_token_service.py
+++ b/stripe/issuing/_token_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.issuing._token import Token
 from typing import List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -107,9 +107,7 @@ class TokenService(StripeService):
             Token,
             self._requestor.request(
                 "get",
-                "/v1/issuing/tokens/{token}".format(
-                    token=_util.sanitize_id(token),
-                ),
+                "/v1/issuing/tokens/{token}".format(token=sanitize_id(token)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -130,9 +128,7 @@ class TokenService(StripeService):
             Token,
             self._requestor.request(
                 "post",
-                "/v1/issuing/tokens/{token}".format(
-                    token=_util.sanitize_id(token),
-                ),
+                "/v1/issuing/tokens/{token}".format(token=sanitize_id(token)),
                 api_mode="V1",
                 base_address="api",
                 params=params,

--- a/stripe/issuing/_transaction.py
+++ b/stripe/issuing/_transaction.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
@@ -8,7 +7,7 @@ from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._test_helpers import APIResourceTestHelpers
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -807,7 +806,7 @@ class Transaction(
         """
         Updates the specified Issuing Transaction object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Transaction",
             cls._static_request(
@@ -875,7 +874,7 @@ class Transaction(
                 cls._static_request(
                     "post",
                     "/v1/test_helpers/issuing/transactions/{transaction}/refund".format(
-                        transaction=_util.sanitize_id(transaction)
+                        transaction=sanitize_id(transaction)
                     ),
                     params=params,
                 ),
@@ -912,7 +911,7 @@ class Transaction(
                 self.resource._request(
                     "post",
                     "/v1/test_helpers/issuing/transactions/{transaction}/refund".format(
-                        transaction=_util.sanitize_id(self.resource.get("id"))
+                        transaction=sanitize_id(self.resource.get("id"))
                     ),
                     params=params,
                 ),

--- a/stripe/issuing/_transaction.py
+++ b/stripe/issuing/_transaction.py
@@ -18,7 +18,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._balance_transaction import BalanceTransaction
@@ -808,10 +807,14 @@ class Transaction(
         """
         Updates the specified Issuing Transaction object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Transaction",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/issuing/_transaction_service.py
+++ b/stripe/issuing/_transaction_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.issuing._transaction import Transaction
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -112,7 +112,7 @@ class TransactionService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/issuing/transactions/{transaction}".format(
-                    transaction=_util.sanitize_id(transaction),
+                    transaction=sanitize_id(transaction),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -135,7 +135,7 @@ class TransactionService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/issuing/transactions/{transaction}".format(
-                    transaction=_util.sanitize_id(transaction),
+                    transaction=sanitize_id(transaction),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/radar/_early_fraud_warning_service.py
+++ b/stripe/radar/_early_fraud_warning_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.radar._early_fraud_warning import EarlyFraudWarning
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
@@ -100,7 +100,7 @@ class EarlyFraudWarningService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/radar/early_fraud_warnings/{early_fraud_warning}".format(
-                    early_fraud_warning=_util.sanitize_id(early_fraud_warning),
+                    early_fraud_warning=sanitize_id(early_fraud_warning),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/radar/_value_list.py
+++ b/stripe/radar/_value_list.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -208,7 +207,7 @@ class ValueList(
         """
         Deletes a ValueList object, also deleting any items contained within the value list. To be deleted, a value list must not be referenced in any rules.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(sid))
         return cast(
             "ValueList",
             cls._static_request(
@@ -278,7 +277,7 @@ class ValueList(
         """
         Updates a ValueList object by setting the values of the parameters passed. Any parameters not provided will be left unchanged. Note that item_type is immutable.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "ValueList",
             cls._static_request(

--- a/stripe/radar/_value_list.py
+++ b/stripe/radar/_value_list.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._list_object import ListObject
@@ -15,7 +16,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe.radar._value_list_item import ValueListItem
@@ -197,7 +197,7 @@ class ValueList(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -208,10 +208,14 @@ class ValueList(
         """
         Deletes a ValueList object, also deleting any items contained within the value list. To be deleted, a value list must not be referenced in any rules.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
         return cast(
             "ValueList",
-            cls._static_request("delete", url, params=params),
+            cls._static_request(
+                "delete",
+                url,
+                params=params,
+            ),
         )
 
     @overload
@@ -274,10 +278,14 @@ class ValueList(
         """
         Updates a ValueList object by setting the values of the parameters passed. Any parameters not provided will be left unchanged. Note that item_type is immutable.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "ValueList",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/radar/_value_list_item.py
+++ b/stripe/radar/_value_list_item.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._list_object import ListObject
@@ -8,7 +9,6 @@ from stripe._request_options import RequestOptions
 from stripe._util import class_method_variant
 from typing import ClassVar, List, Optional, cast, overload
 from typing_extensions import Literal, NotRequired, TypedDict, Unpack
-from urllib.parse import quote_plus
 
 
 class ValueListItem(
@@ -139,7 +139,7 @@ class ValueListItem(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -150,10 +150,14 @@ class ValueListItem(
         """
         Deletes a ValueListItem object, removing it from its parent value list.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
         return cast(
             "ValueListItem",
-            cls._static_request("delete", url, params=params),
+            cls._static_request(
+                "delete",
+                url,
+                params=params,
+            ),
         )
 
     @overload

--- a/stripe/radar/_value_list_item.py
+++ b/stripe/radar/_value_list_item.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, List, Optional, cast, overload
 from typing_extensions import Literal, NotRequired, TypedDict, Unpack
 
@@ -150,7 +149,7 @@ class ValueListItem(
         """
         Deletes a ValueListItem object, removing it from its parent value list.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(sid))
         return cast(
             "ValueListItem",
             cls._static_request(

--- a/stripe/radar/_value_list_item_service.py
+++ b/stripe/radar/_value_list_item_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.radar._value_list_item import ValueListItem
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
@@ -92,7 +92,7 @@ class ValueListItemService(StripeService):
             self._requestor.request(
                 "delete",
                 "/v1/radar/value_list_items/{item}".format(
-                    item=_util.sanitize_id(item),
+                    item=sanitize_id(item),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -115,7 +115,7 @@ class ValueListItemService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/radar/value_list_items/{item}".format(
-                    item=_util.sanitize_id(item),
+                    item=sanitize_id(item),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/radar/_value_list_service.py
+++ b/stripe/radar/_value_list_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.radar._value_list import ValueList
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -120,7 +120,7 @@ class ValueListService(StripeService):
             self._requestor.request(
                 "delete",
                 "/v1/radar/value_lists/{value_list}".format(
-                    value_list=_util.sanitize_id(value_list),
+                    value_list=sanitize_id(value_list),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -143,7 +143,7 @@ class ValueListService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/radar/value_lists/{value_list}".format(
-                    value_list=_util.sanitize_id(value_list),
+                    value_list=sanitize_id(value_list),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -166,7 +166,7 @@ class ValueListService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/radar/value_lists/{value_list}".format(
-                    value_list=_util.sanitize_id(value_list),
+                    value_list=sanitize_id(value_list),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/reporting/_report_run.py
+++ b/stripe/reporting/_report_run.py
@@ -219,7 +219,7 @@ class ReportRun(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 

--- a/stripe/reporting/_report_run_service.py
+++ b/stripe/reporting/_report_run_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.reporting._report_run import ReportRun
 from typing import List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -159,7 +159,7 @@ class ReportRunService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/reporting/report_runs/{report_run}".format(
-                    report_run=_util.sanitize_id(report_run),
+                    report_run=sanitize_id(report_run),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/reporting/_report_type_service.py
+++ b/stripe/reporting/_report_type_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.reporting._report_type import ReportType
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
@@ -56,7 +56,7 @@ class ReportTypeService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/reporting/report_types/{report_type}".format(
-                    report_type=_util.sanitize_id(report_type),
+                    report_type=sanitize_id(report_type),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/sigma/_scheduled_query_run_service.py
+++ b/stripe/sigma/_scheduled_query_run_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.sigma._scheduled_query_run import ScheduledQueryRun
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
@@ -68,7 +68,7 @@ class ScheduledQueryRunService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/sigma/scheduled_query_runs/{scheduled_query_run}".format(
-                    scheduled_query_run=_util.sanitize_id(scheduled_query_run),
+                    scheduled_query_run=sanitize_id(scheduled_query_run),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/tax/_calculation.py
+++ b/stripe/tax/_calculation.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -650,7 +649,7 @@ class Calculation(CreateableAPIResource["Calculation"]):
             cls._static_request(
                 "get",
                 "/v1/tax/calculations/{calculation}/line_items".format(
-                    calculation=_util.sanitize_id(calculation)
+                    calculation=sanitize_id(calculation)
                 ),
                 params=params,
             ),
@@ -687,7 +686,7 @@ class Calculation(CreateableAPIResource["Calculation"]):
             self._request(
                 "get",
                 "/v1/tax/calculations/{calculation}/line_items".format(
-                    calculation=_util.sanitize_id(self.get("id"))
+                    calculation=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),

--- a/stripe/tax/_calculation.py
+++ b/stripe/tax/_calculation.py
@@ -632,7 +632,7 @@ class Calculation(CreateableAPIResource["Calculation"]):
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 

--- a/stripe/tax/_calculation_line_item_service.py
+++ b/stripe/tax/_calculation_line_item_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.tax._calculation_line_item import CalculationLineItem
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
@@ -42,7 +42,7 @@ class CalculationLineItemService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/tax/calculations/{calculation}/line_items".format(
-                    calculation=_util.sanitize_id(calculation),
+                    calculation=sanitize_id(calculation),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/tax/_registration.py
+++ b/stripe/tax/_registration.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
+from stripe._util import sanitize_id
 from typing import ClassVar, List, Optional, Union, cast
 from typing_extensions import Literal, NotRequired, TypedDict, Unpack
 
@@ -1680,7 +1680,7 @@ class Registration(
 
         A registration cannot be deleted after it has been created. If you wish to end a registration you may do so by setting expires_at.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Registration",
             cls._static_request(

--- a/stripe/tax/_registration.py
+++ b/stripe/tax/_registration.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
@@ -8,7 +9,6 @@ from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
 from typing import ClassVar, List, Optional, Union, cast
 from typing_extensions import Literal, NotRequired, TypedDict, Unpack
-from urllib.parse import quote_plus
 
 
 class Registration(
@@ -1646,7 +1646,7 @@ class Registration(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -1680,10 +1680,14 @@ class Registration(
 
         A registration cannot be deleted after it has been created. If you wish to end a registration you may do so by setting expires_at.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Registration",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/tax/_registration_service.py
+++ b/stripe/tax/_registration_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.tax._registration import Registration
 from typing import List, Union, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -993,7 +993,7 @@ class RegistrationService(StripeService):
             Registration,
             self._requestor.request(
                 "get",
-                "/v1/tax/registrations/{id}".format(id=_util.sanitize_id(id)),
+                "/v1/tax/registrations/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",
                 base_address="api",
                 params=params,
@@ -1016,7 +1016,7 @@ class RegistrationService(StripeService):
             Registration,
             self._requestor.request(
                 "post",
-                "/v1/tax/registrations/{id}".format(id=_util.sanitize_id(id)),
+                "/v1/tax/registrations/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",
                 base_address="api",
                 params=params,

--- a/stripe/tax/_settings.py
+++ b/stripe/tax/_settings.py
@@ -166,7 +166,11 @@ class Settings(
         """
         return cast(
             "Settings",
-            cls._static_request("post", cls.class_url(), params=params),
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/tax/_transaction.py
+++ b/stripe/tax/_transaction.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._api_resource import APIResource
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -496,7 +495,7 @@ class Transaction(APIResource["Transaction"]):
             cls._static_request(
                 "get",
                 "/v1/tax/transactions/{transaction}/line_items".format(
-                    transaction=_util.sanitize_id(transaction)
+                    transaction=sanitize_id(transaction)
                 ),
                 params=params,
             ),
@@ -533,7 +532,7 @@ class Transaction(APIResource["Transaction"]):
             self._request(
                 "get",
                 "/v1/tax/transactions/{transaction}/line_items".format(
-                    transaction=_util.sanitize_id(self.get("id"))
+                    transaction=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),

--- a/stripe/tax/_transaction_line_item_service.py
+++ b/stripe/tax/_transaction_line_item_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.tax._transaction_line_item import TransactionLineItem
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
@@ -42,7 +42,7 @@ class TransactionLineItemService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/tax/transactions/{transaction}/line_items".format(
-                    transaction=_util.sanitize_id(transaction),
+                    transaction=sanitize_id(transaction),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/tax/_transaction_service.py
+++ b/stripe/tax/_transaction_service.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.tax._transaction import Transaction
 from stripe.tax._transaction_line_item_service import (
     TransactionLineItemService,
@@ -128,7 +128,7 @@ class TransactionService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/tax/transactions/{transaction}".format(
-                    transaction=_util.sanitize_id(transaction),
+                    transaction=sanitize_id(transaction),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/terminal/_configuration.py
+++ b/stripe/terminal/_configuration.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._expandable_field import ExpandableField
@@ -9,7 +8,7 @@ from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -954,7 +953,7 @@ class Configuration(
         """
         Deletes a Configuration object.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(sid))
         return cast(
             "Configuration",
             cls._static_request(
@@ -1024,7 +1023,7 @@ class Configuration(
         """
         Updates a new Configuration object.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Configuration",
             cls._static_request(

--- a/stripe/terminal/_configuration.py
+++ b/stripe/terminal/_configuration.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._expandable_field import ExpandableField
@@ -17,7 +18,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._file import File
@@ -943,7 +943,7 @@ class Configuration(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -954,10 +954,14 @@ class Configuration(
         """
         Deletes a Configuration object.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
         return cast(
             "Configuration",
-            cls._static_request("delete", url, params=params),
+            cls._static_request(
+                "delete",
+                url,
+                params=params,
+            ),
         )
 
     @overload
@@ -1020,10 +1024,14 @@ class Configuration(
         """
         Updates a new Configuration object.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Configuration",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/terminal/_configuration_service.py
+++ b/stripe/terminal/_configuration_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.terminal._configuration import Configuration
 from typing import List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -659,7 +659,7 @@ class ConfigurationService(StripeService):
             self._requestor.request(
                 "delete",
                 "/v1/terminal/configurations/{configuration}".format(
-                    configuration=_util.sanitize_id(configuration),
+                    configuration=sanitize_id(configuration),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -682,7 +682,7 @@ class ConfigurationService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/terminal/configurations/{configuration}".format(
-                    configuration=_util.sanitize_id(configuration),
+                    configuration=sanitize_id(configuration),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -705,7 +705,7 @@ class ConfigurationService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/terminal/configurations/{configuration}".format(
-                    configuration=_util.sanitize_id(configuration),
+                    configuration=sanitize_id(configuration),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/terminal/_connection_token.py
+++ b/stripe/terminal/_connection_token.py
@@ -52,6 +52,6 @@ class ConnectionToken(CreateableAPIResource["ConnectionToken"]):
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )

--- a/stripe/terminal/_location.py
+++ b/stripe/terminal/_location.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._list_object import ListObject
@@ -8,7 +7,7 @@ from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import Literal, NotRequired, TypedDict, Unpack
 
@@ -228,7 +227,7 @@ class Location(
         """
         Deletes a Location object.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(sid))
         return cast(
             "Location",
             cls._static_request(
@@ -296,7 +295,7 @@ class Location(
         """
         Updates a Location object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Location",
             cls._static_request(

--- a/stripe/terminal/_location.py
+++ b/stripe/terminal/_location.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._list_object import ListObject
@@ -10,7 +11,6 @@ from stripe._updateable_api_resource import UpdateableAPIResource
 from stripe._util import class_method_variant
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import Literal, NotRequired, TypedDict, Unpack
-from urllib.parse import quote_plus
 
 
 class Location(
@@ -217,7 +217,7 @@ class Location(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -228,10 +228,14 @@ class Location(
         """
         Deletes a Location object.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
         return cast(
             "Location",
-            cls._static_request("delete", url, params=params),
+            cls._static_request(
+                "delete",
+                url,
+                params=params,
+            ),
         )
 
     @overload
@@ -292,10 +296,14 @@ class Location(
         """
         Updates a Location object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Location",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/terminal/_location_service.py
+++ b/stripe/terminal/_location_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.terminal._location import Location
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -147,7 +147,7 @@ class LocationService(StripeService):
             self._requestor.request(
                 "delete",
                 "/v1/terminal/locations/{location}".format(
-                    location=_util.sanitize_id(location),
+                    location=sanitize_id(location),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -170,7 +170,7 @@ class LocationService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/terminal/locations/{location}".format(
-                    location=_util.sanitize_id(location),
+                    location=sanitize_id(location),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -193,7 +193,7 @@ class LocationService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/terminal/locations/{location}".format(
-                    location=_util.sanitize_id(location),
+                    location=sanitize_id(location),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/terminal/_reader.py
+++ b/stripe/terminal/_reader.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._expandable_field import ExpandableField
@@ -10,7 +9,7 @@ from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._test_helpers import APIResourceTestHelpers
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -544,7 +543,7 @@ class Reader(
             cls._static_request(
                 "post",
                 "/v1/terminal/readers/{reader}/cancel_action".format(
-                    reader=_util.sanitize_id(reader)
+                    reader=sanitize_id(reader)
                 ),
                 params=params,
             ),
@@ -581,7 +580,7 @@ class Reader(
             self._request(
                 "post",
                 "/v1/terminal/readers/{reader}/cancel_action".format(
-                    reader=_util.sanitize_id(self.get("id"))
+                    reader=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -608,7 +607,7 @@ class Reader(
         """
         Deletes a Reader object.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(sid))
         return cast(
             "Reader",
             cls._static_request(
@@ -674,7 +673,7 @@ class Reader(
         """
         Updates a Reader object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "Reader",
             cls._static_request(
@@ -696,7 +695,7 @@ class Reader(
             cls._static_request(
                 "post",
                 "/v1/terminal/readers/{reader}/process_payment_intent".format(
-                    reader=_util.sanitize_id(reader)
+                    reader=sanitize_id(reader)
                 ),
                 params=params,
             ),
@@ -733,7 +732,7 @@ class Reader(
             self._request(
                 "post",
                 "/v1/terminal/readers/{reader}/process_payment_intent".format(
-                    reader=_util.sanitize_id(self.get("id"))
+                    reader=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -751,7 +750,7 @@ class Reader(
             cls._static_request(
                 "post",
                 "/v1/terminal/readers/{reader}/process_setup_intent".format(
-                    reader=_util.sanitize_id(reader)
+                    reader=sanitize_id(reader)
                 ),
                 params=params,
             ),
@@ -788,7 +787,7 @@ class Reader(
             self._request(
                 "post",
                 "/v1/terminal/readers/{reader}/process_setup_intent".format(
-                    reader=_util.sanitize_id(self.get("id"))
+                    reader=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -806,7 +805,7 @@ class Reader(
             cls._static_request(
                 "post",
                 "/v1/terminal/readers/{reader}/refund_payment".format(
-                    reader=_util.sanitize_id(reader)
+                    reader=sanitize_id(reader)
                 ),
                 params=params,
             ),
@@ -843,7 +842,7 @@ class Reader(
             self._request(
                 "post",
                 "/v1/terminal/readers/{reader}/refund_payment".format(
-                    reader=_util.sanitize_id(self.get("id"))
+                    reader=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -872,7 +871,7 @@ class Reader(
             cls._static_request(
                 "post",
                 "/v1/terminal/readers/{reader}/set_reader_display".format(
-                    reader=_util.sanitize_id(reader)
+                    reader=sanitize_id(reader)
                 ),
                 params=params,
             ),
@@ -909,7 +908,7 @@ class Reader(
             self._request(
                 "post",
                 "/v1/terminal/readers/{reader}/set_reader_display".format(
-                    reader=_util.sanitize_id(self.get("id"))
+                    reader=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -932,7 +931,7 @@ class Reader(
                 cls._static_request(
                     "post",
                     "/v1/test_helpers/terminal/readers/{reader}/present_payment_method".format(
-                        reader=_util.sanitize_id(reader)
+                        reader=sanitize_id(reader)
                     ),
                     params=params,
                 ),
@@ -969,7 +968,7 @@ class Reader(
                 self.resource._request(
                     "post",
                     "/v1/test_helpers/terminal/readers/{reader}/present_payment_method".format(
-                        reader=_util.sanitize_id(self.resource.get("id"))
+                        reader=sanitize_id(self.resource.get("id"))
                     ),
                     params=params,
                 ),

--- a/stripe/terminal/_reader.py
+++ b/stripe/terminal/_reader.py
@@ -20,7 +20,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe._charge import Charge
@@ -598,7 +597,7 @@ class Reader(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -609,10 +608,14 @@ class Reader(
         """
         Deletes a Reader object.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
         return cast(
             "Reader",
-            cls._static_request("delete", url, params=params),
+            cls._static_request(
+                "delete",
+                url,
+                params=params,
+            ),
         )
 
     @overload
@@ -671,10 +674,14 @@ class Reader(
         """
         Updates a Reader object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "Reader",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/terminal/_reader_service.py
+++ b/stripe/terminal/_reader_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.terminal._reader import Reader
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -244,7 +244,7 @@ class ReaderService(StripeService):
             self._requestor.request(
                 "delete",
                 "/v1/terminal/readers/{reader}".format(
-                    reader=_util.sanitize_id(reader),
+                    reader=sanitize_id(reader),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -267,7 +267,7 @@ class ReaderService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/terminal/readers/{reader}".format(
-                    reader=_util.sanitize_id(reader),
+                    reader=sanitize_id(reader),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -290,7 +290,7 @@ class ReaderService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/terminal/readers/{reader}".format(
-                    reader=_util.sanitize_id(reader),
+                    reader=sanitize_id(reader),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -353,7 +353,7 @@ class ReaderService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/terminal/readers/{reader}/cancel_action".format(
-                    reader=_util.sanitize_id(reader),
+                    reader=sanitize_id(reader),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -376,7 +376,7 @@ class ReaderService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/terminal/readers/{reader}/process_payment_intent".format(
-                    reader=_util.sanitize_id(reader),
+                    reader=sanitize_id(reader),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -399,7 +399,7 @@ class ReaderService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/terminal/readers/{reader}/process_setup_intent".format(
-                    reader=_util.sanitize_id(reader),
+                    reader=sanitize_id(reader),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -422,7 +422,7 @@ class ReaderService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/terminal/readers/{reader}/refund_payment".format(
-                    reader=_util.sanitize_id(reader),
+                    reader=sanitize_id(reader),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -445,7 +445,7 @@ class ReaderService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/terminal/readers/{reader}/set_reader_display".format(
-                    reader=_util.sanitize_id(reader),
+                    reader=sanitize_id(reader),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/test_helpers/_customer_service.py
+++ b/stripe/test_helpers/_customer_service.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._customer_cash_balance_transaction import (
     CustomerCashBalanceTransaction,
 )
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -43,7 +43,7 @@ class CustomerService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/test_helpers/customers/{customer}/fund_cash_balance".format(
-                    customer=_util.sanitize_id(customer),
+                    customer=sanitize_id(customer),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/test_helpers/_refund_service.py
+++ b/stripe/test_helpers/_refund_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._refund import Refund
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
 
@@ -29,7 +29,7 @@ class RefundService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/test_helpers/refunds/{refund}/expire".format(
-                    refund=_util.sanitize_id(refund),
+                    refund=sanitize_id(refund),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/test_helpers/_test_clock.py
+++ b/stripe/test_helpers/_test_clock.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, List, Optional, cast, overload
 from typing_extensions import Literal, NotRequired, Unpack
 
@@ -126,7 +125,7 @@ class TestClock(
             cls._static_request(
                 "post",
                 "/v1/test_helpers/test_clocks/{test_clock}/advance".format(
-                    test_clock=_util.sanitize_id(test_clock)
+                    test_clock=sanitize_id(test_clock)
                 ),
                 params=params,
             ),
@@ -163,7 +162,7 @@ class TestClock(
             self._request(
                 "post",
                 "/v1/test_helpers/test_clocks/{test_clock}/advance".format(
-                    test_clock=_util.sanitize_id(self.get("id"))
+                    test_clock=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -190,7 +189,7 @@ class TestClock(
         """
         Deletes a test clock.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(sid))
         return cast(
             "TestClock",
             cls._static_request(

--- a/stripe/test_helpers/_test_clock.py
+++ b/stripe/test_helpers/_test_clock.py
@@ -9,7 +9,6 @@ from stripe._request_options import RequestOptions
 from stripe._util import class_method_variant
 from typing import ClassVar, List, Optional, cast, overload
 from typing_extensions import Literal, NotRequired, Unpack
-from urllib.parse import quote_plus
 
 
 class TestClock(
@@ -180,7 +179,7 @@ class TestClock(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -191,10 +190,14 @@ class TestClock(
         """
         Deletes a test clock.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(sid))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(sid))
         return cast(
             "TestClock",
-            cls._static_request("delete", url, params=params),
+            cls._static_request(
+                "delete",
+                url,
+                params=params,
+            ),
         )
 
     @overload

--- a/stripe/test_helpers/_test_clock_service.py
+++ b/stripe/test_helpers/_test_clock_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.test_helpers._test_clock import TestClock
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
@@ -75,7 +75,7 @@ class TestClockService(StripeService):
             self._requestor.request(
                 "delete",
                 "/v1/test_helpers/test_clocks/{test_clock}".format(
-                    test_clock=_util.sanitize_id(test_clock),
+                    test_clock=sanitize_id(test_clock),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -98,7 +98,7 @@ class TestClockService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/test_helpers/test_clocks/{test_clock}".format(
-                    test_clock=_util.sanitize_id(test_clock),
+                    test_clock=sanitize_id(test_clock),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -161,7 +161,7 @@ class TestClockService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/test_helpers/test_clocks/{test_clock}/advance".format(
-                    test_clock=_util.sanitize_id(test_clock),
+                    test_clock=sanitize_id(test_clock),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/test_helpers/issuing/_authorization_service.py
+++ b/stripe/test_helpers/issuing/_authorization_service.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.issuing._authorization import Authorization
 from typing import List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -379,7 +379,7 @@ class AuthorizationService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/test_helpers/issuing/authorizations/{authorization}/capture".format(
-                    authorization=_util.sanitize_id(authorization),
+                    authorization=sanitize_id(authorization),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -402,7 +402,7 @@ class AuthorizationService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/test_helpers/issuing/authorizations/{authorization}/expire".format(
-                    authorization=_util.sanitize_id(authorization),
+                    authorization=sanitize_id(authorization),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -425,7 +425,7 @@ class AuthorizationService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/test_helpers/issuing/authorizations/{authorization}/increment".format(
-                    authorization=_util.sanitize_id(authorization),
+                    authorization=sanitize_id(authorization),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -448,7 +448,7 @@ class AuthorizationService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/test_helpers/issuing/authorizations/{authorization}/reverse".format(
-                    authorization=_util.sanitize_id(authorization),
+                    authorization=sanitize_id(authorization),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/test_helpers/issuing/_card_service.py
+++ b/stripe/test_helpers/issuing/_card_service.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.issuing._card import Card
 from typing import List, cast
 from typing_extensions import NotRequired, TypedDict
@@ -47,7 +47,7 @@ class CardService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/test_helpers/issuing/cards/{card}/shipping/deliver".format(
-                    card=_util.sanitize_id(card),
+                    card=sanitize_id(card),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -70,7 +70,7 @@ class CardService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/test_helpers/issuing/cards/{card}/shipping/fail".format(
-                    card=_util.sanitize_id(card),
+                    card=sanitize_id(card),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -93,7 +93,7 @@ class CardService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/test_helpers/issuing/cards/{card}/shipping/return".format(
-                    card=_util.sanitize_id(card),
+                    card=sanitize_id(card),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -116,7 +116,7 @@ class CardService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/test_helpers/issuing/cards/{card}/shipping/ship".format(
-                    card=_util.sanitize_id(card),
+                    card=sanitize_id(card),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/test_helpers/issuing/_transaction_service.py
+++ b/stripe/test_helpers/issuing/_transaction_service.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.issuing._transaction import Transaction
 from typing import List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -405,7 +405,7 @@ class TransactionService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/test_helpers/issuing/transactions/{transaction}/refund".format(
-                    transaction=_util.sanitize_id(transaction),
+                    transaction=sanitize_id(transaction),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/test_helpers/terminal/_reader_service.py
+++ b/stripe/test_helpers/terminal/_reader_service.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.terminal._reader import Reader
 from typing import List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -61,7 +61,7 @@ class ReaderService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/test_helpers/terminal/readers/{reader}/present_payment_method".format(
-                    reader=_util.sanitize_id(reader),
+                    reader=sanitize_id(reader),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/test_helpers/treasury/_inbound_transfer_service.py
+++ b/stripe/test_helpers/treasury/_inbound_transfer_service.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.treasury._inbound_transfer import InboundTransfer
 from typing import List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -55,7 +55,7 @@ class InboundTransferService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/test_helpers/treasury/inbound_transfers/{id}/fail".format(
-                    id=_util.sanitize_id(id),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -78,7 +78,7 @@ class InboundTransferService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/test_helpers/treasury/inbound_transfers/{id}/return".format(
-                    id=_util.sanitize_id(id),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -101,7 +101,7 @@ class InboundTransferService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/test_helpers/treasury/inbound_transfers/{id}/succeed".format(
-                    id=_util.sanitize_id(id),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/test_helpers/treasury/_outbound_payment_service.py
+++ b/stripe/test_helpers/treasury/_outbound_payment_service.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.treasury._outbound_payment import OutboundPayment
 from typing import List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -55,7 +55,7 @@ class OutboundPaymentService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/test_helpers/treasury/outbound_payments/{id}/fail".format(
-                    id=_util.sanitize_id(id),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -78,7 +78,7 @@ class OutboundPaymentService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/test_helpers/treasury/outbound_payments/{id}/post".format(
-                    id=_util.sanitize_id(id),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -101,7 +101,7 @@ class OutboundPaymentService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/test_helpers/treasury/outbound_payments/{id}/return".format(
-                    id=_util.sanitize_id(id),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/test_helpers/treasury/_outbound_transfer_service.py
+++ b/stripe/test_helpers/treasury/_outbound_transfer_service.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.treasury._outbound_transfer import OutboundTransfer
 from typing import List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -55,7 +55,7 @@ class OutboundTransferService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/fail".format(
-                    outbound_transfer=_util.sanitize_id(outbound_transfer),
+                    outbound_transfer=sanitize_id(outbound_transfer),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -78,7 +78,7 @@ class OutboundTransferService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/post".format(
-                    outbound_transfer=_util.sanitize_id(outbound_transfer),
+                    outbound_transfer=sanitize_id(outbound_transfer),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -101,7 +101,7 @@ class OutboundTransferService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/return".format(
-                    outbound_transfer=_util.sanitize_id(outbound_transfer),
+                    outbound_transfer=sanitize_id(outbound_transfer),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/treasury/_credit_reversal.py
+++ b/stripe/treasury/_credit_reversal.py
@@ -147,7 +147,7 @@ class CreditReversal(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 

--- a/stripe/treasury/_credit_reversal_service.py
+++ b/stripe/treasury/_credit_reversal_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.treasury._credit_reversal import CreditReversal
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -114,7 +114,7 @@ class CreditReversalService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/treasury/credit_reversals/{credit_reversal}".format(
-                    credit_reversal=_util.sanitize_id(credit_reversal),
+                    credit_reversal=sanitize_id(credit_reversal),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/treasury/_debit_reversal.py
+++ b/stripe/treasury/_debit_reversal.py
@@ -161,7 +161,7 @@ class DebitReversal(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 

--- a/stripe/treasury/_debit_reversal_service.py
+++ b/stripe/treasury/_debit_reversal_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.treasury._debit_reversal import DebitReversal
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -118,7 +118,7 @@ class DebitReversalService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/treasury/debit_reversals/{debit_reversal}".format(
-                    debit_reversal=_util.sanitize_id(debit_reversal),
+                    debit_reversal=sanitize_id(debit_reversal),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/treasury/_financial_account.py
+++ b/stripe/treasury/_financial_account.py
@@ -16,7 +16,6 @@ from typing_extensions import (
     Unpack,
     TYPE_CHECKING,
 )
-from urllib.parse import quote_plus
 
 if TYPE_CHECKING:
     from stripe.treasury._financial_account_features import (
@@ -777,7 +776,7 @@ class FinancialAccount(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 
@@ -809,10 +808,14 @@ class FinancialAccount(
         """
         Updates the details of a FinancialAccount.
         """
-        url = "%s/%s" % (cls.class_url(), quote_plus(id))
+        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
         return cast(
             "FinancialAccount",
-            cls._static_request("post", url, params=params),
+            cls._static_request(
+                "post",
+                url,
+                params=params,
+            ),
         )
 
     @classmethod

--- a/stripe/treasury/_financial_account.py
+++ b/stripe/treasury/_financial_account.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._list_object import ListObject
 from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._updateable_api_resource import UpdateableAPIResource
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -808,7 +807,7 @@ class FinancialAccount(
         """
         Updates the details of a FinancialAccount.
         """
-        url = "%s/%s" % (cls.class_url(), _util.sanitize_id(id))
+        url = "%s/%s" % (cls.class_url(), sanitize_id(id))
         return cast(
             "FinancialAccount",
             cls._static_request(
@@ -843,7 +842,7 @@ class FinancialAccount(
             cls._static_request(
                 "get",
                 "/v1/treasury/financial_accounts/{financial_account}/features".format(
-                    financial_account=_util.sanitize_id(financial_account)
+                    financial_account=sanitize_id(financial_account)
                 ),
                 params=params,
             ),
@@ -881,7 +880,7 @@ class FinancialAccount(
             self._request(
                 "get",
                 "/v1/treasury/financial_accounts/{financial_account}/features".format(
-                    financial_account=_util.sanitize_id(self.get("id"))
+                    financial_account=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -901,7 +900,7 @@ class FinancialAccount(
             cls._static_request(
                 "post",
                 "/v1/treasury/financial_accounts/{financial_account}/features".format(
-                    financial_account=_util.sanitize_id(financial_account)
+                    financial_account=sanitize_id(financial_account)
                 ),
                 params=params,
             ),
@@ -939,7 +938,7 @@ class FinancialAccount(
             self._request(
                 "post",
                 "/v1/treasury/financial_accounts/{financial_account}/features".format(
-                    financial_account=_util.sanitize_id(self.get("id"))
+                    financial_account=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),

--- a/stripe/treasury/_financial_account_features_service.py
+++ b/stripe/treasury/_financial_account_features_service.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.treasury._financial_account_features import (
     FinancialAccountFeatures,
 )
@@ -177,7 +177,7 @@ class FinancialAccountFeaturesService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/treasury/financial_accounts/{financial_account}/features".format(
-                    financial_account=_util.sanitize_id(financial_account),
+                    financial_account=sanitize_id(financial_account),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -200,7 +200,7 @@ class FinancialAccountFeaturesService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/treasury/financial_accounts/{financial_account}/features".format(
-                    financial_account=_util.sanitize_id(financial_account),
+                    financial_account=sanitize_id(financial_account),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/treasury/_financial_account_service.py
+++ b/stripe/treasury/_financial_account_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.treasury._financial_account import FinancialAccount
 from stripe.treasury._financial_account_features_service import (
     FinancialAccountFeaturesService,
@@ -462,7 +462,7 @@ class FinancialAccountService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/treasury/financial_accounts/{financial_account}".format(
-                    financial_account=_util.sanitize_id(financial_account),
+                    financial_account=sanitize_id(financial_account),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -485,7 +485,7 @@ class FinancialAccountService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/treasury/financial_accounts/{financial_account}".format(
-                    financial_account=_util.sanitize_id(financial_account),
+                    financial_account=sanitize_id(financial_account),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/treasury/_inbound_transfer.py
+++ b/stripe/treasury/_inbound_transfer.py
@@ -405,7 +405,7 @@ class InboundTransfer(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 

--- a/stripe/treasury/_inbound_transfer.py
+++ b/stripe/treasury/_inbound_transfer.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -8,7 +7,7 @@ from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._test_helpers import APIResourceTestHelpers
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -350,7 +349,7 @@ class InboundTransfer(
             cls._static_request(
                 "post",
                 "/v1/treasury/inbound_transfers/{inbound_transfer}/cancel".format(
-                    inbound_transfer=_util.sanitize_id(inbound_transfer)
+                    inbound_transfer=sanitize_id(inbound_transfer)
                 ),
                 params=params,
             ),
@@ -387,7 +386,7 @@ class InboundTransfer(
             self._request(
                 "post",
                 "/v1/treasury/inbound_transfers/{inbound_transfer}/cancel".format(
-                    inbound_transfer=_util.sanitize_id(self.get("id"))
+                    inbound_transfer=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -456,7 +455,7 @@ class InboundTransfer(
                 cls._static_request(
                     "post",
                     "/v1/test_helpers/treasury/inbound_transfers/{id}/fail".format(
-                        id=_util.sanitize_id(id)
+                        id=sanitize_id(id)
                     ),
                     params=params,
                 ),
@@ -493,7 +492,7 @@ class InboundTransfer(
                 self.resource._request(
                     "post",
                     "/v1/test_helpers/treasury/inbound_transfers/{id}/fail".format(
-                        id=_util.sanitize_id(self.resource.get("id"))
+                        id=sanitize_id(self.resource.get("id"))
                     ),
                     params=params,
                 ),
@@ -513,7 +512,7 @@ class InboundTransfer(
                 cls._static_request(
                     "post",
                     "/v1/test_helpers/treasury/inbound_transfers/{id}/return".format(
-                        id=_util.sanitize_id(id)
+                        id=sanitize_id(id)
                     ),
                     params=params,
                 ),
@@ -553,7 +552,7 @@ class InboundTransfer(
                 self.resource._request(
                     "post",
                     "/v1/test_helpers/treasury/inbound_transfers/{id}/return".format(
-                        id=_util.sanitize_id(self.resource.get("id"))
+                        id=sanitize_id(self.resource.get("id"))
                     ),
                     params=params,
                 ),
@@ -571,7 +570,7 @@ class InboundTransfer(
                 cls._static_request(
                     "post",
                     "/v1/test_helpers/treasury/inbound_transfers/{id}/succeed".format(
-                        id=_util.sanitize_id(id)
+                        id=sanitize_id(id)
                     ),
                     params=params,
                 ),
@@ -608,7 +607,7 @@ class InboundTransfer(
                 self.resource._request(
                     "post",
                     "/v1/test_helpers/treasury/inbound_transfers/{id}/succeed".format(
-                        id=_util.sanitize_id(self.resource.get("id"))
+                        id=sanitize_id(self.resource.get("id"))
                     ),
                     params=params,
                 ),

--- a/stripe/treasury/_inbound_transfer_service.py
+++ b/stripe/treasury/_inbound_transfer_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.treasury._inbound_transfer import InboundTransfer
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -138,7 +138,7 @@ class InboundTransferService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/treasury/inbound_transfers/{id}".format(
-                    id=_util.sanitize_id(id),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -161,7 +161,7 @@ class InboundTransferService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/treasury/inbound_transfers/{inbound_transfer}/cancel".format(
-                    inbound_transfer=_util.sanitize_id(inbound_transfer),
+                    inbound_transfer=sanitize_id(inbound_transfer),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/treasury/_outbound_payment.py
+++ b/stripe/treasury/_outbound_payment.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -8,7 +7,7 @@ from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._test_helpers import APIResourceTestHelpers
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -526,7 +525,7 @@ class OutboundPayment(
             cls._static_request(
                 "post",
                 "/v1/treasury/outbound_payments/{id}/cancel".format(
-                    id=_util.sanitize_id(id)
+                    id=sanitize_id(id)
                 ),
                 params=params,
             ),
@@ -563,7 +562,7 @@ class OutboundPayment(
             self._request(
                 "post",
                 "/v1/treasury/outbound_payments/{id}/cancel".format(
-                    id=_util.sanitize_id(self.get("id"))
+                    id=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -632,7 +631,7 @@ class OutboundPayment(
                 cls._static_request(
                     "post",
                     "/v1/test_helpers/treasury/outbound_payments/{id}/fail".format(
-                        id=_util.sanitize_id(id)
+                        id=sanitize_id(id)
                     ),
                     params=params,
                 ),
@@ -669,7 +668,7 @@ class OutboundPayment(
                 self.resource._request(
                     "post",
                     "/v1/test_helpers/treasury/outbound_payments/{id}/fail".format(
-                        id=_util.sanitize_id(self.resource.get("id"))
+                        id=sanitize_id(self.resource.get("id"))
                     ),
                     params=params,
                 ),
@@ -687,7 +686,7 @@ class OutboundPayment(
                 cls._static_request(
                     "post",
                     "/v1/test_helpers/treasury/outbound_payments/{id}/post".format(
-                        id=_util.sanitize_id(id)
+                        id=sanitize_id(id)
                     ),
                     params=params,
                 ),
@@ -724,7 +723,7 @@ class OutboundPayment(
                 self.resource._request(
                     "post",
                     "/v1/test_helpers/treasury/outbound_payments/{id}/post".format(
-                        id=_util.sanitize_id(self.resource.get("id"))
+                        id=sanitize_id(self.resource.get("id"))
                     ),
                     params=params,
                 ),
@@ -744,7 +743,7 @@ class OutboundPayment(
                 cls._static_request(
                     "post",
                     "/v1/test_helpers/treasury/outbound_payments/{id}/return".format(
-                        id=_util.sanitize_id(id)
+                        id=sanitize_id(id)
                     ),
                     params=params,
                 ),
@@ -784,7 +783,7 @@ class OutboundPayment(
                 self.resource._request(
                     "post",
                     "/v1/test_helpers/treasury/outbound_payments/{id}/return".format(
-                        id=_util.sanitize_id(self.resource.get("id"))
+                        id=sanitize_id(self.resource.get("id"))
                     ),
                     params=params,
                 ),

--- a/stripe/treasury/_outbound_payment.py
+++ b/stripe/treasury/_outbound_payment.py
@@ -581,7 +581,7 @@ class OutboundPayment(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 

--- a/stripe/treasury/_outbound_payment_service.py
+++ b/stripe/treasury/_outbound_payment_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.treasury._outbound_payment import OutboundPayment
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -284,7 +284,7 @@ class OutboundPaymentService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/treasury/outbound_payments/{id}".format(
-                    id=_util.sanitize_id(id),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -307,7 +307,7 @@ class OutboundPaymentService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/treasury/outbound_payments/{id}/cancel".format(
-                    id=_util.sanitize_id(id),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/treasury/_outbound_transfer.py
+++ b/stripe/treasury/_outbound_transfer.py
@@ -423,7 +423,7 @@ class OutboundTransfer(
             cls._static_request(
                 "post",
                 cls.class_url(),
-                params,
+                params=params,
             ),
         )
 

--- a/stripe/treasury/_outbound_transfer.py
+++ b/stripe/treasury/_outbound_transfer.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._createable_api_resource import CreateableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -8,7 +7,7 @@ from stripe._listable_api_resource import ListableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from stripe._test_helpers import APIResourceTestHelpers
-from stripe._util import class_method_variant
+from stripe._util import class_method_variant, sanitize_id
 from typing import ClassVar, Dict, List, Optional, cast, overload
 from typing_extensions import (
     Literal,
@@ -367,7 +366,7 @@ class OutboundTransfer(
             cls._static_request(
                 "post",
                 "/v1/treasury/outbound_transfers/{outbound_transfer}/cancel".format(
-                    outbound_transfer=_util.sanitize_id(outbound_transfer)
+                    outbound_transfer=sanitize_id(outbound_transfer)
                 ),
                 params=params,
             ),
@@ -405,7 +404,7 @@ class OutboundTransfer(
             self._request(
                 "post",
                 "/v1/treasury/outbound_transfers/{outbound_transfer}/cancel".format(
-                    outbound_transfer=_util.sanitize_id(self.get("id"))
+                    outbound_transfer=sanitize_id(self.get("id"))
                 ),
                 params=params,
             ),
@@ -476,7 +475,7 @@ class OutboundTransfer(
                 cls._static_request(
                     "post",
                     "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/fail".format(
-                        outbound_transfer=_util.sanitize_id(outbound_transfer)
+                        outbound_transfer=sanitize_id(outbound_transfer)
                     ),
                     params=params,
                 ),
@@ -514,9 +513,7 @@ class OutboundTransfer(
                 self.resource._request(
                     "post",
                     "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/fail".format(
-                        outbound_transfer=_util.sanitize_id(
-                            self.resource.get("id")
-                        )
+                        outbound_transfer=sanitize_id(self.resource.get("id"))
                     ),
                     params=params,
                 ),
@@ -536,7 +533,7 @@ class OutboundTransfer(
                 cls._static_request(
                     "post",
                     "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/post".format(
-                        outbound_transfer=_util.sanitize_id(outbound_transfer)
+                        outbound_transfer=sanitize_id(outbound_transfer)
                     ),
                     params=params,
                 ),
@@ -574,9 +571,7 @@ class OutboundTransfer(
                 self.resource._request(
                     "post",
                     "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/post".format(
-                        outbound_transfer=_util.sanitize_id(
-                            self.resource.get("id")
-                        )
+                        outbound_transfer=sanitize_id(self.resource.get("id"))
                     ),
                     params=params,
                 ),
@@ -596,7 +591,7 @@ class OutboundTransfer(
                 cls._static_request(
                     "post",
                     "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/return".format(
-                        outbound_transfer=_util.sanitize_id(outbound_transfer)
+                        outbound_transfer=sanitize_id(outbound_transfer)
                     ),
                     params=params,
                 ),
@@ -636,9 +631,7 @@ class OutboundTransfer(
                 self.resource._request(
                     "post",
                     "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/return".format(
-                        outbound_transfer=_util.sanitize_id(
-                            self.resource.get("id")
-                        )
+                        outbound_transfer=sanitize_id(self.resource.get("id"))
                     ),
                     params=params,
                 ),

--- a/stripe/treasury/_outbound_transfer_service.py
+++ b/stripe/treasury/_outbound_transfer_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.treasury._outbound_transfer import OutboundTransfer
 from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -158,7 +158,7 @@ class OutboundTransferService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/treasury/outbound_transfers/{outbound_transfer}".format(
-                    outbound_transfer=_util.sanitize_id(outbound_transfer),
+                    outbound_transfer=sanitize_id(outbound_transfer),
                 ),
                 api_mode="V1",
                 base_address="api",
@@ -181,7 +181,7 @@ class OutboundTransferService(StripeService):
             self._requestor.request(
                 "post",
                 "/v1/treasury/outbound_transfers/{outbound_transfer}/cancel".format(
-                    outbound_transfer=_util.sanitize_id(outbound_transfer),
+                    outbound_transfer=sanitize_id(outbound_transfer),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/treasury/_received_credit_service.py
+++ b/stripe/treasury/_received_credit_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.treasury._received_credit import ReceivedCredit
 from typing import List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -90,7 +90,7 @@ class ReceivedCreditService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/treasury/received_credits/{id}".format(
-                    id=_util.sanitize_id(id),
+                    id=sanitize_id(id)
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/treasury/_received_debit_service.py
+++ b/stripe/treasury/_received_debit_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.treasury._received_debit import ReceivedDebit
 from typing import List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -75,9 +75,7 @@ class ReceivedDebitService(StripeService):
             ReceivedDebit,
             self._requestor.request(
                 "get",
-                "/v1/treasury/received_debits/{id}".format(
-                    id=_util.sanitize_id(id),
-                ),
+                "/v1/treasury/received_debits/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",
                 base_address="api",
                 params=params,

--- a/stripe/treasury/_transaction_entry_service.py
+++ b/stripe/treasury/_transaction_entry_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.treasury._transaction_entry import TransactionEntry
 from typing import List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -120,7 +120,7 @@ class TransactionEntryService(StripeService):
             self._requestor.request(
                 "get",
                 "/v1/treasury/transaction_entries/{id}".format(
-                    id=_util.sanitize_id(id),
+                    id=sanitize_id(id),
                 ),
                 api_mode="V1",
                 base_address="api",

--- a/stripe/treasury/_transaction_service.py
+++ b/stripe/treasury/_transaction_service.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe import _util
 from stripe._list_object import ListObject
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
+from stripe._util import sanitize_id
 from stripe.treasury._transaction import Transaction
 from typing import List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
@@ -130,9 +130,7 @@ class TransactionService(StripeService):
             Transaction,
             self._requestor.request(
                 "get",
-                "/v1/treasury/transactions/{id}".format(
-                    id=_util.sanitize_id(id),
-                ),
+                "/v1/treasury/transactions/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",
                 base_address="api",
                 params=params,


### PR DESCRIPTION
## Summary
* Always use `_util.sanitize_id` instead of `urllib.parse.quote_plus` (the former is an alias for the latter).
* Consistently pass `params=params` as a keyword argument (not a positional argument) into `cls._static_request` in api resources.
* Formatting changes

These changes should be no-ops and allow us to simplify the code in our generator.