### PR TITLE
Introduce `stripe.absent_as_none`

### DIFF
--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -42,6 +42,7 @@ max_network_retries: int = 0
 ca_bundle_path: str = os.path.join(
     os.path.dirname(__file__), "data", "ca-certificates.crt"
 )
+absent_as_none: bool = False
 
 # Set to either 'debug' or 'info', controls console logging
 log: Optional[Literal["debug", "info"]] = None

--- a/stripe/_stripe_object.py
+++ b/stripe/_stripe_object.py
@@ -170,7 +170,8 @@ class StripeObject(Dict[str, Any]):
                 return self[k]
             except KeyError as err:
                 if stripe.absent_as_none:
-                    return None
+                    if k in self.__annotations__:
+                        return None
                 raise AttributeError(*err.args)
 
         def __delattr__(self, k):

--- a/stripe/_stripe_object.py
+++ b/stripe/_stripe_object.py
@@ -169,9 +169,8 @@ class StripeObject(Dict[str, Any]):
                     k = self._field_remappings[k]
                 return self[k]
             except KeyError as err:
-                if stripe.absent_as_none:
-                    if k in self.__annotations__:
-                        return None
+                if stripe.absent_as_none and k in self.__annotations__:
+                    return None
                 raise AttributeError(*err.args)
 
         def __delattr__(self, k):

--- a/stripe/_stripe_object.py
+++ b/stripe/_stripe_object.py
@@ -169,6 +169,8 @@ class StripeObject(Dict[str, Any]):
                     k = self._field_remappings[k]
                 return self[k]
             except KeyError as err:
+                if stripe.absent_as_none:
+                    return None
                 raise AttributeError(*err.args)
 
         def __delattr__(self, k):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,7 @@ def setup_stripe():
         "api_key": stripe.api_key,
         "client_id": stripe.client_id,
         "default_http_client": stripe.default_http_client,
+        "absent_as_none": stripe.absent_as_none,
     }
     http_client = stripe.http_client.new_default_http_client()
     stripe.api_base = MOCK_API_BASE
@@ -72,6 +73,7 @@ def setup_stripe():
     stripe.api_key = MOCK_API_KEY
     stripe.client_id = "ca_123"
     stripe.default_http_client = http_client
+    stripe.absent_as_none = True
     yield
     http_client.close()
     stripe.api_base = orig_attrs["api_base"]
@@ -79,6 +81,7 @@ def setup_stripe():
     stripe.api_key = orig_attrs["api_key"]
     stripe.client_id = orig_attrs["client_id"]
     stripe.default_http_client = orig_attrs["default_http_client"]
+    stripe.absent_as_none = orig_attrs["absent_as_none"]
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,6 @@ def setup_stripe():
     stripe.api_key = MOCK_API_KEY
     stripe.client_id = "ca_123"
     stripe.default_http_client = http_client
-    stripe.absent_as_none = True
     yield
     http_client.close()
     stripe.api_base = orig_attrs["api_base"]

--- a/tests/test_stripe_object.py
+++ b/tests/test_stripe_object.py
@@ -2,14 +2,12 @@ import datetime
 import json
 import pickle
 from copy import copy, deepcopy
-from typing import Any
-from typing_extensions import Optional
+from typing import Any, Optional
 
 import pytest
 
 import stripe
 from stripe._stripe_object import StripeObject
-from stripe import Customer
 
 
 SAMPLE_INVOICE = json.loads(


### PR DESCRIPTION
## Background
Stripe resources have properties that are sometimes *absent*. The way stripe-python handles this is, it gives you an AttributeError if you try and access the property.

Unfortunately, we type these properties with `Optional[...]`, which implies that you can always access the property but it will sometimes be `None`.

We can't type the properties with `NotRequired[...]`, as `NotRequired` only exists for `TypedDict` and Stripe resources are real classes that extend from `StripeObject`.

## Summary
This PR introduces `stripe.absent_as_none`. If you set this to true, then stripe-python will give you `None` when you try and access an absent property, instead of producing an `AttributeError`. Hypothetical way to address the issue in https://github.com/stripe/stripe-python/issues/1227 without a breaking change.

I'm not sure I like this. I don't know how discoverable we could make `stripe.absent_as_none`. We could consider adding a message to the `AttributeError` you get when trying to access an absent property that advertises `stripe.absent_as_none`, but that would only help a little.


