### PR TITLE
Improve types in _http_client.py

### DIFF
--- a/flake8_stripe/flake8_stripe.py
+++ b/flake8_stripe/flake8_stripe.py
@@ -52,7 +52,7 @@ class TypingImportsChecker:
         "Mapping",
         "Tuple",
         "Iterator",
-        "Mapping",
+        "MutableMapping",
         "Set",
         "Callable",
         "Generator",

--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -345,24 +345,27 @@ class _APIRequestor(object):
         if stripe.app_info:
             ua["application"] = stripe.app_info
 
-        headers: Dict[str, Optional[str]] = {
+        headers: Dict[str, str] = {
             "X-Stripe-Client-User-Agent": json.dumps(ua),
             "User-Agent": user_agent,
             "Authorization": "Bearer %s" % (options.get("api_key"),),
         }
 
-        if options.get("stripe_account"):
-            headers["Stripe-Account"] = options.get("stripe_account")
+        stripe_account = options.get("stripe_account")
+        if stripe_account:
+            headers["Stripe-Account"] = stripe_account
 
-        if options.get("idempotency_key"):
-            headers["Idempotency-Key"] = options.get("idempotency_key")
+        idempotency_key = options.get("idempotency_key")
+        if idempotency_key:
+            headers["Idempotency-Key"] = idempotency_key
 
         if method == "post":
             headers.setdefault("Idempotency-Key", str(uuid.uuid4()))
             headers["Content-Type"] = "application/x-www-form-urlencoded"
 
-        if options.get("stripe_version"):
-            headers["Stripe-Version"] = options.get("stripe_version")
+        stripe_version = options.get("stripe_version")
+        if stripe_version:
+            headers["Stripe-Version"] = stripe_version
 
         return headers
 

--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -624,17 +624,34 @@ class UrlFetchClient(HTTPClient):
 
     @overload
     def _request_internal(
-        self, method: str, url: str, headers: Mapping[str, str], post_data, is_streaming: Literal[True]
+        self,
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
+        post_data,
+        is_streaming: Literal[True],
     ) -> Tuple[BytesIO, int, Any]:
         ...
 
     @overload
     def _request_internal(
-        self, method: str, url: str, headers: Mapping[str, str], post_data, is_streaming: Literal[False]
+        self,
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
+        post_data,
+        is_streaming: Literal[False],
     ) -> Tuple[str, int, Any]:
         ...
 
-    def _request_internal(self, method: str, url: str, headers: Mapping[str, str], post_data, is_streaming):
+    def _request_internal(
+        self,
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
+        post_data,
+        is_streaming,
+    ):
         try:
             result = self.urlfetch.fetch(
                 url=url,
@@ -742,13 +759,23 @@ class PycurlClient(HTTPClient):
 
     @overload
     def _request_internal(
-        self, method: str, url: str, headers: Mapping[str, str], post_data, is_streaming: Literal[True]
+        self,
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
+        post_data,
+        is_streaming: Literal[True],
     ) -> Tuple[BytesIO, int, Any]:
         ...
 
     @overload
     def _request_internal(
-        self, method: str, url: str, headers: Mapping[str, str], post_data, is_streaming: Literal[False]
+        self,
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
+        post_data,
+        is_streaming: Literal[False],
     ) -> Tuple[str, int, Mapping[str, str]]:
         ...
 
@@ -908,21 +935,40 @@ class Urllib2Client(HTTPClient):
 
     @overload
     def _request_internal(
-        self, method: str, url: str, headers: Mapping[str, str], post_data, is_streaming: Literal[False]
+        self,
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
+        post_data,
+        is_streaming: Literal[False],
     ) -> Tuple[str, int, Any]:
         ...
 
     @overload
     def _request_internal(
-        self, method: str, url: str, headers: Mapping[str, str], post_data, is_streaming: Literal[True]
+        self,
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
+        post_data,
+        is_streaming: Literal[True],
     ) -> Tuple[HTTPResponse, int, Any]:
         ...
 
-    def _request_internal(self, method: str, url: str, headers: Mapping[str, str], post_data, is_streaming):
+    def _request_internal(
+        self,
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
+        post_data,
+        is_streaming,
+    ):
         if isinstance(post_data, str):
             post_data = post_data.encode("utf-8")
 
-        req = urllibrequest.Request(url, post_data, cast(MutableMapping[str, str], headers))
+        req = urllibrequest.Request(
+            url, post_data, cast(MutableMapping[str, str], headers)
+        )
 
         if method not in ("get", "post"):
             req.get_method = lambda: method.upper()

--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -463,7 +463,7 @@ class RequestsClient(HTTPClient):
         headers: Optional[Mapping[str, str]],
         post_data,
         is_streaming: bool,
-    ) -> Tuple[bytes | Any, int, Mapping[str, str]]:
+    ) -> Tuple[Union[bytes, Any], int, Mapping[str, str]]:
         kwargs = {}
         if self._verify_ssl_certs:
             kwargs["verify"] = stripe.ca_bundle_path
@@ -758,7 +758,7 @@ class PycurlClient(HTTPClient):
         headers: Mapping[str, str],
         post_data,
         is_streaming,
-    ) -> Tuple[str | BytesIO, int, Mapping[str, str]]:
+    ) -> Tuple[Union[str, BytesIO], int, Mapping[str, str]]:
         b = _util.io.BytesIO()
         rheaders = _util.io.BytesIO()
 

