### PR TITLE
Measure StripeClient usage

### DIFF
--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -60,9 +60,11 @@ class _APIRequestor(object):
         self,
         options: RequestorOptions = RequestorOptions(),
         client: Optional[HTTPClient] = None,
+        usage: Optional[List[str]] = None,
     ):
         self._options = options
         self._client = client
+        self._usage = usage or []
 
     # In the case of client=None, we should use the current value of stripe.default_http_client
     # or lazily initialize it. Since stripe.default_http_client can change throughout the lifetime of
@@ -171,7 +173,7 @@ class _APIRequestor(object):
             api_mode=api_mode,
             base_address=base_address,
             options=options,
-            _usage=_usage,
+            _usage=self._usage + (_usage or []),
         )
         resp = requestor._interpret_response(rbody, rcode, rheaders)
 

--- a/stripe/_stripe_client.py
+++ b/stripe/_stripe_client.py
@@ -148,6 +148,7 @@ class StripeClient(object):
         self._requestor = _APIRequestor(
             options=requestor_options,
             client=http_client,
+            usage=["stripe_client"],
         )
 
         self._options = _ClientOptions(


### PR DESCRIPTION
Paired with @richardm-stripe to start measuring usage of StripeClient which we introduced in v8.0.0.