### PR TITLE
Move StripeClient usage collection onto StripeService

### DIFF
--- a/stripe/_account_capability_service.py
+++ b/stripe/_account_capability_service.py
@@ -45,7 +45,7 @@ class AccountCapabilityService(StripeService):
         """
         return cast(
             ListObject[Capability],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/accounts/{account}/capabilities".format(
                     account=sanitize_id(account),
@@ -69,7 +69,7 @@ class AccountCapabilityService(StripeService):
         """
         return cast(
             Capability,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/accounts/{account}/capabilities/{capability}".format(
                     account=sanitize_id(account),
@@ -94,7 +94,7 @@ class AccountCapabilityService(StripeService):
         """
         return cast(
             Capability,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/accounts/{account}/capabilities/{capability}".format(
                     account=sanitize_id(account),

--- a/stripe/_account_external_account_service.py
+++ b/stripe/_account_external_account_service.py
@@ -214,7 +214,7 @@ class AccountExternalAccountService(StripeService):
         """
         return cast(
             Union[BankAccount, Card],
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/accounts/{account}/external_accounts/{id}".format(
                     account=sanitize_id(account),
@@ -239,7 +239,7 @@ class AccountExternalAccountService(StripeService):
         """
         return cast(
             Union[BankAccount, Card],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/accounts/{account}/external_accounts/{id}".format(
                     account=sanitize_id(account),
@@ -266,7 +266,7 @@ class AccountExternalAccountService(StripeService):
         """
         return cast(
             Union[BankAccount, Card],
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/accounts/{account}/external_accounts/{id}".format(
                     account=sanitize_id(account),
@@ -290,7 +290,7 @@ class AccountExternalAccountService(StripeService):
         """
         return cast(
             ListObject[Union[BankAccount, Card]],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/accounts/{account}/external_accounts".format(
                     account=sanitize_id(account),
@@ -313,7 +313,7 @@ class AccountExternalAccountService(StripeService):
         """
         return cast(
             Union[BankAccount, Card],
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/accounts/{account}/external_accounts".format(
                     account=sanitize_id(account),

--- a/stripe/_account_link_service.py
+++ b/stripe/_account_link_service.py
@@ -60,7 +60,7 @@ class AccountLinkService(StripeService):
         """
         return cast(
             AccountLink,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/account_links",
                 api_mode="V1",

--- a/stripe/_account_login_link_service.py
+++ b/stripe/_account_login_link_service.py
@@ -28,7 +28,7 @@ class AccountLoginLinkService(StripeService):
         """
         return cast(
             LoginLink,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/accounts/{account}/login_links".format(
                     account=sanitize_id(account),

--- a/stripe/_account_person_service.py
+++ b/stripe/_account_person_service.py
@@ -825,7 +825,7 @@ class AccountPersonService(StripeService):
         """
         return cast(
             Person,
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/accounts/{account}/persons/{person}".format(
                     account=sanitize_id(account),
@@ -850,7 +850,7 @@ class AccountPersonService(StripeService):
         """
         return cast(
             Person,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/accounts/{account}/persons/{person}".format(
                     account=sanitize_id(account),
@@ -875,7 +875,7 @@ class AccountPersonService(StripeService):
         """
         return cast(
             Person,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/accounts/{account}/persons/{person}".format(
                     account=sanitize_id(account),
@@ -899,7 +899,7 @@ class AccountPersonService(StripeService):
         """
         return cast(
             ListObject[Person],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/accounts/{account}/persons".format(
                     account=sanitize_id(account),
@@ -922,7 +922,7 @@ class AccountPersonService(StripeService):
         """
         return cast(
             Person,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/accounts/{account}/persons".format(
                     account=sanitize_id(account),

--- a/stripe/_account_service.py
+++ b/stripe/_account_service.py
@@ -3032,7 +3032,7 @@ class AccountService(StripeService):
         """
         return cast(
             Account,
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/accounts/{account}".format(account=sanitize_id(account)),
                 api_mode="V1",
@@ -3053,7 +3053,7 @@ class AccountService(StripeService):
         """
         return cast(
             Account,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/accounts/{account}".format(account=sanitize_id(account)),
                 api_mode="V1",
@@ -3082,7 +3082,7 @@ class AccountService(StripeService):
         """
         return cast(
             Account,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/accounts/{account}".format(account=sanitize_id(account)),
                 api_mode="V1",
@@ -3102,7 +3102,7 @@ class AccountService(StripeService):
         """
         return cast(
             Account,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/account",
                 api_mode="V1",
@@ -3122,7 +3122,7 @@ class AccountService(StripeService):
         """
         return cast(
             ListObject[Account],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/accounts",
                 api_mode="V1",
@@ -3147,7 +3147,7 @@ class AccountService(StripeService):
         """
         return cast(
             Account,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/accounts",
                 api_mode="V1",
@@ -3170,7 +3170,7 @@ class AccountService(StripeService):
         """
         return cast(
             Account,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/accounts/{account}/reject".format(
                     account=sanitize_id(account),

--- a/stripe/_account_session_service.py
+++ b/stripe/_account_session_service.py
@@ -151,7 +151,7 @@ class AccountSessionService(StripeService):
         """
         return cast(
             AccountSession,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/account_sessions",
                 api_mode="V1",

--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -60,11 +60,9 @@ class _APIRequestor(object):
         self,
         options: RequestorOptions = RequestorOptions(),
         client: Optional[HTTPClient] = None,
-        usage: Optional[List[str]] = None,
     ):
         self._options = options
         self._client = client
-        self._usage = usage or []
 
     # In the case of client=None, we should use the current value of stripe.default_http_client
     # or lazily initialize it. Since stripe.default_http_client can change throughout the lifetime of
@@ -173,7 +171,7 @@ class _APIRequestor(object):
             api_mode=api_mode,
             base_address=base_address,
             options=options,
-            _usage=self._usage + (_usage or []),
+            _usage=_usage,
         )
         resp = requestor._interpret_response(rbody, rcode, rheaders)
 

--- a/stripe/_apple_pay_domain_service.py
+++ b/stripe/_apple_pay_domain_service.py
@@ -56,7 +56,7 @@ class ApplePayDomainService(StripeService):
         """
         return cast(
             ApplePayDomain,
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/apple_pay/domains/{domain}".format(
                     domain=sanitize_id(domain),
@@ -79,7 +79,7 @@ class ApplePayDomainService(StripeService):
         """
         return cast(
             ApplePayDomain,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/apple_pay/domains/{domain}".format(
                     domain=sanitize_id(domain),
@@ -101,7 +101,7 @@ class ApplePayDomainService(StripeService):
         """
         return cast(
             ListObject[ApplePayDomain],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/apple_pay/domains",
                 api_mode="V1",
@@ -121,7 +121,7 @@ class ApplePayDomainService(StripeService):
         """
         return cast(
             ApplePayDomain,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/apple_pay/domains",
                 api_mode="V1",

--- a/stripe/_application_fee_refund_service.py
+++ b/stripe/_application_fee_refund_service.py
@@ -70,7 +70,7 @@ class ApplicationFeeRefundService(StripeService):
         """
         return cast(
             ApplicationFeeRefund,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/application_fees/{fee}/refunds/{id}".format(
                     fee=sanitize_id(fee),
@@ -97,7 +97,7 @@ class ApplicationFeeRefundService(StripeService):
         """
         return cast(
             ApplicationFeeRefund,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/application_fees/{fee}/refunds/{id}".format(
                     fee=sanitize_id(fee),
@@ -121,7 +121,7 @@ class ApplicationFeeRefundService(StripeService):
         """
         return cast(
             ListObject[ApplicationFeeRefund],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/application_fees/{id}/refunds".format(id=sanitize_id(id)),
                 api_mode="V1",
@@ -150,7 +150,7 @@ class ApplicationFeeRefundService(StripeService):
         """
         return cast(
             ApplicationFeeRefund,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/application_fees/{id}/refunds".format(id=sanitize_id(id)),
                 api_mode="V1",

--- a/stripe/_application_fee_service.py
+++ b/stripe/_application_fee_service.py
@@ -72,7 +72,7 @@ class ApplicationFeeService(StripeService):
         """
         return cast(
             ListObject[ApplicationFee],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/application_fees",
                 api_mode="V1",
@@ -93,7 +93,7 @@ class ApplicationFeeService(StripeService):
         """
         return cast(
             ApplicationFee,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/application_fees/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",

--- a/stripe/_balance_service.py
+++ b/stripe/_balance_service.py
@@ -25,7 +25,7 @@ class BalanceService(StripeService):
         """
         return cast(
             Balance,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/balance",
                 api_mode="V1",

--- a/stripe/_balance_transaction_service.py
+++ b/stripe/_balance_transaction_service.py
@@ -81,7 +81,7 @@ class BalanceTransactionService(StripeService):
         """
         return cast(
             ListObject[BalanceTransaction],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/balance_transactions",
                 api_mode="V1",
@@ -104,7 +104,7 @@ class BalanceTransactionService(StripeService):
         """
         return cast(
             BalanceTransaction,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/balance_transactions/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",

--- a/stripe/_charge_service.py
+++ b/stripe/_charge_service.py
@@ -372,7 +372,7 @@ class ChargeService(StripeService):
         """
         return cast(
             ListObject[Charge],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/charges",
                 api_mode="V1",
@@ -394,7 +394,7 @@ class ChargeService(StripeService):
         """
         return cast(
             Charge,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/charges",
                 api_mode="V1",
@@ -415,7 +415,7 @@ class ChargeService(StripeService):
         """
         return cast(
             Charge,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/charges/{charge}".format(charge=sanitize_id(charge)),
                 api_mode="V1",
@@ -436,7 +436,7 @@ class ChargeService(StripeService):
         """
         return cast(
             Charge,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/charges/{charge}".format(charge=sanitize_id(charge)),
                 api_mode="V1",
@@ -459,7 +459,7 @@ class ChargeService(StripeService):
         """
         return cast(
             SearchResultObject[Charge],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/charges/search",
                 api_mode="V1",
@@ -484,7 +484,7 @@ class ChargeService(StripeService):
         """
         return cast(
             Charge,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/charges/{charge}/capture".format(
                     charge=sanitize_id(charge),

--- a/stripe/_country_spec_service.py
+++ b/stripe/_country_spec_service.py
@@ -44,7 +44,7 @@ class CountrySpecService(StripeService):
         """
         return cast(
             ListObject[CountrySpec],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/country_specs",
                 api_mode="V1",
@@ -65,7 +65,7 @@ class CountrySpecService(StripeService):
         """
         return cast(
             CountrySpec,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/country_specs/{country}".format(
                     country=sanitize_id(country),

--- a/stripe/_coupon_service.py
+++ b/stripe/_coupon_service.py
@@ -164,7 +164,7 @@ class CouponService(StripeService):
         """
         return cast(
             Coupon,
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/coupons/{coupon}".format(coupon=sanitize_id(coupon)),
                 api_mode="V1",
@@ -185,7 +185,7 @@ class CouponService(StripeService):
         """
         return cast(
             Coupon,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/coupons/{coupon}".format(coupon=sanitize_id(coupon)),
                 api_mode="V1",
@@ -206,7 +206,7 @@ class CouponService(StripeService):
         """
         return cast(
             Coupon,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/coupons/{coupon}".format(coupon=sanitize_id(coupon)),
                 api_mode="V1",
@@ -226,7 +226,7 @@ class CouponService(StripeService):
         """
         return cast(
             ListObject[Coupon],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/coupons",
                 api_mode="V1",
@@ -248,7 +248,7 @@ class CouponService(StripeService):
         """
         return cast(
             Coupon,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/coupons",
                 api_mode="V1",

--- a/stripe/_credit_note_line_item_service.py
+++ b/stripe/_credit_note_line_item_service.py
@@ -39,7 +39,7 @@ class CreditNoteLineItemService(StripeService):
         """
         return cast(
             ListObject[CreditNoteLineItem],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/credit_notes/{credit_note}/lines".format(
                     credit_note=sanitize_id(credit_note),

--- a/stripe/_credit_note_preview_lines_service.py
+++ b/stripe/_credit_note_preview_lines_service.py
@@ -151,7 +151,7 @@ class CreditNotePreviewLinesService(StripeService):
         """
         return cast(
             ListObject[CreditNoteLineItem],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/credit_notes/preview/lines",
                 api_mode="V1",

--- a/stripe/_credit_note_service.py
+++ b/stripe/_credit_note_service.py
@@ -317,7 +317,7 @@ class CreditNoteService(StripeService):
         """
         return cast(
             ListObject[CreditNote],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/credit_notes",
                 api_mode="V1",
@@ -350,7 +350,7 @@ class CreditNoteService(StripeService):
         """
         return cast(
             CreditNote,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/credit_notes",
                 api_mode="V1",
@@ -371,7 +371,7 @@ class CreditNoteService(StripeService):
         """
         return cast(
             CreditNote,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/credit_notes/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",
@@ -392,7 +392,7 @@ class CreditNoteService(StripeService):
         """
         return cast(
             CreditNote,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/credit_notes/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",
@@ -412,7 +412,7 @@ class CreditNoteService(StripeService):
         """
         return cast(
             CreditNote,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/credit_notes/preview",
                 api_mode="V1",
@@ -433,7 +433,7 @@ class CreditNoteService(StripeService):
         """
         return cast(
             CreditNote,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/credit_notes/{id}/void".format(id=sanitize_id(id)),
                 api_mode="V1",

--- a/stripe/_customer_balance_transaction_service.py
+++ b/stripe/_customer_balance_transaction_service.py
@@ -81,7 +81,7 @@ class CustomerBalanceTransactionService(StripeService):
         """
         return cast(
             ListObject[CustomerBalanceTransaction],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/customers/{customer}/balance_transactions".format(
                     customer=sanitize_id(customer),
@@ -104,7 +104,7 @@ class CustomerBalanceTransactionService(StripeService):
         """
         return cast(
             CustomerBalanceTransaction,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/customers/{customer}/balance_transactions".format(
                     customer=sanitize_id(customer),
@@ -128,7 +128,7 @@ class CustomerBalanceTransactionService(StripeService):
         """
         return cast(
             CustomerBalanceTransaction,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/customers/{customer}/balance_transactions/{transaction}".format(
                     customer=sanitize_id(customer),
@@ -153,7 +153,7 @@ class CustomerBalanceTransactionService(StripeService):
         """
         return cast(
             CustomerBalanceTransaction,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/customers/{customer}/balance_transactions/{transaction}".format(
                     customer=sanitize_id(customer),

--- a/stripe/_customer_cash_balance_service.py
+++ b/stripe/_customer_cash_balance_service.py
@@ -46,7 +46,7 @@ class CustomerCashBalanceService(StripeService):
         """
         return cast(
             CashBalance,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/customers/{customer}/cash_balance".format(
                     customer=sanitize_id(customer),
@@ -69,7 +69,7 @@ class CustomerCashBalanceService(StripeService):
         """
         return cast(
             CashBalance,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/customers/{customer}/cash_balance".format(
                     customer=sanitize_id(customer),

--- a/stripe/_customer_cash_balance_transaction_service.py
+++ b/stripe/_customer_cash_balance_transaction_service.py
@@ -47,7 +47,7 @@ class CustomerCashBalanceTransactionService(StripeService):
         """
         return cast(
             ListObject[CustomerCashBalanceTransaction],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/customers/{customer}/cash_balance_transactions".format(
                     customer=sanitize_id(customer),
@@ -71,7 +71,7 @@ class CustomerCashBalanceTransactionService(StripeService):
         """
         return cast(
             CustomerCashBalanceTransaction,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/customers/{customer}/cash_balance_transactions/{transaction}".format(
                     customer=sanitize_id(customer),

--- a/stripe/_customer_funding_instructions_service.py
+++ b/stripe/_customer_funding_instructions_service.py
@@ -72,7 +72,7 @@ class CustomerFundingInstructionsService(StripeService):
         """
         return cast(
             FundingInstructions,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/customers/{customer}/funding_instructions".format(
                     customer=sanitize_id(customer),

--- a/stripe/_customer_payment_method_service.py
+++ b/stripe/_customer_payment_method_service.py
@@ -51,7 +51,7 @@ class CustomerPaymentMethodService(StripeService):
         """
         return cast(
             ListObject[PaymentMethod],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/customers/{customer}/payment_methods".format(
                     customer=sanitize_id(customer),
@@ -75,7 +75,7 @@ class CustomerPaymentMethodService(StripeService):
         """
         return cast(
             PaymentMethod,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/customers/{customer}/payment_methods/{payment_method}".format(
                     customer=sanitize_id(customer),

--- a/stripe/_customer_payment_source_service.py
+++ b/stripe/_customer_payment_source_service.py
@@ -184,7 +184,7 @@ class CustomerPaymentSourceService(StripeService):
         """
         return cast(
             ListObject[Union[Account, BankAccount, Card, Source]],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/customers/{customer}/sources".format(
                     customer=sanitize_id(customer),
@@ -211,7 +211,7 @@ class CustomerPaymentSourceService(StripeService):
         """
         return cast(
             Union[Account, BankAccount, Card, Source],
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/customers/{customer}/sources".format(
                     customer=sanitize_id(customer),
@@ -235,7 +235,7 @@ class CustomerPaymentSourceService(StripeService):
         """
         return cast(
             Union[Account, BankAccount, Card, Source],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/customers/{customer}/sources/{id}".format(
                     customer=sanitize_id(customer),
@@ -260,7 +260,7 @@ class CustomerPaymentSourceService(StripeService):
         """
         return cast(
             Union[Account, BankAccount, Card, Source],
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/customers/{customer}/sources/{id}".format(
                     customer=sanitize_id(customer),
@@ -285,7 +285,7 @@ class CustomerPaymentSourceService(StripeService):
         """
         return cast(
             Union[Account, BankAccount, Card, Source],
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/customers/{customer}/sources/{id}".format(
                     customer=sanitize_id(customer),
@@ -310,7 +310,7 @@ class CustomerPaymentSourceService(StripeService):
         """
         return cast(
             BankAccount,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/customers/{customer}/sources/{id}/verify".format(
                     customer=sanitize_id(customer),

--- a/stripe/_customer_service.py
+++ b/stripe/_customer_service.py
@@ -651,7 +651,7 @@ class CustomerService(StripeService):
         """
         return cast(
             Customer,
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/customers/{customer}".format(
                     customer=sanitize_id(customer),
@@ -674,7 +674,7 @@ class CustomerService(StripeService):
         """
         return cast(
             Customer,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/customers/{customer}".format(
                     customer=sanitize_id(customer),
@@ -699,7 +699,7 @@ class CustomerService(StripeService):
         """
         return cast(
             Customer,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/customers/{customer}".format(
                     customer=sanitize_id(customer),
@@ -722,7 +722,7 @@ class CustomerService(StripeService):
         """
         return cast(
             Discount,
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/customers/{customer}/discount".format(
                     customer=sanitize_id(customer),
@@ -744,7 +744,7 @@ class CustomerService(StripeService):
         """
         return cast(
             ListObject[Customer],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/customers",
                 api_mode="V1",
@@ -764,7 +764,7 @@ class CustomerService(StripeService):
         """
         return cast(
             Customer,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/customers",
                 api_mode="V1",
@@ -787,7 +787,7 @@ class CustomerService(StripeService):
         """
         return cast(
             SearchResultObject[Customer],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/customers/search",
                 api_mode="V1",

--- a/stripe/_customer_session_service.py
+++ b/stripe/_customer_session_service.py
@@ -58,7 +58,7 @@ class CustomerSessionService(StripeService):
         """
         return cast(
             CustomerSession,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/customer_sessions",
                 api_mode="V1",

--- a/stripe/_customer_tax_id_service.py
+++ b/stripe/_customer_tax_id_service.py
@@ -130,7 +130,7 @@ class CustomerTaxIdService(StripeService):
         """
         return cast(
             TaxId,
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/customers/{customer}/tax_ids/{id}".format(
                     customer=sanitize_id(customer),
@@ -155,7 +155,7 @@ class CustomerTaxIdService(StripeService):
         """
         return cast(
             TaxId,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/customers/{customer}/tax_ids/{id}".format(
                     customer=sanitize_id(customer),
@@ -179,7 +179,7 @@ class CustomerTaxIdService(StripeService):
         """
         return cast(
             ListObject[TaxId],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/customers/{customer}/tax_ids".format(
                     customer=sanitize_id(customer),
@@ -202,7 +202,7 @@ class CustomerTaxIdService(StripeService):
         """
         return cast(
             TaxId,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/customers/{customer}/tax_ids".format(
                     customer=sanitize_id(customer),

--- a/stripe/_dispute_service.py
+++ b/stripe/_dispute_service.py
@@ -205,7 +205,7 @@ class DisputeService(StripeService):
         """
         return cast(
             ListObject[Dispute],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/disputes",
                 api_mode="V1",
@@ -226,7 +226,7 @@ class DisputeService(StripeService):
         """
         return cast(
             Dispute,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/disputes/{dispute}".format(dispute=sanitize_id(dispute)),
                 api_mode="V1",
@@ -249,7 +249,7 @@ class DisputeService(StripeService):
         """
         return cast(
             Dispute,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/disputes/{dispute}".format(dispute=sanitize_id(dispute)),
                 api_mode="V1",
@@ -272,7 +272,7 @@ class DisputeService(StripeService):
         """
         return cast(
             Dispute,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/disputes/{dispute}/close".format(
                     dispute=sanitize_id(dispute),

--- a/stripe/_ephemeral_key_service.py
+++ b/stripe/_ephemeral_key_service.py
@@ -48,7 +48,7 @@ class EphemeralKeyService(StripeService):
         """
         return cast(
             EphemeralKey,
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/ephemeral_keys/{key}".format(key=sanitize_id(key)),
                 api_mode="V1",
@@ -68,7 +68,7 @@ class EphemeralKeyService(StripeService):
         """
         return cast(
             EphemeralKey,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/ephemeral_keys",
                 api_mode="V1",

--- a/stripe/_event_service.py
+++ b/stripe/_event_service.py
@@ -75,7 +75,7 @@ class EventService(StripeService):
         """
         return cast(
             ListObject[Event],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/events",
                 api_mode="V1",
@@ -96,7 +96,7 @@ class EventService(StripeService):
         """
         return cast(
             Event,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/events/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",

--- a/stripe/_exchange_rate_service.py
+++ b/stripe/_exchange_rate_service.py
@@ -44,7 +44,7 @@ class ExchangeRateService(StripeService):
         """
         return cast(
             ListObject[ExchangeRate],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/exchange_rates",
                 api_mode="V1",
@@ -65,7 +65,7 @@ class ExchangeRateService(StripeService):
         """
         return cast(
             ExchangeRate,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/exchange_rates/{rate_id}".format(
                     rate_id=sanitize_id(rate_id),

--- a/stripe/_file_link_service.py
+++ b/stripe/_file_link_service.py
@@ -103,7 +103,7 @@ class FileLinkService(StripeService):
         """
         return cast(
             ListObject[FileLink],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/file_links",
                 api_mode="V1",
@@ -123,7 +123,7 @@ class FileLinkService(StripeService):
         """
         return cast(
             FileLink,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/file_links",
                 api_mode="V1",
@@ -144,7 +144,7 @@ class FileLinkService(StripeService):
         """
         return cast(
             FileLink,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/file_links/{link}".format(link=sanitize_id(link)),
                 api_mode="V1",
@@ -165,7 +165,7 @@ class FileLinkService(StripeService):
         """
         return cast(
             FileLink,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/file_links/{link}".format(link=sanitize_id(link)),
                 api_mode="V1",

--- a/stripe/_file_service.py
+++ b/stripe/_file_service.py
@@ -112,7 +112,7 @@ class FileService(StripeService):
         """
         return cast(
             ListObject[File],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/files",
                 api_mode="V1",
@@ -132,7 +132,7 @@ class FileService(StripeService):
         """
         return cast(
             File,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/files",
                 api_mode="V1FILES",
@@ -153,7 +153,7 @@ class FileService(StripeService):
         """
         return cast(
             File,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/files/{file}".format(file=sanitize_id(file)),
                 api_mode="V1",

--- a/stripe/_invoice_item_service.py
+++ b/stripe/_invoice_item_service.py
@@ -315,7 +315,7 @@ class InvoiceItemService(StripeService):
         """
         return cast(
             InvoiceItem,
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/invoiceitems/{invoiceitem}".format(
                     invoiceitem=sanitize_id(invoiceitem),
@@ -338,7 +338,7 @@ class InvoiceItemService(StripeService):
         """
         return cast(
             InvoiceItem,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/invoiceitems/{invoiceitem}".format(
                     invoiceitem=sanitize_id(invoiceitem),
@@ -361,7 +361,7 @@ class InvoiceItemService(StripeService):
         """
         return cast(
             InvoiceItem,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/invoiceitems/{invoiceitem}".format(
                     invoiceitem=sanitize_id(invoiceitem),
@@ -383,7 +383,7 @@ class InvoiceItemService(StripeService):
         """
         return cast(
             ListObject[InvoiceItem],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/invoiceitems",
                 api_mode="V1",
@@ -403,7 +403,7 @@ class InvoiceItemService(StripeService):
         """
         return cast(
             InvoiceItem,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/invoiceitems",
                 api_mode="V1",

--- a/stripe/_invoice_line_item_service.py
+++ b/stripe/_invoice_line_item_service.py
@@ -39,7 +39,7 @@ class InvoiceLineItemService(StripeService):
         """
         return cast(
             ListObject[InvoiceLineItem],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/invoices/{invoice}/lines".format(
                     invoice=sanitize_id(invoice),

--- a/stripe/_invoice_service.py
+++ b/stripe/_invoice_service.py
@@ -1903,7 +1903,7 @@ class InvoiceService(StripeService):
         """
         return cast(
             Invoice,
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/invoices/{invoice}".format(invoice=sanitize_id(invoice)),
                 api_mode="V1",
@@ -1924,7 +1924,7 @@ class InvoiceService(StripeService):
         """
         return cast(
             Invoice,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/invoices/{invoice}".format(invoice=sanitize_id(invoice)),
                 api_mode="V1",
@@ -1950,7 +1950,7 @@ class InvoiceService(StripeService):
         """
         return cast(
             Invoice,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/invoices/{invoice}".format(invoice=sanitize_id(invoice)),
                 api_mode="V1",
@@ -1970,7 +1970,7 @@ class InvoiceService(StripeService):
         """
         return cast(
             ListObject[Invoice],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/invoices",
                 api_mode="V1",
@@ -1990,7 +1990,7 @@ class InvoiceService(StripeService):
         """
         return cast(
             Invoice,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/invoices",
                 api_mode="V1",
@@ -2013,7 +2013,7 @@ class InvoiceService(StripeService):
         """
         return cast(
             SearchResultObject[Invoice],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/invoices/search",
                 api_mode="V1",
@@ -2037,7 +2037,7 @@ class InvoiceService(StripeService):
         """
         return cast(
             Invoice,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/invoices/upcoming",
                 api_mode="V1",
@@ -2058,7 +2058,7 @@ class InvoiceService(StripeService):
         """
         return cast(
             Invoice,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/invoices/{invoice}/finalize".format(
                     invoice=sanitize_id(invoice),
@@ -2081,7 +2081,7 @@ class InvoiceService(StripeService):
         """
         return cast(
             Invoice,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/invoices/{invoice}/mark_uncollectible".format(
                     invoice=sanitize_id(invoice),
@@ -2104,7 +2104,7 @@ class InvoiceService(StripeService):
         """
         return cast(
             Invoice,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/invoices/{invoice}/pay".format(
                     invoice=sanitize_id(invoice),
@@ -2129,7 +2129,7 @@ class InvoiceService(StripeService):
         """
         return cast(
             Invoice,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/invoices/{invoice}/send".format(
                     invoice=sanitize_id(invoice),
@@ -2152,7 +2152,7 @@ class InvoiceService(StripeService):
         """
         return cast(
             Invoice,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/invoices/{invoice}/void".format(
                     invoice=sanitize_id(invoice),

--- a/stripe/_invoice_upcoming_lines_service.py
+++ b/stripe/_invoice_upcoming_lines_service.py
@@ -582,7 +582,7 @@ class InvoiceUpcomingLinesService(StripeService):
         """
         return cast(
             ListObject[InvoiceLineItem],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/invoices/upcoming/lines",
                 api_mode="V1",

--- a/stripe/_mandate_service.py
+++ b/stripe/_mandate_service.py
@@ -26,7 +26,7 @@ class MandateService(StripeService):
         """
         return cast(
             Mandate,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/mandates/{mandate}".format(mandate=sanitize_id(mandate)),
                 api_mode="V1",

--- a/stripe/_payment_intent_service.py
+++ b/stripe/_payment_intent_service.py
@@ -5889,7 +5889,7 @@ class PaymentIntentService(StripeService):
         """
         return cast(
             ListObject[PaymentIntent],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/payment_intents",
                 api_mode="V1",
@@ -5918,7 +5918,7 @@ class PaymentIntentService(StripeService):
         """
         return cast(
             PaymentIntent,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/payment_intents",
                 api_mode="V1",
@@ -5943,7 +5943,7 @@ class PaymentIntentService(StripeService):
         """
         return cast(
             PaymentIntent,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/payment_intents/{intent}".format(
                     intent=sanitize_id(intent),
@@ -5972,7 +5972,7 @@ class PaymentIntentService(StripeService):
         """
         return cast(
             PaymentIntent,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/payment_intents/{intent}".format(
                     intent=sanitize_id(intent),
@@ -5997,7 +5997,7 @@ class PaymentIntentService(StripeService):
         """
         return cast(
             SearchResultObject[PaymentIntent],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/payment_intents/search",
                 api_mode="V1",
@@ -6018,7 +6018,7 @@ class PaymentIntentService(StripeService):
         """
         return cast(
             PaymentIntent,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/payment_intents/{intent}/apply_customer_balance".format(
                     intent=sanitize_id(intent),
@@ -6045,7 +6045,7 @@ class PaymentIntentService(StripeService):
         """
         return cast(
             PaymentIntent,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/payment_intents/{intent}/cancel".format(
                     intent=sanitize_id(intent),
@@ -6072,7 +6072,7 @@ class PaymentIntentService(StripeService):
         """
         return cast(
             PaymentIntent,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/payment_intents/{intent}/capture".format(
                     intent=sanitize_id(intent),
@@ -6117,7 +6117,7 @@ class PaymentIntentService(StripeService):
         """
         return cast(
             PaymentIntent,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/payment_intents/{intent}/confirm".format(
                     intent=sanitize_id(intent),
@@ -6163,7 +6163,7 @@ class PaymentIntentService(StripeService):
         """
         return cast(
             PaymentIntent,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/payment_intents/{intent}/increment_authorization".format(
                     intent=sanitize_id(intent),
@@ -6186,7 +6186,7 @@ class PaymentIntentService(StripeService):
         """
         return cast(
             PaymentIntent,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/payment_intents/{intent}/verify_microdeposits".format(
                     intent=sanitize_id(intent),

--- a/stripe/_payment_link_line_item_service.py
+++ b/stripe/_payment_link_line_item_service.py
@@ -39,7 +39,7 @@ class PaymentLinkLineItemService(StripeService):
         """
         return cast(
             ListObject[LineItem],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/payment_links/{payment_link}/line_items".format(
                     payment_link=sanitize_id(payment_link),

--- a/stripe/_payment_link_service.py
+++ b/stripe/_payment_link_service.py
@@ -1630,7 +1630,7 @@ class PaymentLinkService(StripeService):
         """
         return cast(
             ListObject[PaymentLink],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/payment_links",
                 api_mode="V1",
@@ -1650,7 +1650,7 @@ class PaymentLinkService(StripeService):
         """
         return cast(
             PaymentLink,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/payment_links",
                 api_mode="V1",
@@ -1671,7 +1671,7 @@ class PaymentLinkService(StripeService):
         """
         return cast(
             PaymentLink,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/payment_links/{payment_link}".format(
                     payment_link=sanitize_id(payment_link),
@@ -1694,7 +1694,7 @@ class PaymentLinkService(StripeService):
         """
         return cast(
             PaymentLink,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/payment_links/{payment_link}".format(
                     payment_link=sanitize_id(payment_link),

--- a/stripe/_payment_method_configuration_service.py
+++ b/stripe/_payment_method_configuration_service.py
@@ -1432,7 +1432,7 @@ class PaymentMethodConfigurationService(StripeService):
         """
         return cast(
             ListObject[PaymentMethodConfiguration],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/payment_method_configurations",
                 api_mode="V1",
@@ -1452,7 +1452,7 @@ class PaymentMethodConfigurationService(StripeService):
         """
         return cast(
             PaymentMethodConfiguration,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/payment_method_configurations",
                 api_mode="V1",
@@ -1473,7 +1473,7 @@ class PaymentMethodConfigurationService(StripeService):
         """
         return cast(
             PaymentMethodConfiguration,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/payment_method_configurations/{configuration}".format(
                     configuration=sanitize_id(configuration),
@@ -1496,7 +1496,7 @@ class PaymentMethodConfigurationService(StripeService):
         """
         return cast(
             PaymentMethodConfiguration,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/payment_method_configurations/{configuration}".format(
                     configuration=sanitize_id(configuration),

--- a/stripe/_payment_method_domain_service.py
+++ b/stripe/_payment_method_domain_service.py
@@ -82,7 +82,7 @@ class PaymentMethodDomainService(StripeService):
         """
         return cast(
             ListObject[PaymentMethodDomain],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/payment_method_domains",
                 api_mode="V1",
@@ -102,7 +102,7 @@ class PaymentMethodDomainService(StripeService):
         """
         return cast(
             PaymentMethodDomain,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/payment_method_domains",
                 api_mode="V1",
@@ -123,7 +123,7 @@ class PaymentMethodDomainService(StripeService):
         """
         return cast(
             PaymentMethodDomain,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/payment_method_domains/{payment_method_domain}".format(
                     payment_method_domain=sanitize_id(payment_method_domain),
@@ -146,7 +146,7 @@ class PaymentMethodDomainService(StripeService):
         """
         return cast(
             PaymentMethodDomain,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/payment_method_domains/{payment_method_domain}".format(
                     payment_method_domain=sanitize_id(payment_method_domain),
@@ -174,7 +174,7 @@ class PaymentMethodDomainService(StripeService):
         """
         return cast(
             PaymentMethodDomain,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/payment_method_domains/{payment_method_domain}/validate".format(
                     payment_method_domain=sanitize_id(payment_method_domain),

--- a/stripe/_payment_method_service.py
+++ b/stripe/_payment_method_service.py
@@ -639,7 +639,7 @@ class PaymentMethodService(StripeService):
         """
         return cast(
             ListObject[PaymentMethod],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/payment_methods",
                 api_mode="V1",
@@ -661,7 +661,7 @@ class PaymentMethodService(StripeService):
         """
         return cast(
             PaymentMethod,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/payment_methods",
                 api_mode="V1",
@@ -682,7 +682,7 @@ class PaymentMethodService(StripeService):
         """
         return cast(
             PaymentMethod,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/payment_methods/{payment_method}".format(
                     payment_method=sanitize_id(payment_method),
@@ -705,7 +705,7 @@ class PaymentMethodService(StripeService):
         """
         return cast(
             PaymentMethod,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/payment_methods/{payment_method}".format(
                     payment_method=sanitize_id(payment_method),
@@ -740,7 +740,7 @@ class PaymentMethodService(StripeService):
         """
         return cast(
             PaymentMethod,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/payment_methods/{payment_method}/attach".format(
                     payment_method=sanitize_id(payment_method),
@@ -763,7 +763,7 @@ class PaymentMethodService(StripeService):
         """
         return cast(
             PaymentMethod,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/payment_methods/{payment_method}/detach".format(
                     payment_method=sanitize_id(payment_method),

--- a/stripe/_payout_service.py
+++ b/stripe/_payout_service.py
@@ -154,7 +154,7 @@ class PayoutService(StripeService):
         """
         return cast(
             ListObject[Payout],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/payouts",
                 api_mode="V1",
@@ -178,7 +178,7 @@ class PayoutService(StripeService):
         """
         return cast(
             Payout,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/payouts",
                 api_mode="V1",
@@ -199,7 +199,7 @@ class PayoutService(StripeService):
         """
         return cast(
             Payout,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/payouts/{payout}".format(payout=sanitize_id(payout)),
                 api_mode="V1",
@@ -220,7 +220,7 @@ class PayoutService(StripeService):
         """
         return cast(
             Payout,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/payouts/{payout}".format(payout=sanitize_id(payout)),
                 api_mode="V1",
@@ -241,7 +241,7 @@ class PayoutService(StripeService):
         """
         return cast(
             Payout,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/payouts/{payout}/cancel".format(
                     payout=sanitize_id(payout),
@@ -266,7 +266,7 @@ class PayoutService(StripeService):
         """
         return cast(
             Payout,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/payouts/{payout}/reverse".format(
                     payout=sanitize_id(payout),

--- a/stripe/_plan_service.py
+++ b/stripe/_plan_service.py
@@ -241,7 +241,7 @@ class PlanService(StripeService):
         """
         return cast(
             Plan,
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/plans/{plan}".format(plan=sanitize_id(plan)),
                 api_mode="V1",
@@ -262,7 +262,7 @@ class PlanService(StripeService):
         """
         return cast(
             Plan,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/plans/{plan}".format(plan=sanitize_id(plan)),
                 api_mode="V1",
@@ -283,7 +283,7 @@ class PlanService(StripeService):
         """
         return cast(
             Plan,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/plans/{plan}".format(plan=sanitize_id(plan)),
                 api_mode="V1",
@@ -303,7 +303,7 @@ class PlanService(StripeService):
         """
         return cast(
             ListObject[Plan],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/plans",
                 api_mode="V1",
@@ -321,7 +321,7 @@ class PlanService(StripeService):
         """
         return cast(
             Plan,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/plans",
                 api_mode="V1",

--- a/stripe/_price_service.py
+++ b/stripe/_price_service.py
@@ -485,7 +485,7 @@ class PriceService(StripeService):
         """
         return cast(
             ListObject[Price],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/prices",
                 api_mode="V1",
@@ -503,7 +503,7 @@ class PriceService(StripeService):
         """
         return cast(
             Price,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/prices",
                 api_mode="V1",
@@ -524,7 +524,7 @@ class PriceService(StripeService):
         """
         return cast(
             Price,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/prices/{price}".format(price=sanitize_id(price)),
                 api_mode="V1",
@@ -545,7 +545,7 @@ class PriceService(StripeService):
         """
         return cast(
             Price,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/prices/{price}".format(price=sanitize_id(price)),
                 api_mode="V1",
@@ -566,7 +566,7 @@ class PriceService(StripeService):
         """
         return cast(
             SearchResultObject[Price],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/prices/search",
                 api_mode="V1",

--- a/stripe/_product_service.py
+++ b/stripe/_product_service.py
@@ -407,7 +407,7 @@ class ProductService(StripeService):
         """
         return cast(
             Product,
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/products/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",
@@ -428,7 +428,7 @@ class ProductService(StripeService):
         """
         return cast(
             Product,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/products/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",
@@ -449,7 +449,7 @@ class ProductService(StripeService):
         """
         return cast(
             Product,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/products/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",
@@ -469,7 +469,7 @@ class ProductService(StripeService):
         """
         return cast(
             ListObject[Product],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/products",
                 api_mode="V1",
@@ -489,7 +489,7 @@ class ProductService(StripeService):
         """
         return cast(
             Product,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/products",
                 api_mode="V1",
@@ -512,7 +512,7 @@ class ProductService(StripeService):
         """
         return cast(
             SearchResultObject[Product],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/products/search",
                 api_mode="V1",

--- a/stripe/_promotion_code_service.py
+++ b/stripe/_promotion_code_service.py
@@ -182,7 +182,7 @@ class PromotionCodeService(StripeService):
         """
         return cast(
             ListObject[PromotionCode],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/promotion_codes",
                 api_mode="V1",
@@ -202,7 +202,7 @@ class PromotionCodeService(StripeService):
         """
         return cast(
             PromotionCode,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/promotion_codes",
                 api_mode="V1",
@@ -223,7 +223,7 @@ class PromotionCodeService(StripeService):
         """
         return cast(
             PromotionCode,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/promotion_codes/{promotion_code}".format(
                     promotion_code=sanitize_id(promotion_code),
@@ -246,7 +246,7 @@ class PromotionCodeService(StripeService):
         """
         return cast(
             PromotionCode,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/promotion_codes/{promotion_code}".format(
                     promotion_code=sanitize_id(promotion_code),

--- a/stripe/_quote_computed_upfront_line_items_service.py
+++ b/stripe/_quote_computed_upfront_line_items_service.py
@@ -39,7 +39,7 @@ class QuoteComputedUpfrontLineItemsService(StripeService):
         """
         return cast(
             ListObject[LineItem],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/quotes/{quote}/computed_upfront_line_items".format(
                     quote=sanitize_id(quote),

--- a/stripe/_quote_line_item_service.py
+++ b/stripe/_quote_line_item_service.py
@@ -39,7 +39,7 @@ class QuoteLineItemService(StripeService):
         """
         return cast(
             ListObject[LineItem],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/quotes/{quote}/line_items".format(
                     quote=sanitize_id(quote),

--- a/stripe/_quote_service.py
+++ b/stripe/_quote_service.py
@@ -575,7 +575,7 @@ class QuoteService(StripeService):
         """
         return cast(
             ListObject[Quote],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/quotes",
                 api_mode="V1",
@@ -595,7 +595,7 @@ class QuoteService(StripeService):
         """
         return cast(
             Quote,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/quotes",
                 api_mode="V1",
@@ -616,7 +616,7 @@ class QuoteService(StripeService):
         """
         return cast(
             Quote,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/quotes/{quote}".format(quote=sanitize_id(quote)),
                 api_mode="V1",
@@ -637,7 +637,7 @@ class QuoteService(StripeService):
         """
         return cast(
             Quote,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/quotes/{quote}".format(quote=sanitize_id(quote)),
                 api_mode="V1",
@@ -658,7 +658,7 @@ class QuoteService(StripeService):
         """
         return cast(
             Quote,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/quotes/{quote}/accept".format(quote=sanitize_id(quote)),
                 api_mode="V1",
@@ -679,7 +679,7 @@ class QuoteService(StripeService):
         """
         return cast(
             Quote,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/quotes/{quote}/cancel".format(quote=sanitize_id(quote)),
                 api_mode="V1",
@@ -700,7 +700,7 @@ class QuoteService(StripeService):
         """
         return cast(
             Quote,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/quotes/{quote}/finalize".format(quote=sanitize_id(quote)),
                 api_mode="V1",
@@ -721,7 +721,7 @@ class QuoteService(StripeService):
         """
         return cast(
             Any,
-            self._requestor.request_stream(
+            self._request_stream(
                 "get",
                 "/v1/quotes/{quote}/pdf".format(quote=sanitize_id(quote)),
                 api_mode="V1",

--- a/stripe/_refund_service.py
+++ b/stripe/_refund_service.py
@@ -138,7 +138,7 @@ class RefundService(StripeService):
         """
         return cast(
             ListObject[Refund],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/refunds",
                 api_mode="V1",
@@ -168,7 +168,7 @@ class RefundService(StripeService):
         """
         return cast(
             Refund,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/refunds",
                 api_mode="V1",
@@ -189,7 +189,7 @@ class RefundService(StripeService):
         """
         return cast(
             Refund,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/refunds/{refund}".format(refund=sanitize_id(refund)),
                 api_mode="V1",
@@ -212,7 +212,7 @@ class RefundService(StripeService):
         """
         return cast(
             Refund,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/refunds/{refund}".format(refund=sanitize_id(refund)),
                 api_mode="V1",
@@ -235,7 +235,7 @@ class RefundService(StripeService):
         """
         return cast(
             Refund,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/refunds/{refund}/cancel".format(
                     refund=sanitize_id(refund),

--- a/stripe/_review_service.py
+++ b/stripe/_review_service.py
@@ -69,7 +69,7 @@ class ReviewService(StripeService):
         """
         return cast(
             ListObject[Review],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/reviews",
                 api_mode="V1",
@@ -90,7 +90,7 @@ class ReviewService(StripeService):
         """
         return cast(
             Review,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/reviews/{review}".format(review=sanitize_id(review)),
                 api_mode="V1",
@@ -111,7 +111,7 @@ class ReviewService(StripeService):
         """
         return cast(
             Review,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/reviews/{review}/approve".format(
                     review=sanitize_id(review),

--- a/stripe/_setup_attempt_service.py
+++ b/stripe/_setup_attempt_service.py
@@ -66,7 +66,7 @@ class SetupAttemptService(StripeService):
         """
         return cast(
             ListObject[SetupAttempt],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/setup_attempts",
                 api_mode="V1",

--- a/stripe/_setup_intent_service.py
+++ b/stripe/_setup_intent_service.py
@@ -2887,7 +2887,7 @@ class SetupIntentService(StripeService):
         """
         return cast(
             ListObject[SetupIntent],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/setup_intents",
                 api_mode="V1",
@@ -2910,7 +2910,7 @@ class SetupIntentService(StripeService):
         """
         return cast(
             SetupIntent,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/setup_intents",
                 api_mode="V1",
@@ -2935,7 +2935,7 @@ class SetupIntentService(StripeService):
         """
         return cast(
             SetupIntent,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/setup_intents/{intent}".format(
                     intent=sanitize_id(intent)
@@ -2958,7 +2958,7 @@ class SetupIntentService(StripeService):
         """
         return cast(
             SetupIntent,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/setup_intents/{intent}".format(
                     intent=sanitize_id(intent)
@@ -2983,7 +2983,7 @@ class SetupIntentService(StripeService):
         """
         return cast(
             SetupIntent,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/setup_intents/{intent}/cancel".format(
                     intent=sanitize_id(intent),
@@ -3019,7 +3019,7 @@ class SetupIntentService(StripeService):
         """
         return cast(
             SetupIntent,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/setup_intents/{intent}/confirm".format(
                     intent=sanitize_id(intent),
@@ -3042,7 +3042,7 @@ class SetupIntentService(StripeService):
         """
         return cast(
             SetupIntent,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/setup_intents/{intent}/verify_microdeposits".format(
                     intent=sanitize_id(intent),

--- a/stripe/_shipping_rate_service.py
+++ b/stripe/_shipping_rate_service.py
@@ -222,7 +222,7 @@ class ShippingRateService(StripeService):
         """
         return cast(
             ListObject[ShippingRate],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/shipping_rates",
                 api_mode="V1",
@@ -242,7 +242,7 @@ class ShippingRateService(StripeService):
         """
         return cast(
             ShippingRate,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/shipping_rates",
                 api_mode="V1",
@@ -263,7 +263,7 @@ class ShippingRateService(StripeService):
         """
         return cast(
             ShippingRate,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/shipping_rates/{shipping_rate_token}".format(
                     shipping_rate_token=sanitize_id(shipping_rate_token),
@@ -286,7 +286,7 @@ class ShippingRateService(StripeService):
         """
         return cast(
             ShippingRate,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/shipping_rates/{shipping_rate_token}".format(
                     shipping_rate_token=sanitize_id(shipping_rate_token),

--- a/stripe/_source_service.py
+++ b/stripe/_source_service.py
@@ -545,7 +545,7 @@ class SourceService(StripeService):
         """
         return cast(
             Union[Account, BankAccount, Card, Source],
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/customers/{customer}/sources/{id}".format(
                     customer=sanitize_id(customer),
@@ -569,7 +569,7 @@ class SourceService(StripeService):
         """
         return cast(
             Source,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/sources/{source}".format(source=sanitize_id(source)),
                 api_mode="V1",
@@ -592,7 +592,7 @@ class SourceService(StripeService):
         """
         return cast(
             Source,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/sources/{source}".format(source=sanitize_id(source)),
                 api_mode="V1",
@@ -612,7 +612,7 @@ class SourceService(StripeService):
         """
         return cast(
             Source,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/sources",
                 api_mode="V1",
@@ -633,7 +633,7 @@ class SourceService(StripeService):
         """
         return cast(
             Source,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/sources/{source}/verify".format(
                     source=sanitize_id(source),

--- a/stripe/_source_transaction_service.py
+++ b/stripe/_source_transaction_service.py
@@ -39,7 +39,7 @@ class SourceTransactionService(StripeService):
         """
         return cast(
             ListObject[SourceTransaction],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/sources/{source}/source_transactions".format(
                     source=sanitize_id(source),

--- a/stripe/_stripe_client.py
+++ b/stripe/_stripe_client.py
@@ -148,7 +148,6 @@ class StripeClient(object):
         self._requestor = _APIRequestor(
             options=requestor_options,
             client=http_client,
-            usage=["stripe_client"],
         )
 
         self._options = _ClientOptions(

--- a/stripe/_stripe_service.py
+++ b/stripe/_stripe_service.py
@@ -1,4 +1,10 @@
-from stripe._api_requestor import _APIRequestor
+from stripe._api_requestor import _APIRequestor, StripeStreamResponse
+from stripe._stripe_object import StripeObject
+from stripe._request_options import RequestOptions
+from stripe._base_address import BaseAddress
+from stripe._api_mode import ApiMode
+
+from typing import Any, Mapping, Optional
 
 
 class StripeService(object):
@@ -6,3 +12,43 @@ class StripeService(object):
 
     def __init__(self, requestor):
         self._requestor = requestor
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        params: Optional[Mapping[str, Any]] = None,
+        options: Optional[RequestOptions] = None,
+        *,
+        base_address: BaseAddress,
+        api_mode: ApiMode,
+    ) -> StripeObject:
+        return self._requestor.request(
+            method,
+            url,
+            params,
+            options,
+            base_address=base_address,
+            api_mode=api_mode,
+            _usage=["stripe_client"],
+        )
+
+    def _request_stream(
+        self,
+        method: str,
+        url: str,
+        params: Optional[Mapping[str, Any]] = None,
+        options: Optional[RequestOptions] = None,
+        *,
+        base_address: BaseAddress,
+        api_mode: ApiMode,
+    ) -> StripeStreamResponse:
+        return self._requestor.request_stream(
+            method,
+            url,
+            params,
+            options,
+            base_address=base_address,
+            api_mode=api_mode,
+            _usage=["stripe_client"],
+        )

--- a/stripe/_subscription_item_service.py
+++ b/stripe/_subscription_item_service.py
@@ -298,7 +298,7 @@ class SubscriptionItemService(StripeService):
         """
         return cast(
             SubscriptionItem,
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/subscription_items/{item}".format(item=sanitize_id(item)),
                 api_mode="V1",
@@ -319,7 +319,7 @@ class SubscriptionItemService(StripeService):
         """
         return cast(
             SubscriptionItem,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/subscription_items/{item}".format(item=sanitize_id(item)),
                 api_mode="V1",
@@ -340,7 +340,7 @@ class SubscriptionItemService(StripeService):
         """
         return cast(
             SubscriptionItem,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/subscription_items/{item}".format(item=sanitize_id(item)),
                 api_mode="V1",
@@ -360,7 +360,7 @@ class SubscriptionItemService(StripeService):
         """
         return cast(
             ListObject[SubscriptionItem],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/subscription_items",
                 api_mode="V1",
@@ -380,7 +380,7 @@ class SubscriptionItemService(StripeService):
         """
         return cast(
             SubscriptionItem,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/subscription_items",
                 api_mode="V1",

--- a/stripe/_subscription_item_usage_record_service.py
+++ b/stripe/_subscription_item_usage_record_service.py
@@ -44,7 +44,7 @@ class SubscriptionItemUsageRecordService(StripeService):
         """
         return cast(
             UsageRecord,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/subscription_items/{subscription_item}/usage_records".format(
                     subscription_item=sanitize_id(subscription_item),

--- a/stripe/_subscription_item_usage_record_summary_service.py
+++ b/stripe/_subscription_item_usage_record_summary_service.py
@@ -41,7 +41,7 @@ class SubscriptionItemUsageRecordSummaryService(StripeService):
         """
         return cast(
             ListObject[UsageRecordSummary],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/subscription_items/{subscription_item}/usage_record_summaries".format(
                     subscription_item=sanitize_id(subscription_item),

--- a/stripe/_subscription_schedule_service.py
+++ b/stripe/_subscription_schedule_service.py
@@ -1062,7 +1062,7 @@ class SubscriptionScheduleService(StripeService):
         """
         return cast(
             ListObject[SubscriptionSchedule],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/subscription_schedules",
                 api_mode="V1",
@@ -1082,7 +1082,7 @@ class SubscriptionScheduleService(StripeService):
         """
         return cast(
             SubscriptionSchedule,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/subscription_schedules",
                 api_mode="V1",
@@ -1103,7 +1103,7 @@ class SubscriptionScheduleService(StripeService):
         """
         return cast(
             SubscriptionSchedule,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/subscription_schedules/{schedule}".format(
                     schedule=sanitize_id(schedule),
@@ -1126,7 +1126,7 @@ class SubscriptionScheduleService(StripeService):
         """
         return cast(
             SubscriptionSchedule,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/subscription_schedules/{schedule}".format(
                     schedule=sanitize_id(schedule),
@@ -1149,7 +1149,7 @@ class SubscriptionScheduleService(StripeService):
         """
         return cast(
             SubscriptionSchedule,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/subscription_schedules/{schedule}/cancel".format(
                     schedule=sanitize_id(schedule),
@@ -1172,7 +1172,7 @@ class SubscriptionScheduleService(StripeService):
         """
         return cast(
             SubscriptionSchedule,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/subscription_schedules/{schedule}/release".format(
                     schedule=sanitize_id(schedule),

--- a/stripe/_subscription_service.py
+++ b/stripe/_subscription_service.py
@@ -1405,7 +1405,7 @@ class SubscriptionService(StripeService):
         """
         return cast(
             Subscription,
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/subscriptions/{subscription_exposed_id}".format(
                     subscription_exposed_id=sanitize_id(
@@ -1430,7 +1430,7 @@ class SubscriptionService(StripeService):
         """
         return cast(
             Subscription,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/subscriptions/{subscription_exposed_id}".format(
                     subscription_exposed_id=sanitize_id(
@@ -1475,7 +1475,7 @@ class SubscriptionService(StripeService):
         """
         return cast(
             Subscription,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/subscriptions/{subscription_exposed_id}".format(
                     subscription_exposed_id=sanitize_id(
@@ -1500,7 +1500,7 @@ class SubscriptionService(StripeService):
         """
         return cast(
             Discount,
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/subscriptions/{subscription_exposed_id}/discount".format(
                     subscription_exposed_id=sanitize_id(
@@ -1524,7 +1524,7 @@ class SubscriptionService(StripeService):
         """
         return cast(
             ListObject[Subscription],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/subscriptions",
                 api_mode="V1",
@@ -1550,7 +1550,7 @@ class SubscriptionService(StripeService):
         """
         return cast(
             Subscription,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/subscriptions",
                 api_mode="V1",
@@ -1573,7 +1573,7 @@ class SubscriptionService(StripeService):
         """
         return cast(
             SearchResultObject[Subscription],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/subscriptions/search",
                 api_mode="V1",
@@ -1594,7 +1594,7 @@ class SubscriptionService(StripeService):
         """
         return cast(
             Subscription,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/subscriptions/{subscription}/resume".format(
                     subscription=sanitize_id(subscription),

--- a/stripe/_tax_code_service.py
+++ b/stripe/_tax_code_service.py
@@ -44,7 +44,7 @@ class TaxCodeService(StripeService):
         """
         return cast(
             ListObject[TaxCode],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/tax_codes",
                 api_mode="V1",
@@ -65,7 +65,7 @@ class TaxCodeService(StripeService):
         """
         return cast(
             TaxCode,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/tax_codes/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",

--- a/stripe/_tax_rate_service.py
+++ b/stripe/_tax_rate_service.py
@@ -162,7 +162,7 @@ class TaxRateService(StripeService):
         """
         return cast(
             ListObject[TaxRate],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/tax_rates",
                 api_mode="V1",
@@ -182,7 +182,7 @@ class TaxRateService(StripeService):
         """
         return cast(
             TaxRate,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/tax_rates",
                 api_mode="V1",
@@ -203,7 +203,7 @@ class TaxRateService(StripeService):
         """
         return cast(
             TaxRate,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/tax_rates/{tax_rate}".format(
                     tax_rate=sanitize_id(tax_rate),
@@ -226,7 +226,7 @@ class TaxRateService(StripeService):
         """
         return cast(
             TaxRate,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/tax_rates/{tax_rate}".format(
                     tax_rate=sanitize_id(tax_rate),

--- a/stripe/_token_service.py
+++ b/stripe/_token_service.py
@@ -1040,7 +1040,7 @@ class TokenService(StripeService):
         """
         return cast(
             Token,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/tokens/{token}".format(token=sanitize_id(token)),
                 api_mode="V1",
@@ -1061,7 +1061,7 @@ class TokenService(StripeService):
         """
         return cast(
             Token,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/tokens",
                 api_mode="V1",

--- a/stripe/_topup_service.py
+++ b/stripe/_topup_service.py
@@ -148,7 +148,7 @@ class TopupService(StripeService):
         """
         return cast(
             ListObject[Topup],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/topups",
                 api_mode="V1",
@@ -166,7 +166,7 @@ class TopupService(StripeService):
         """
         return cast(
             Topup,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/topups",
                 api_mode="V1",
@@ -187,7 +187,7 @@ class TopupService(StripeService):
         """
         return cast(
             Topup,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/topups/{topup}".format(topup=sanitize_id(topup)),
                 api_mode="V1",
@@ -208,7 +208,7 @@ class TopupService(StripeService):
         """
         return cast(
             Topup,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/topups/{topup}".format(topup=sanitize_id(topup)),
                 api_mode="V1",
@@ -229,7 +229,7 @@ class TopupService(StripeService):
         """
         return cast(
             Topup,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/topups/{topup}/cancel".format(topup=sanitize_id(topup)),
                 api_mode="V1",

--- a/stripe/_transfer_reversal_service.py
+++ b/stripe/_transfer_reversal_service.py
@@ -77,7 +77,7 @@ class TransferReversalService(StripeService):
         """
         return cast(
             ListObject[Reversal],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/transfers/{id}/reversals".format(id=sanitize_id(id)),
                 api_mode="V1",
@@ -102,7 +102,7 @@ class TransferReversalService(StripeService):
         """
         return cast(
             Reversal,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/transfers/{id}/reversals".format(id=sanitize_id(id)),
                 api_mode="V1",
@@ -124,7 +124,7 @@ class TransferReversalService(StripeService):
         """
         return cast(
             Reversal,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/transfers/{transfer}/reversals/{id}".format(
                     transfer=sanitize_id(transfer),
@@ -151,7 +151,7 @@ class TransferReversalService(StripeService):
         """
         return cast(
             Reversal,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/transfers/{transfer}/reversals/{id}".format(
                     transfer=sanitize_id(transfer),

--- a/stripe/_transfer_service.py
+++ b/stripe/_transfer_service.py
@@ -128,7 +128,7 @@ class TransferService(StripeService):
         """
         return cast(
             ListObject[Transfer],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/transfers",
                 api_mode="V1",
@@ -148,7 +148,7 @@ class TransferService(StripeService):
         """
         return cast(
             Transfer,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/transfers",
                 api_mode="V1",
@@ -169,7 +169,7 @@ class TransferService(StripeService):
         """
         return cast(
             Transfer,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/transfers/{transfer}".format(
                     transfer=sanitize_id(transfer),
@@ -194,7 +194,7 @@ class TransferService(StripeService):
         """
         return cast(
             Transfer,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/transfers/{transfer}".format(
                     transfer=sanitize_id(transfer),

--- a/stripe/_webhook_endpoint_service.py
+++ b/stripe/_webhook_endpoint_service.py
@@ -345,7 +345,7 @@ class WebhookEndpointService(StripeService):
         """
         return cast(
             WebhookEndpoint,
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/webhook_endpoints/{webhook_endpoint}".format(
                     webhook_endpoint=sanitize_id(webhook_endpoint),
@@ -368,7 +368,7 @@ class WebhookEndpointService(StripeService):
         """
         return cast(
             WebhookEndpoint,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/webhook_endpoints/{webhook_endpoint}".format(
                     webhook_endpoint=sanitize_id(webhook_endpoint),
@@ -391,7 +391,7 @@ class WebhookEndpointService(StripeService):
         """
         return cast(
             WebhookEndpoint,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/webhook_endpoints/{webhook_endpoint}".format(
                     webhook_endpoint=sanitize_id(webhook_endpoint),
@@ -413,7 +413,7 @@ class WebhookEndpointService(StripeService):
         """
         return cast(
             ListObject[WebhookEndpoint],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/webhook_endpoints",
                 api_mode="V1",
@@ -433,7 +433,7 @@ class WebhookEndpointService(StripeService):
         """
         return cast(
             WebhookEndpoint,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/webhook_endpoints",
                 api_mode="V1",

--- a/stripe/apps/_secret_service.py
+++ b/stripe/apps/_secret_service.py
@@ -129,7 +129,7 @@ class SecretService(StripeService):
         """
         return cast(
             ListObject[Secret],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/apps/secrets",
                 api_mode="V1",
@@ -149,7 +149,7 @@ class SecretService(StripeService):
         """
         return cast(
             Secret,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/apps/secrets",
                 api_mode="V1",
@@ -167,7 +167,7 @@ class SecretService(StripeService):
         """
         return cast(
             Secret,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/apps/secrets/find",
                 api_mode="V1",
@@ -187,7 +187,7 @@ class SecretService(StripeService):
         """
         return cast(
             Secret,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/apps/secrets/delete",
                 api_mode="V1",

--- a/stripe/billing_portal/_configuration_service.py
+++ b/stripe/billing_portal/_configuration_service.py
@@ -439,7 +439,7 @@ class ConfigurationService(StripeService):
         """
         return cast(
             ListObject[Configuration],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/billing_portal/configurations",
                 api_mode="V1",
@@ -459,7 +459,7 @@ class ConfigurationService(StripeService):
         """
         return cast(
             Configuration,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/billing_portal/configurations",
                 api_mode="V1",
@@ -480,7 +480,7 @@ class ConfigurationService(StripeService):
         """
         return cast(
             Configuration,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/billing_portal/configurations/{configuration}".format(
                     configuration=sanitize_id(configuration),
@@ -503,7 +503,7 @@ class ConfigurationService(StripeService):
         """
         return cast(
             Configuration,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/billing_portal/configurations/{configuration}".format(
                     configuration=sanitize_id(configuration),

--- a/stripe/billing_portal/_session_service.py
+++ b/stripe/billing_portal/_session_service.py
@@ -193,7 +193,7 @@ class SessionService(StripeService):
         """
         return cast(
             Session,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/billing_portal/sessions",
                 api_mode="V1",

--- a/stripe/checkout/_session_line_item_service.py
+++ b/stripe/checkout/_session_line_item_service.py
@@ -39,7 +39,7 @@ class SessionLineItemService(StripeService):
         """
         return cast(
             ListObject[LineItem],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/checkout/sessions/{session}/line_items".format(
                     session=sanitize_id(session),

--- a/stripe/checkout/_session_service.py
+++ b/stripe/checkout/_session_service.py
@@ -2050,7 +2050,7 @@ class SessionService(StripeService):
         """
         return cast(
             ListObject[Session],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/checkout/sessions",
                 api_mode="V1",
@@ -2070,7 +2070,7 @@ class SessionService(StripeService):
         """
         return cast(
             Session,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/checkout/sessions",
                 api_mode="V1",
@@ -2091,7 +2091,7 @@ class SessionService(StripeService):
         """
         return cast(
             Session,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/checkout/sessions/{session}".format(
                     session=sanitize_id(session),
@@ -2116,7 +2116,7 @@ class SessionService(StripeService):
         """
         return cast(
             Session,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/checkout/sessions/{session}/expire".format(
                     session=sanitize_id(session),

--- a/stripe/climate/_order_service.py
+++ b/stripe/climate/_order_service.py
@@ -109,7 +109,7 @@ class OrderService(StripeService):
         """
         return cast(
             ListObject[Order],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/climate/orders",
                 api_mode="V1",
@@ -128,7 +128,7 @@ class OrderService(StripeService):
         """
         return cast(
             Order,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/climate/orders",
                 api_mode="V1",
@@ -149,7 +149,7 @@ class OrderService(StripeService):
         """
         return cast(
             Order,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/climate/orders/{order}".format(order=sanitize_id(order)),
                 api_mode="V1",
@@ -170,7 +170,7 @@ class OrderService(StripeService):
         """
         return cast(
             Order,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/climate/orders/{order}".format(order=sanitize_id(order)),
                 api_mode="V1",
@@ -194,7 +194,7 @@ class OrderService(StripeService):
         """
         return cast(
             Order,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/climate/orders/{order}/cancel".format(
                     order=sanitize_id(order),

--- a/stripe/climate/_product_service.py
+++ b/stripe/climate/_product_service.py
@@ -44,7 +44,7 @@ class ProductService(StripeService):
         """
         return cast(
             ListObject[Product],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/climate/products",
                 api_mode="V1",
@@ -65,7 +65,7 @@ class ProductService(StripeService):
         """
         return cast(
             Product,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/climate/products/{product}".format(
                     product=sanitize_id(product),

--- a/stripe/climate/_supplier_service.py
+++ b/stripe/climate/_supplier_service.py
@@ -44,7 +44,7 @@ class SupplierService(StripeService):
         """
         return cast(
             ListObject[Supplier],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/climate/suppliers",
                 api_mode="V1",
@@ -65,7 +65,7 @@ class SupplierService(StripeService):
         """
         return cast(
             Supplier,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/climate/suppliers/{supplier}".format(
                     supplier=sanitize_id(supplier),

--- a/stripe/financial_connections/_account_owner_service.py
+++ b/stripe/financial_connections/_account_owner_service.py
@@ -43,7 +43,7 @@ class AccountOwnerService(StripeService):
         """
         return cast(
             ListObject[AccountOwner],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/financial_connections/accounts/{account}/owners".format(
                     account=sanitize_id(account),

--- a/stripe/financial_connections/_account_service.py
+++ b/stripe/financial_connections/_account_service.py
@@ -105,7 +105,7 @@ class AccountService(StripeService):
         """
         return cast(
             ListObject[Account],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/financial_connections/accounts",
                 api_mode="V1",
@@ -126,7 +126,7 @@ class AccountService(StripeService):
         """
         return cast(
             Account,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/financial_connections/accounts/{account}".format(
                     account=sanitize_id(account),
@@ -149,7 +149,7 @@ class AccountService(StripeService):
         """
         return cast(
             Account,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/financial_connections/accounts/{account}/disconnect".format(
                     account=sanitize_id(account),
@@ -172,7 +172,7 @@ class AccountService(StripeService):
         """
         return cast(
             Account,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/financial_connections/accounts/{account}/refresh".format(
                     account=sanitize_id(account),
@@ -195,7 +195,7 @@ class AccountService(StripeService):
         """
         return cast(
             Account,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/financial_connections/accounts/{account}/subscribe".format(
                     account=sanitize_id(account),
@@ -218,7 +218,7 @@ class AccountService(StripeService):
         """
         return cast(
             Account,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/financial_connections/accounts/{account}/unsubscribe".format(
                     account=sanitize_id(account),

--- a/stripe/financial_connections/_session_service.py
+++ b/stripe/financial_connections/_session_service.py
@@ -78,7 +78,7 @@ class SessionService(StripeService):
         """
         return cast(
             Session,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/financial_connections/sessions/{session}".format(
                     session=sanitize_id(session),
@@ -100,7 +100,7 @@ class SessionService(StripeService):
         """
         return cast(
             Session,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/financial_connections/sessions",
                 api_mode="V1",

--- a/stripe/financial_connections/_transaction_service.py
+++ b/stripe/financial_connections/_transaction_service.py
@@ -84,7 +84,7 @@ class TransactionService(StripeService):
         """
         return cast(
             ListObject[Transaction],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/financial_connections/transactions",
                 api_mode="V1",
@@ -105,7 +105,7 @@ class TransactionService(StripeService):
         """
         return cast(
             Transaction,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/financial_connections/transactions/{transaction}".format(
                     transaction=sanitize_id(transaction),

--- a/stripe/identity/_verification_report_service.py
+++ b/stripe/identity/_verification_report_service.py
@@ -71,7 +71,7 @@ class VerificationReportService(StripeService):
         """
         return cast(
             ListObject[VerificationReport],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/identity/verification_reports",
                 api_mode="V1",
@@ -92,7 +92,7 @@ class VerificationReportService(StripeService):
         """
         return cast(
             VerificationReport,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/identity/verification_reports/{report}".format(
                     report=sanitize_id(report),

--- a/stripe/identity/_verification_session_service.py
+++ b/stripe/identity/_verification_session_service.py
@@ -179,7 +179,7 @@ class VerificationSessionService(StripeService):
         """
         return cast(
             ListObject[VerificationSession],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/identity/verification_sessions",
                 api_mode="V1",
@@ -205,7 +205,7 @@ class VerificationSessionService(StripeService):
         """
         return cast(
             VerificationSession,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/identity/verification_sessions",
                 api_mode="V1",
@@ -229,7 +229,7 @@ class VerificationSessionService(StripeService):
         """
         return cast(
             VerificationSession,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/identity/verification_sessions/{session}".format(
                     session=sanitize_id(session),
@@ -255,7 +255,7 @@ class VerificationSessionService(StripeService):
         """
         return cast(
             VerificationSession,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/identity/verification_sessions/{session}".format(
                     session=sanitize_id(session),
@@ -280,7 +280,7 @@ class VerificationSessionService(StripeService):
         """
         return cast(
             VerificationSession,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/identity/verification_sessions/{session}/cancel".format(
                     session=sanitize_id(session),
@@ -321,7 +321,7 @@ class VerificationSessionService(StripeService):
         """
         return cast(
             VerificationSession,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/identity/verification_sessions/{session}/redact".format(
                     session=sanitize_id(session),

--- a/stripe/issuing/_authorization_service.py
+++ b/stripe/issuing/_authorization_service.py
@@ -112,7 +112,7 @@ class AuthorizationService(StripeService):
         """
         return cast(
             ListObject[Authorization],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/issuing/authorizations",
                 api_mode="V1",
@@ -133,7 +133,7 @@ class AuthorizationService(StripeService):
         """
         return cast(
             Authorization,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/issuing/authorizations/{authorization}".format(
                     authorization=sanitize_id(authorization),
@@ -156,7 +156,7 @@ class AuthorizationService(StripeService):
         """
         return cast(
             Authorization,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/issuing/authorizations/{authorization}".format(
                     authorization=sanitize_id(authorization),
@@ -180,7 +180,7 @@ class AuthorizationService(StripeService):
         """
         return cast(
             Authorization,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/issuing/authorizations/{authorization}/approve".format(
                     authorization=sanitize_id(authorization),
@@ -204,7 +204,7 @@ class AuthorizationService(StripeService):
         """
         return cast(
             Authorization,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/issuing/authorizations/{authorization}/decline".format(
                     authorization=sanitize_id(authorization),

--- a/stripe/issuing/_card_service.py
+++ b/stripe/issuing/_card_service.py
@@ -329,7 +329,7 @@ class CardService(StripeService):
         """
         return cast(
             ListObject[Card],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/issuing/cards",
                 api_mode="V1",
@@ -347,7 +347,7 @@ class CardService(StripeService):
         """
         return cast(
             Card,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/issuing/cards",
                 api_mode="V1",
@@ -368,7 +368,7 @@ class CardService(StripeService):
         """
         return cast(
             Card,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/issuing/cards/{card}".format(card=sanitize_id(card)),
                 api_mode="V1",
@@ -389,7 +389,7 @@ class CardService(StripeService):
         """
         return cast(
             Card,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/issuing/cards/{card}".format(card=sanitize_id(card)),
                 api_mode="V1",

--- a/stripe/issuing/_cardholder_service.py
+++ b/stripe/issuing/_cardholder_service.py
@@ -514,7 +514,7 @@ class CardholderService(StripeService):
         """
         return cast(
             ListObject[Cardholder],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/issuing/cardholders",
                 api_mode="V1",
@@ -534,7 +534,7 @@ class CardholderService(StripeService):
         """
         return cast(
             Cardholder,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/issuing/cardholders",
                 api_mode="V1",
@@ -555,7 +555,7 @@ class CardholderService(StripeService):
         """
         return cast(
             Cardholder,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/issuing/cardholders/{cardholder}".format(
                     cardholder=sanitize_id(cardholder),
@@ -578,7 +578,7 @@ class CardholderService(StripeService):
         """
         return cast(
             Cardholder,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/issuing/cardholders/{cardholder}".format(
                     cardholder=sanitize_id(cardholder),

--- a/stripe/issuing/_dispute_service.py
+++ b/stripe/issuing/_dispute_service.py
@@ -588,7 +588,7 @@ class DisputeService(StripeService):
         """
         return cast(
             ListObject[Dispute],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/issuing/disputes",
                 api_mode="V1",
@@ -608,7 +608,7 @@ class DisputeService(StripeService):
         """
         return cast(
             Dispute,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/issuing/disputes",
                 api_mode="V1",
@@ -629,7 +629,7 @@ class DisputeService(StripeService):
         """
         return cast(
             Dispute,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/issuing/disputes/{dispute}".format(
                     dispute=sanitize_id(dispute),
@@ -652,7 +652,7 @@ class DisputeService(StripeService):
         """
         return cast(
             Dispute,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/issuing/disputes/{dispute}".format(
                     dispute=sanitize_id(dispute),
@@ -675,7 +675,7 @@ class DisputeService(StripeService):
         """
         return cast(
             Dispute,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/issuing/disputes/{dispute}/submit".format(
                     dispute=sanitize_id(dispute),

--- a/stripe/issuing/_token_service.py
+++ b/stripe/issuing/_token_service.py
@@ -84,7 +84,7 @@ class TokenService(StripeService):
         """
         return cast(
             ListObject[Token],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/issuing/tokens",
                 api_mode="V1",
@@ -105,7 +105,7 @@ class TokenService(StripeService):
         """
         return cast(
             Token,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/issuing/tokens/{token}".format(token=sanitize_id(token)),
                 api_mode="V1",
@@ -126,7 +126,7 @@ class TokenService(StripeService):
         """
         return cast(
             Token,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/issuing/tokens/{token}".format(token=sanitize_id(token)),
                 api_mode="V1",

--- a/stripe/issuing/_transaction_service.py
+++ b/stripe/issuing/_transaction_service.py
@@ -88,7 +88,7 @@ class TransactionService(StripeService):
         """
         return cast(
             ListObject[Transaction],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/issuing/transactions",
                 api_mode="V1",
@@ -109,7 +109,7 @@ class TransactionService(StripeService):
         """
         return cast(
             Transaction,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/issuing/transactions/{transaction}".format(
                     transaction=sanitize_id(transaction),
@@ -132,7 +132,7 @@ class TransactionService(StripeService):
         """
         return cast(
             Transaction,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/issuing/transactions/{transaction}".format(
                     transaction=sanitize_id(transaction),

--- a/stripe/radar/_early_fraud_warning_service.py
+++ b/stripe/radar/_early_fraud_warning_service.py
@@ -74,7 +74,7 @@ class EarlyFraudWarningService(StripeService):
         """
         return cast(
             ListObject[EarlyFraudWarning],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/radar/early_fraud_warnings",
                 api_mode="V1",
@@ -97,7 +97,7 @@ class EarlyFraudWarningService(StripeService):
         """
         return cast(
             EarlyFraudWarning,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/radar/early_fraud_warnings/{early_fraud_warning}".format(
                     early_fraud_warning=sanitize_id(early_fraud_warning),

--- a/stripe/radar/_value_list_item_service.py
+++ b/stripe/radar/_value_list_item_service.py
@@ -89,7 +89,7 @@ class ValueListItemService(StripeService):
         """
         return cast(
             ValueListItem,
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/radar/value_list_items/{item}".format(
                     item=sanitize_id(item),
@@ -112,7 +112,7 @@ class ValueListItemService(StripeService):
         """
         return cast(
             ValueListItem,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/radar/value_list_items/{item}".format(
                     item=sanitize_id(item),
@@ -134,7 +134,7 @@ class ValueListItemService(StripeService):
         """
         return cast(
             ListObject[ValueListItem],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/radar/value_list_items",
                 api_mode="V1",
@@ -154,7 +154,7 @@ class ValueListItemService(StripeService):
         """
         return cast(
             ValueListItem,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/radar/value_list_items",
                 api_mode="V1",

--- a/stripe/radar/_value_list_service.py
+++ b/stripe/radar/_value_list_service.py
@@ -117,7 +117,7 @@ class ValueListService(StripeService):
         """
         return cast(
             ValueList,
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/radar/value_lists/{value_list}".format(
                     value_list=sanitize_id(value_list),
@@ -140,7 +140,7 @@ class ValueListService(StripeService):
         """
         return cast(
             ValueList,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/radar/value_lists/{value_list}".format(
                     value_list=sanitize_id(value_list),
@@ -163,7 +163,7 @@ class ValueListService(StripeService):
         """
         return cast(
             ValueList,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/radar/value_lists/{value_list}".format(
                     value_list=sanitize_id(value_list),
@@ -185,7 +185,7 @@ class ValueListService(StripeService):
         """
         return cast(
             ListObject[ValueList],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/radar/value_lists",
                 api_mode="V1",
@@ -205,7 +205,7 @@ class ValueListService(StripeService):
         """
         return cast(
             ValueList,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/radar/value_lists",
                 api_mode="V1",

--- a/stripe/reporting/_report_run_service.py
+++ b/stripe/reporting/_report_run_service.py
@@ -115,7 +115,7 @@ class ReportRunService(StripeService):
         """
         return cast(
             ListObject[ReportRun],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/reporting/report_runs",
                 api_mode="V1",
@@ -135,7 +135,7 @@ class ReportRunService(StripeService):
         """
         return cast(
             ReportRun,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/reporting/report_runs",
                 api_mode="V1",
@@ -156,7 +156,7 @@ class ReportRunService(StripeService):
         """
         return cast(
             ReportRun,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/reporting/report_runs/{report_run}".format(
                     report_run=sanitize_id(report_run),

--- a/stripe/reporting/_report_type_service.py
+++ b/stripe/reporting/_report_type_service.py
@@ -32,7 +32,7 @@ class ReportTypeService(StripeService):
         """
         return cast(
             ListObject[ReportType],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/reporting/report_types",
                 api_mode="V1",
@@ -53,7 +53,7 @@ class ReportTypeService(StripeService):
         """
         return cast(
             ReportType,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/reporting/report_types/{report_type}".format(
                     report_type=sanitize_id(report_type),

--- a/stripe/sigma/_scheduled_query_run_service.py
+++ b/stripe/sigma/_scheduled_query_run_service.py
@@ -44,7 +44,7 @@ class ScheduledQueryRunService(StripeService):
         """
         return cast(
             ListObject[ScheduledQueryRun],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/sigma/scheduled_query_runs",
                 api_mode="V1",
@@ -65,7 +65,7 @@ class ScheduledQueryRunService(StripeService):
         """
         return cast(
             ScheduledQueryRun,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/sigma/scheduled_query_runs/{scheduled_query_run}".format(
                     scheduled_query_run=sanitize_id(scheduled_query_run),

--- a/stripe/tax/_calculation_line_item_service.py
+++ b/stripe/tax/_calculation_line_item_service.py
@@ -39,7 +39,7 @@ class CalculationLineItemService(StripeService):
         """
         return cast(
             ListObject[CalculationLineItem],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/tax/calculations/{calculation}/line_items".format(
                     calculation=sanitize_id(calculation),

--- a/stripe/tax/_calculation_service.py
+++ b/stripe/tax/_calculation_service.py
@@ -234,7 +234,7 @@ class CalculationService(StripeService):
         """
         return cast(
             Calculation,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/tax/calculations",
                 api_mode="V1",

--- a/stripe/tax/_registration_service.py
+++ b/stripe/tax/_registration_service.py
@@ -950,7 +950,7 @@ class RegistrationService(StripeService):
         """
         return cast(
             ListObject[Registration],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/tax/registrations",
                 api_mode="V1",
@@ -970,7 +970,7 @@ class RegistrationService(StripeService):
         """
         return cast(
             Registration,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/tax/registrations",
                 api_mode="V1",
@@ -991,7 +991,7 @@ class RegistrationService(StripeService):
         """
         return cast(
             Registration,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/tax/registrations/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",
@@ -1014,7 +1014,7 @@ class RegistrationService(StripeService):
         """
         return cast(
             Registration,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/tax/registrations/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",

--- a/stripe/tax/_settings_service.py
+++ b/stripe/tax/_settings_service.py
@@ -82,7 +82,7 @@ class SettingsService(StripeService):
         """
         return cast(
             Settings,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/tax/settings",
                 api_mode="V1",
@@ -102,7 +102,7 @@ class SettingsService(StripeService):
         """
         return cast(
             Settings,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/tax/settings",
                 api_mode="V1",

--- a/stripe/tax/_transaction_line_item_service.py
+++ b/stripe/tax/_transaction_line_item_service.py
@@ -39,7 +39,7 @@ class TransactionLineItemService(StripeService):
         """
         return cast(
             ListObject[TransactionLineItem],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/tax/transactions/{transaction}/line_items".format(
                     transaction=sanitize_id(transaction),

--- a/stripe/tax/_transaction_service.py
+++ b/stripe/tax/_transaction_service.py
@@ -125,7 +125,7 @@ class TransactionService(StripeService):
         """
         return cast(
             Transaction,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/tax/transactions/{transaction}".format(
                     transaction=sanitize_id(transaction),
@@ -147,7 +147,7 @@ class TransactionService(StripeService):
         """
         return cast(
             Transaction,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/tax/transactions/create_from_calculation",
                 api_mode="V1",
@@ -167,7 +167,7 @@ class TransactionService(StripeService):
         """
         return cast(
             Transaction,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/tax/transactions/create_reversal",
                 api_mode="V1",

--- a/stripe/terminal/_configuration_service.py
+++ b/stripe/terminal/_configuration_service.py
@@ -656,7 +656,7 @@ class ConfigurationService(StripeService):
         """
         return cast(
             Configuration,
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/terminal/configurations/{configuration}".format(
                     configuration=sanitize_id(configuration),
@@ -679,7 +679,7 @@ class ConfigurationService(StripeService):
         """
         return cast(
             Configuration,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/terminal/configurations/{configuration}".format(
                     configuration=sanitize_id(configuration),
@@ -702,7 +702,7 @@ class ConfigurationService(StripeService):
         """
         return cast(
             Configuration,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/terminal/configurations/{configuration}".format(
                     configuration=sanitize_id(configuration),
@@ -724,7 +724,7 @@ class ConfigurationService(StripeService):
         """
         return cast(
             ListObject[Configuration],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/terminal/configurations",
                 api_mode="V1",
@@ -744,7 +744,7 @@ class ConfigurationService(StripeService):
         """
         return cast(
             Configuration,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/terminal/configurations",
                 api_mode="V1",

--- a/stripe/terminal/_connection_token_service.py
+++ b/stripe/terminal/_connection_token_service.py
@@ -28,7 +28,7 @@ class ConnectionTokenService(StripeService):
         """
         return cast(
             ConnectionToken,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/terminal/connection_tokens",
                 api_mode="V1",

--- a/stripe/terminal/_location_service.py
+++ b/stripe/terminal/_location_service.py
@@ -144,7 +144,7 @@ class LocationService(StripeService):
         """
         return cast(
             Location,
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/terminal/locations/{location}".format(
                     location=sanitize_id(location),
@@ -167,7 +167,7 @@ class LocationService(StripeService):
         """
         return cast(
             Location,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/terminal/locations/{location}".format(
                     location=sanitize_id(location),
@@ -190,7 +190,7 @@ class LocationService(StripeService):
         """
         return cast(
             Location,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/terminal/locations/{location}".format(
                     location=sanitize_id(location),
@@ -212,7 +212,7 @@ class LocationService(StripeService):
         """
         return cast(
             ListObject[Location],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/terminal/locations",
                 api_mode="V1",
@@ -233,7 +233,7 @@ class LocationService(StripeService):
         """
         return cast(
             Location,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/terminal/locations",
                 api_mode="V1",

--- a/stripe/terminal/_reader_service.py
+++ b/stripe/terminal/_reader_service.py
@@ -241,7 +241,7 @@ class ReaderService(StripeService):
         """
         return cast(
             Reader,
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/terminal/readers/{reader}".format(
                     reader=sanitize_id(reader),
@@ -264,7 +264,7 @@ class ReaderService(StripeService):
         """
         return cast(
             Reader,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/terminal/readers/{reader}".format(
                     reader=sanitize_id(reader),
@@ -287,7 +287,7 @@ class ReaderService(StripeService):
         """
         return cast(
             Reader,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/terminal/readers/{reader}".format(
                     reader=sanitize_id(reader),
@@ -309,7 +309,7 @@ class ReaderService(StripeService):
         """
         return cast(
             ListObject[Reader],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/terminal/readers",
                 api_mode="V1",
@@ -329,7 +329,7 @@ class ReaderService(StripeService):
         """
         return cast(
             Reader,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/terminal/readers",
                 api_mode="V1",
@@ -350,7 +350,7 @@ class ReaderService(StripeService):
         """
         return cast(
             Reader,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/terminal/readers/{reader}/cancel_action".format(
                     reader=sanitize_id(reader),
@@ -373,7 +373,7 @@ class ReaderService(StripeService):
         """
         return cast(
             Reader,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/terminal/readers/{reader}/process_payment_intent".format(
                     reader=sanitize_id(reader),
@@ -396,7 +396,7 @@ class ReaderService(StripeService):
         """
         return cast(
             Reader,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/terminal/readers/{reader}/process_setup_intent".format(
                     reader=sanitize_id(reader),
@@ -419,7 +419,7 @@ class ReaderService(StripeService):
         """
         return cast(
             Reader,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/terminal/readers/{reader}/refund_payment".format(
                     reader=sanitize_id(reader),
@@ -442,7 +442,7 @@ class ReaderService(StripeService):
         """
         return cast(
             Reader,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/terminal/readers/{reader}/set_reader_display".format(
                     reader=sanitize_id(reader),

--- a/stripe/test_helpers/_customer_service.py
+++ b/stripe/test_helpers/_customer_service.py
@@ -40,7 +40,7 @@ class CustomerService(StripeService):
         """
         return cast(
             CustomerCashBalanceTransaction,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/customers/{customer}/fund_cash_balance".format(
                     customer=sanitize_id(customer),

--- a/stripe/test_helpers/_refund_service.py
+++ b/stripe/test_helpers/_refund_service.py
@@ -26,7 +26,7 @@ class RefundService(StripeService):
         """
         return cast(
             Refund,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/refunds/{refund}/expire".format(
                     refund=sanitize_id(refund),

--- a/stripe/test_helpers/_test_clock_service.py
+++ b/stripe/test_helpers/_test_clock_service.py
@@ -72,7 +72,7 @@ class TestClockService(StripeService):
         """
         return cast(
             TestClock,
-            self._requestor.request(
+            self._request(
                 "delete",
                 "/v1/test_helpers/test_clocks/{test_clock}".format(
                     test_clock=sanitize_id(test_clock),
@@ -95,7 +95,7 @@ class TestClockService(StripeService):
         """
         return cast(
             TestClock,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/test_helpers/test_clocks/{test_clock}".format(
                     test_clock=sanitize_id(test_clock),
@@ -117,7 +117,7 @@ class TestClockService(StripeService):
         """
         return cast(
             ListObject[TestClock],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/test_helpers/test_clocks",
                 api_mode="V1",
@@ -137,7 +137,7 @@ class TestClockService(StripeService):
         """
         return cast(
             TestClock,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/test_clocks",
                 api_mode="V1",
@@ -158,7 +158,7 @@ class TestClockService(StripeService):
         """
         return cast(
             TestClock,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/test_clocks/{test_clock}/advance".format(
                     test_clock=sanitize_id(test_clock),

--- a/stripe/test_helpers/issuing/_authorization_service.py
+++ b/stripe/test_helpers/issuing/_authorization_service.py
@@ -355,7 +355,7 @@ class AuthorizationService(StripeService):
         """
         return cast(
             Authorization,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/issuing/authorizations",
                 api_mode="V1",
@@ -376,7 +376,7 @@ class AuthorizationService(StripeService):
         """
         return cast(
             Authorization,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/issuing/authorizations/{authorization}/capture".format(
                     authorization=sanitize_id(authorization),
@@ -399,7 +399,7 @@ class AuthorizationService(StripeService):
         """
         return cast(
             Authorization,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/issuing/authorizations/{authorization}/expire".format(
                     authorization=sanitize_id(authorization),
@@ -422,7 +422,7 @@ class AuthorizationService(StripeService):
         """
         return cast(
             Authorization,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/issuing/authorizations/{authorization}/increment".format(
                     authorization=sanitize_id(authorization),
@@ -445,7 +445,7 @@ class AuthorizationService(StripeService):
         """
         return cast(
             Authorization,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/issuing/authorizations/{authorization}/reverse".format(
                     authorization=sanitize_id(authorization),

--- a/stripe/test_helpers/issuing/_card_service.py
+++ b/stripe/test_helpers/issuing/_card_service.py
@@ -44,7 +44,7 @@ class CardService(StripeService):
         """
         return cast(
             Card,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/issuing/cards/{card}/shipping/deliver".format(
                     card=sanitize_id(card),
@@ -67,7 +67,7 @@ class CardService(StripeService):
         """
         return cast(
             Card,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/issuing/cards/{card}/shipping/fail".format(
                     card=sanitize_id(card),
@@ -90,7 +90,7 @@ class CardService(StripeService):
         """
         return cast(
             Card,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/issuing/cards/{card}/shipping/return".format(
                     card=sanitize_id(card),
@@ -113,7 +113,7 @@ class CardService(StripeService):
         """
         return cast(
             Card,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/issuing/cards/{card}/shipping/ship".format(
                     card=sanitize_id(card),

--- a/stripe/test_helpers/issuing/_transaction_service.py
+++ b/stripe/test_helpers/issuing/_transaction_service.py
@@ -402,7 +402,7 @@ class TransactionService(StripeService):
         """
         return cast(
             Transaction,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/issuing/transactions/{transaction}/refund".format(
                     transaction=sanitize_id(transaction),
@@ -424,7 +424,7 @@ class TransactionService(StripeService):
         """
         return cast(
             Transaction,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/issuing/transactions/create_force_capture",
                 api_mode="V1",
@@ -444,7 +444,7 @@ class TransactionService(StripeService):
         """
         return cast(
             Transaction,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/issuing/transactions/create_unlinked_refund",
                 api_mode="V1",

--- a/stripe/test_helpers/terminal/_reader_service.py
+++ b/stripe/test_helpers/terminal/_reader_service.py
@@ -58,7 +58,7 @@ class ReaderService(StripeService):
         """
         return cast(
             Reader,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/terminal/readers/{reader}/present_payment_method".format(
                     reader=sanitize_id(reader),

--- a/stripe/test_helpers/treasury/_inbound_transfer_service.py
+++ b/stripe/test_helpers/treasury/_inbound_transfer_service.py
@@ -52,7 +52,7 @@ class InboundTransferService(StripeService):
         """
         return cast(
             InboundTransfer,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/treasury/inbound_transfers/{id}/fail".format(
                     id=sanitize_id(id),
@@ -75,7 +75,7 @@ class InboundTransferService(StripeService):
         """
         return cast(
             InboundTransfer,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/treasury/inbound_transfers/{id}/return".format(
                     id=sanitize_id(id),
@@ -98,7 +98,7 @@ class InboundTransferService(StripeService):
         """
         return cast(
             InboundTransfer,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/treasury/inbound_transfers/{id}/succeed".format(
                     id=sanitize_id(id),

--- a/stripe/test_helpers/treasury/_outbound_payment_service.py
+++ b/stripe/test_helpers/treasury/_outbound_payment_service.py
@@ -52,7 +52,7 @@ class OutboundPaymentService(StripeService):
         """
         return cast(
             OutboundPayment,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/treasury/outbound_payments/{id}/fail".format(
                     id=sanitize_id(id),
@@ -75,7 +75,7 @@ class OutboundPaymentService(StripeService):
         """
         return cast(
             OutboundPayment,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/treasury/outbound_payments/{id}/post".format(
                     id=sanitize_id(id),
@@ -98,7 +98,7 @@ class OutboundPaymentService(StripeService):
         """
         return cast(
             OutboundPayment,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/treasury/outbound_payments/{id}/return".format(
                     id=sanitize_id(id),

--- a/stripe/test_helpers/treasury/_outbound_transfer_service.py
+++ b/stripe/test_helpers/treasury/_outbound_transfer_service.py
@@ -52,7 +52,7 @@ class OutboundTransferService(StripeService):
         """
         return cast(
             OutboundTransfer,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/fail".format(
                     outbound_transfer=sanitize_id(outbound_transfer),
@@ -75,7 +75,7 @@ class OutboundTransferService(StripeService):
         """
         return cast(
             OutboundTransfer,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/post".format(
                     outbound_transfer=sanitize_id(outbound_transfer),
@@ -98,7 +98,7 @@ class OutboundTransferService(StripeService):
         """
         return cast(
             OutboundTransfer,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/return".format(
                     outbound_transfer=sanitize_id(outbound_transfer),

--- a/stripe/test_helpers/treasury/_received_credit_service.py
+++ b/stripe/test_helpers/treasury/_received_credit_service.py
@@ -76,7 +76,7 @@ class ReceivedCreditService(StripeService):
         """
         return cast(
             ReceivedCredit,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/treasury/received_credits",
                 api_mode="V1",

--- a/stripe/test_helpers/treasury/_received_debit_service.py
+++ b/stripe/test_helpers/treasury/_received_debit_service.py
@@ -76,7 +76,7 @@ class ReceivedDebitService(StripeService):
         """
         return cast(
             ReceivedDebit,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/test_helpers/treasury/received_debits",
                 api_mode="V1",

--- a/stripe/treasury/_credit_reversal_service.py
+++ b/stripe/treasury/_credit_reversal_service.py
@@ -70,7 +70,7 @@ class CreditReversalService(StripeService):
         """
         return cast(
             ListObject[CreditReversal],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/treasury/credit_reversals",
                 api_mode="V1",
@@ -90,7 +90,7 @@ class CreditReversalService(StripeService):
         """
         return cast(
             CreditReversal,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/treasury/credit_reversals",
                 api_mode="V1",
@@ -111,7 +111,7 @@ class CreditReversalService(StripeService):
         """
         return cast(
             CreditReversal,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/treasury/credit_reversals/{credit_reversal}".format(
                     credit_reversal=sanitize_id(credit_reversal),

--- a/stripe/treasury/_debit_reversal_service.py
+++ b/stripe/treasury/_debit_reversal_service.py
@@ -74,7 +74,7 @@ class DebitReversalService(StripeService):
         """
         return cast(
             ListObject[DebitReversal],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/treasury/debit_reversals",
                 api_mode="V1",
@@ -94,7 +94,7 @@ class DebitReversalService(StripeService):
         """
         return cast(
             DebitReversal,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/treasury/debit_reversals",
                 api_mode="V1",
@@ -115,7 +115,7 @@ class DebitReversalService(StripeService):
         """
         return cast(
             DebitReversal,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/treasury/debit_reversals/{debit_reversal}".format(
                     debit_reversal=sanitize_id(debit_reversal),

--- a/stripe/treasury/_financial_account_features_service.py
+++ b/stripe/treasury/_financial_account_features_service.py
@@ -174,7 +174,7 @@ class FinancialAccountFeaturesService(StripeService):
         """
         return cast(
             FinancialAccountFeatures,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/treasury/financial_accounts/{financial_account}/features".format(
                     financial_account=sanitize_id(financial_account),
@@ -197,7 +197,7 @@ class FinancialAccountFeaturesService(StripeService):
         """
         return cast(
             FinancialAccountFeatures,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/treasury/financial_accounts/{financial_account}/features".format(
                     financial_account=sanitize_id(financial_account),

--- a/stripe/treasury/_financial_account_service.py
+++ b/stripe/treasury/_financial_account_service.py
@@ -418,7 +418,7 @@ class FinancialAccountService(StripeService):
         """
         return cast(
             ListObject[FinancialAccount],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/treasury/financial_accounts",
                 api_mode="V1",
@@ -438,7 +438,7 @@ class FinancialAccountService(StripeService):
         """
         return cast(
             FinancialAccount,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/treasury/financial_accounts",
                 api_mode="V1",
@@ -459,7 +459,7 @@ class FinancialAccountService(StripeService):
         """
         return cast(
             FinancialAccount,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/treasury/financial_accounts/{financial_account}".format(
                     financial_account=sanitize_id(financial_account),
@@ -482,7 +482,7 @@ class FinancialAccountService(StripeService):
         """
         return cast(
             FinancialAccount,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/treasury/financial_accounts/{financial_account}".format(
                     financial_account=sanitize_id(financial_account),

--- a/stripe/treasury/_inbound_transfer_service.py
+++ b/stripe/treasury/_inbound_transfer_service.py
@@ -94,7 +94,7 @@ class InboundTransferService(StripeService):
         """
         return cast(
             ListObject[InboundTransfer],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/treasury/inbound_transfers",
                 api_mode="V1",
@@ -114,7 +114,7 @@ class InboundTransferService(StripeService):
         """
         return cast(
             InboundTransfer,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/treasury/inbound_transfers",
                 api_mode="V1",
@@ -135,7 +135,7 @@ class InboundTransferService(StripeService):
         """
         return cast(
             InboundTransfer,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/treasury/inbound_transfers/{id}".format(
                     id=sanitize_id(id),
@@ -158,7 +158,7 @@ class InboundTransferService(StripeService):
         """
         return cast(
             InboundTransfer,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/treasury/inbound_transfers/{inbound_transfer}/cancel".format(
                     inbound_transfer=sanitize_id(inbound_transfer),

--- a/stripe/treasury/_outbound_payment_service.py
+++ b/stripe/treasury/_outbound_payment_service.py
@@ -240,7 +240,7 @@ class OutboundPaymentService(StripeService):
         """
         return cast(
             ListObject[OutboundPayment],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/treasury/outbound_payments",
                 api_mode="V1",
@@ -260,7 +260,7 @@ class OutboundPaymentService(StripeService):
         """
         return cast(
             OutboundPayment,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/treasury/outbound_payments",
                 api_mode="V1",
@@ -281,7 +281,7 @@ class OutboundPaymentService(StripeService):
         """
         return cast(
             OutboundPayment,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/treasury/outbound_payments/{id}".format(
                     id=sanitize_id(id),
@@ -304,7 +304,7 @@ class OutboundPaymentService(StripeService):
         """
         return cast(
             OutboundPayment,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/treasury/outbound_payments/{id}/cancel".format(
                     id=sanitize_id(id),

--- a/stripe/treasury/_outbound_transfer_service.py
+++ b/stripe/treasury/_outbound_transfer_service.py
@@ -114,7 +114,7 @@ class OutboundTransferService(StripeService):
         """
         return cast(
             ListObject[OutboundTransfer],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/treasury/outbound_transfers",
                 api_mode="V1",
@@ -134,7 +134,7 @@ class OutboundTransferService(StripeService):
         """
         return cast(
             OutboundTransfer,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/treasury/outbound_transfers",
                 api_mode="V1",
@@ -155,7 +155,7 @@ class OutboundTransferService(StripeService):
         """
         return cast(
             OutboundTransfer,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/treasury/outbound_transfers/{outbound_transfer}".format(
                     outbound_transfer=sanitize_id(outbound_transfer),
@@ -178,7 +178,7 @@ class OutboundTransferService(StripeService):
         """
         return cast(
             OutboundTransfer,
-            self._requestor.request(
+            self._request(
                 "post",
                 "/v1/treasury/outbound_transfers/{outbound_transfer}/cancel".format(
                     outbound_transfer=sanitize_id(outbound_transfer),

--- a/stripe/treasury/_received_credit_service.py
+++ b/stripe/treasury/_received_credit_service.py
@@ -66,7 +66,7 @@ class ReceivedCreditService(StripeService):
         """
         return cast(
             ListObject[ReceivedCredit],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/treasury/received_credits",
                 api_mode="V1",
@@ -87,7 +87,7 @@ class ReceivedCreditService(StripeService):
         """
         return cast(
             ReceivedCredit,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/treasury/received_credits/{id}".format(
                     id=sanitize_id(id)

--- a/stripe/treasury/_received_debit_service.py
+++ b/stripe/treasury/_received_debit_service.py
@@ -52,7 +52,7 @@ class ReceivedDebitService(StripeService):
         """
         return cast(
             ListObject[ReceivedDebit],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/treasury/received_debits",
                 api_mode="V1",
@@ -73,7 +73,7 @@ class ReceivedDebitService(StripeService):
         """
         return cast(
             ReceivedDebit,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/treasury/received_debits/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",

--- a/stripe/treasury/_transaction_entry_service.py
+++ b/stripe/treasury/_transaction_entry_service.py
@@ -96,7 +96,7 @@ class TransactionEntryService(StripeService):
         """
         return cast(
             ListObject[TransactionEntry],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/treasury/transaction_entries",
                 api_mode="V1",
@@ -117,7 +117,7 @@ class TransactionEntryService(StripeService):
         """
         return cast(
             TransactionEntry,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/treasury/transaction_entries/{id}".format(
                     id=sanitize_id(id),

--- a/stripe/treasury/_transaction_service.py
+++ b/stripe/treasury/_transaction_service.py
@@ -107,7 +107,7 @@ class TransactionService(StripeService):
         """
         return cast(
             ListObject[Transaction],
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/treasury/transactions",
                 api_mode="V1",
@@ -128,7 +128,7 @@ class TransactionService(StripeService):
         """
         return cast(
             Transaction,
-            self._requestor.request(
+            self._request(
                 "get",
                 "/v1/treasury/transactions/{id}".format(id=sanitize_id(id)),
                 api_mode="V1",

--- a/tests/test_stripe_client.py
+++ b/tests/test_stripe_client.py
@@ -372,3 +372,34 @@ class TestStripeClient(object):
             api_key="sk_test_123",
             max_network_retries=0,
         )
+
+    def test_stripe_client_sends_usage(
+        self, stripe_mock_stripe_client, http_client_mock
+    ):
+        path = "/v1/customers/cus_xxxxxxxxxxxxx"
+        http_client_mock.stub_request(
+            "get",
+            path=path,
+            rbody='{"id": "cus_xxxxxxxxxxxxx","object": "customer"}',
+            rcode=200,
+            rheaders={},
+        )
+
+        customer = stripe_mock_stripe_client.customers.retrieve(
+            "cus_xxxxxxxxxxxxx"
+        )
+
+        http_client_mock.assert_requested(
+            "get", path=path, usage=["stripe_client"]
+        )
+
+        http_client_mock.stub_request(
+            "delete",
+            path=path,
+            rbody='{"id": "cus_xxxxxxxxxxxxx","object": "customer", "deleted": true}',
+            rcode=200,
+            rheaders={},
+        )
+
+        customer.delete()
+        http_client_mock.assert_requested("delete", path=path, usage=None)


### PR DESCRIPTION
A more disciplined way of ensuring that our "stripe_client" usage is only collected on client / service requests. This way, even if the `APIRequestor` ends up getting reused between client and resource requests, it won't sent the "stripe_client" usage on the resource request (see new test in `tests/test_stripe_client.py`).