--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -19,6 +19,7 @@ from typing import (
     Dict,
     List,
     Mapping,
+    MutableMapping,
     Optional,
     Tuple,
     ClassVar,
@@ -608,14 +609,14 @@ class UrlFetchClient(HTTPClient):
         self.urlfetch = urlfetch
 
     def request(
-        self, method, url, headers, post_data=None
+        self, method: str, url: str, headers: Mapping[str, str], post_data=None
     ) -> Tuple[str, int, Mapping[str, str]]:
         return self._request_internal(
             method, url, headers, post_data, is_streaming=False
         )
 
     def request_stream(
-        self, method, url, headers, post_data=None
+        self, method: str, url: str, headers: Mapping[str, str], post_data=None
     ) -> Tuple[BytesIO, int, Mapping[str, str]]:
         return self._request_internal(
             method, url, headers, post_data, is_streaming=True
@@ -623,17 +624,17 @@ class UrlFetchClient(HTTPClient):
 
     @overload
     def _request_internal(
-        self, method, url, headers, post_data, is_streaming: Literal[True]
+        self, method: str, url: str, headers: Mapping[str, str], post_data, is_streaming: Literal[True]
     ) -> Tuple[BytesIO, int, Any]:
         ...
 
     @overload
     def _request_internal(
-        self, method, url, headers, post_data, is_streaming: Literal[False]
+        self, method: str, url: str, headers: Mapping[str, str], post_data, is_streaming: Literal[False]
     ) -> Tuple[str, int, Any]:
         ...
 
-    def _request_internal(self, method, url, headers, post_data, is_streaming):
+    def _request_internal(self, method: str, url: str, headers: Mapping[str, str], post_data, is_streaming):
         try:
             result = self.urlfetch.fetch(
                 url=url,
@@ -726,14 +727,14 @@ class PycurlClient(HTTPClient):
         return dict((k.lower(), v) for k, v in dict(headers).items())
 
     def request(
-        self, method, url, headers, post_data=None
+        self, method, url, headers: Mapping[str, str], post_data=None
     ) -> Tuple[str, int, Mapping[str, str]]:
         return self._request_internal(
             method, url, headers, post_data, is_streaming=False
         )
 
     def request_stream(
-        self, method, url, headers, post_data=None
+        self, method, url, headers: Mapping[str, str], post_data=None
     ) -> Tuple[BytesIO, int, Mapping[str, str]]:
         return self._request_internal(
             method, url, headers, post_data, is_streaming=True
@@ -741,13 +742,13 @@ class PycurlClient(HTTPClient):
 
     @overload
     def _request_internal(
-        self, method, url, headers, post_data, is_streaming: Literal[True]
+        self, method: str, url: str, headers: Mapping[str, str], post_data, is_streaming: Literal[True]
     ) -> Tuple[BytesIO, int, Any]:
         ...
 
     @overload
     def _request_internal(
-        self, method, url, headers, post_data, is_streaming: Literal[False]
+        self, method: str, url: str, headers: Mapping[str, str], post_data, is_streaming: Literal[False]
     ) -> Tuple[str, int, Mapping[str, str]]:
         ...
 
@@ -892,14 +893,14 @@ class Urllib2Client(HTTPClient):
             self._opener = urllibrequest.build_opener(proxy_handler)
 
     def request(
-        self, method, url, headers, post_data=None
+        self, method: str, url: str, headers: Mapping[str, str], post_data=None
     ) -> Tuple[str, int, Mapping[str, str]]:
         return self._request_internal(
             method, url, headers, post_data, is_streaming=False
         )
 
     def request_stream(
-        self, method, url, headers, post_data=None
+        self, method: str, url: str, headers: Mapping[str, str], post_data=None
     ) -> Tuple[HTTPResponse, int, Mapping[str, str]]:
         return self._request_internal(
             method, url, headers, post_data, is_streaming=True
@@ -907,21 +908,21 @@ class Urllib2Client(HTTPClient):
 
     @overload
     def _request_internal(
-        self, method, url, headers, post_data, is_streaming: Literal[False]
+        self, method: str, url: str, headers: Mapping[str, str], post_data, is_streaming: Literal[False]
     ) -> Tuple[str, int, Any]:
         ...
 
     @overload
     def _request_internal(
-        self, method, url, headers, post_data, is_streaming: Literal[True]
+        self, method: str, url: str, headers: Mapping[str, str], post_data, is_streaming: Literal[True]
     ) -> Tuple[HTTPResponse, int, Any]:
         ...
 
-    def _request_internal(self, method, url, headers, post_data, is_streaming):
+    def _request_internal(self, method: str, url: str, headers: Mapping[str, str], post_data, is_streaming):
         if isinstance(post_data, str):
             post_data = post_data.encode("utf-8")
 
-        req = urllibrequest.Request(url, post_data, headers)
+        req = urllibrequest.Request(url, post_data, cast(MutableMapping[str, str], headers))
 
         if method not in ("get", "post"):
             req.get_method = lambda: method.upper()


### PR DESCRIPTION
Adds more type annotations to `_http_client.py`.

Mostly just making types narrower / describe what exists. I was really hoping to be able to make the type for streaming endpoints more specific than `Any` but, because `stripe.default_http_client` can change dynamically, you really can't do much better.