### PR TITLE
Beta: async streaming

### DIFF
--- a/flake8_stripe/flake8_stripe.py
+++ b/flake8_stripe/flake8_stripe.py
@@ -40,6 +40,7 @@ class TypingImportsChecker:
     allowed_typing_imports = [
         "Any",
         "AsyncIterator",
+        "AsyncIterable",
         "ClassVar",
         "Optional",
         "TypeVar",

--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -141,6 +141,7 @@ from stripe._stripe_response import StripeResponse as StripeResponse
 from stripe._stripe_response import StripeResponseBase as StripeResponseBase
 from stripe._stripe_response import (
     StripeStreamResponse as StripeStreamResponse,
+    StripeStreamResponseAsync as StripeStreamResponseAsync,
 )
 
 # Error types

--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -298,8 +298,6 @@ class _APIRequestor(object):
             _usage=_usage,
         )
         resp = await self._interpret_streaming_response_async(
-            # TODO: should be able to remove this cast once self._client.request_stream_with_retries
-            # returns a more specific type.
             stream,
             rcode,
             rheaders,

--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -276,7 +276,7 @@ class _APIRequestor(object):
         )
         return resp
 
-    async def request_stream_async(
+    async def _request_stream_async(
         self,
         method: str,
         url: str,

--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -276,7 +276,7 @@ class _APIRequestor(object):
         )
         return resp
 
-    async def _request_stream_async(
+    async def request_stream_async(
         self,
         method: str,
         url: str,

--- a/stripe/_api_resource.py
+++ b/stripe/_api_resource.py
@@ -234,7 +234,7 @@ class APIResource(StripeObject, Generic[T]):
         api_mode: ApiMode = "V1",
     ):
         request_options, request_params = extract_options_from_dict(params)
-        return await _APIRequestor._global_instance().request_stream_async(
+        return await _APIRequestor._global_instance()._request_stream_async(
             method,
             url,
             params=request_params,

--- a/stripe/_api_resource.py
+++ b/stripe/_api_resource.py
@@ -234,7 +234,7 @@ class APIResource(StripeObject, Generic[T]):
         api_mode: ApiMode = "V1",
     ):
         request_options, request_params = extract_options_from_dict(params)
-        return await _APIRequestor._global_instance()._request_stream_async(
+        return await _APIRequestor._global_instance().request_stream_async(
             method,
             url,
             params=request_params,

--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -26,6 +26,7 @@ from typing import (
     Union,
     cast,
     overload,
+    AsyncIterable,
 )
 from typing_extensions import (
     Literal,
@@ -418,11 +419,11 @@ class HTTPClient(HTTPClientBase):
 class HTTPClientAsync(HTTPClientBase):
     async def request_with_retries_async(
         self,
-        method,
-        url,
-        headers,
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
         post_data=None,
-        max_network_retries=None,
+        max_network_retries: Optional[int] = None,
         *,
         _usage: Optional[List[str]] = None
     ) -> Tuple[Any, int, Any]:
@@ -438,14 +439,14 @@ class HTTPClientAsync(HTTPClientBase):
 
     async def request_stream_with_retries_async(
         self,
-        method,
-        url,
-        headers,
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
         post_data=None,
         max_network_retries=None,
         *,
         _usage: Optional[List[str]] = None
-    ) -> Tuple[Any, int, Any]:
+    ) -> Tuple[AsyncIterable[bytes], int, Any]:
         return await self._request_with_retries_internal_async(
             method,
             url,
@@ -462,17 +463,45 @@ class HTTPClientAsync(HTTPClientBase):
             "HTTPClientAsync subclasses must implement `sleep`"
         )
 
+    @overload
     async def _request_with_retries_internal_async(
         self,
-        method,
-        url,
-        headers,
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
         post_data,
-        is_streaming,
-        max_network_retries,
+        is_streaming: Literal[False],
+        max_network_retries: Optional[int],
         *,
-        _usage=None
-    ):
+        _usage: Optional[List[str]] = None
+    ) -> Tuple[Any, int, Mapping[str, str]]:
+        ...
+
+    @overload
+    async def _request_with_retries_internal_async(
+        self,
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
+        post_data,
+        is_streaming: Literal[True],
+        max_network_retries: Optional[int],
+        *,
+        _usage: Optional[List[str]] = None
+    ) -> Tuple[AsyncIterable[bytes], int, Mapping[str, str]]:
+        ...
+
+    async def _request_with_retries_internal_async(
+        self,
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
+        post_data,
+        is_streaming: bool,
+        max_network_retries: Optional[int],
+        *,
+        _usage: Optional[List[str]] = None
+    ) -> Tuple[Any, int, Mapping[str, str]]:
         self._add_telemetry_header(headers)
 
         num_retries = 0
@@ -523,14 +552,18 @@ class HTTPClientAsync(HTTPClientBase):
                     assert connection_error is not None
                     raise connection_error
 
-    async def request_async(self, method, url, headers, post_data=None):
+    async def request_async(
+        self, method: str, url: str, headers: Mapping[str, str], post_data=None
+    ) -> Tuple[bytes, int, Mapping[str, str]]:
         raise NotImplementedError(
-            "HTTPClientAsync subclasses must implement `request`"
+            "HTTPClientAsync subclasses must implement `request_async`"
         )
 
-    async def request_stream_async(self, method, url, headers, post_data=None):
+    async def request_stream_async(
+        self, method: str, url: str, headers: Mapping[str, str], post_data=None
+    ) -> Tuple[AsyncIterable[bytes], int, Mapping[str, str]]:
         raise NotImplementedError(
-            "HTTPClientAsync subclasses must implement `request_stream`"
+            "HTTPClientAsync subclasses must implement `request_stream_async`"
         )
 
     async def close_async(self):
@@ -1189,7 +1222,9 @@ class HTTPXClient(HTTPClientAsync):
     def sleep_async(self, secs):
         return self.anyio.sleep(secs)
 
-    def _get_request_args_kwargs(self, method, url, headers, post_data):
+    def _get_request_args_kwargs(
+        self, method: str, url: str, headers: Mapping[str, str], post_data
+    ):
         kwargs = {}
 
         if self._proxy:
@@ -1203,7 +1238,12 @@ class HTTPXClient(HTTPClientAsync):
         ]
 
     async def request_async(
-        self, method, url, headers, post_data=None, timeout=80.0
+        self,
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
+        post_data=None,
+        timeout: float = 80.0,
     ) -> Tuple[bytes, int, Mapping[str, str]]:
         args, kwargs = self._get_request_args_kwargs(
             method, url, headers, post_data
@@ -1229,7 +1269,9 @@ class HTTPXClient(HTTPClientAsync):
         msg = textwrap.fill(msg) + "\n\n(Network error: %s)" % (err,)
         raise APIConnectionError(msg, should_retry=should_retry)
 
-    async def request_stream_async(self, method, url, headers, post_data=None):
+    async def request_stream_async(
+        self, method: str, url: str, headers: Mapping[str, str], post_data=None
+    ) -> Tuple[AsyncIterable[bytes], int, Mapping[str, str]]:
         args, kwargs = self._get_request_args_kwargs(
             method, url, headers, post_data
         )
@@ -1266,11 +1308,13 @@ class NoImportFoundAsyncClient(HTTPClientAsync):
         )
 
     async def request_async(
-        self, method, url, headers, post_data=None
+        self, method: str, url: str, headers: Mapping[str, str], post_data=None
     ) -> Tuple[bytes, int, Mapping[str, str]]:
         self.raise_async_client_import_error()
 
-    async def request_stream_async(self, method, url, headers, post_data=None):
+    async def request_stream_async(
+        self, method: str, url: str, headers: Mapping[str, str], post_data=None
+    ):
         self.raise_async_client_import_error()
 
     async def close_async(self):

--- a/stripe/_quote.py
+++ b/stripe/_quote.py
@@ -7,6 +7,7 @@ from stripe._listable_api_resource import ListableAPIResource
 from stripe._nested_resource_class_methods import nested_resource_class_methods
 from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
+from stripe._stripe_response import StripeStreamResponseAsync
 from stripe._updateable_api_resource import UpdateableAPIResource
 from stripe._util import class_method_variant, sanitize_id
 from typing import Any, ClassVar, Dict, List, Optional, cast, overload
@@ -4992,14 +4993,14 @@ class Quote(
     @staticmethod
     async def pdf_async(
         quote: str, **params: Unpack["Quote.PdfParams"]
-    ) -> Any:
+    ) -> StripeStreamResponseAsync:
         """
         Download the PDF for a finalized quote
         """
         ...
 
     @overload
-    async def pdf_async(self, **params: Unpack["Quote.PdfParams"]) -> Any:
+    async def pdf_async(self, **params: Unpack["Quote.PdfParams"]) -> StripeStreamResponseAsync:
         """
         Download the PDF for a finalized quote
         """
@@ -5008,19 +5009,16 @@ class Quote(
     @class_method_variant("_cls_pdf_async")
     async def pdf_async(  # pyright: ignore[reportGeneralTypeIssues]
         self, **params: Unpack["Quote.PdfParams"]
-    ) -> Any:
+    ) -> StripeStreamResponseAsync:
         """
         Download the PDF for a finalized quote
         """
-        return cast(
-            Any,
-            await self._request_stream_async(
-                "get",
-                "/v1/quotes/{quote}/pdf".format(
-                    quote=sanitize_id(self.get("id"))
-                ),
-                params=params,
+        return await self._request_stream_async(
+            "get",
+            "/v1/quotes/{quote}/pdf".format(
+                quote=sanitize_id(self.get("id"))
             ),
+            params=params,
         )
 
     @classmethod

--- a/stripe/_quote.py
+++ b/stripe/_quote.py
@@ -5000,7 +5000,9 @@ class Quote(
         ...
 
     @overload
-    async def pdf_async(self, **params: Unpack["Quote.PdfParams"]) -> StripeStreamResponseAsync:
+    async def pdf_async(
+        self, **params: Unpack["Quote.PdfParams"]
+    ) -> StripeStreamResponseAsync:
         """
         Download the PDF for a finalized quote
         """
@@ -5015,9 +5017,7 @@ class Quote(
         """
         return await self._request_stream_async(
             "get",
-            "/v1/quotes/{quote}/pdf".format(
-                quote=sanitize_id(self.get("id"))
-            ),
+            "/v1/quotes/{quote}/pdf".format(quote=sanitize_id(self.get("id"))),
             params=params,
         )
 

--- a/stripe/_stripe_object.py
+++ b/stripe/_stripe_object.py
@@ -480,7 +480,7 @@ class StripeObject(Dict[str, Any]):
             params = self._retrieve_params
 
         request_options, request_params = extract_options_from_dict(params)
-        return await self._requestor._request_stream_async(  # pyright: ignore[reportPrivateUsage]
+        return await self._requestor.request_stream_async(
             method,
             url,
             params=request_params,

--- a/stripe/_stripe_object.py
+++ b/stripe/_stripe_object.py
@@ -21,7 +21,11 @@ from typing import (
 import stripe  # noqa: IMP101
 from stripe import _util
 
-from stripe._stripe_response import StripeResponse, StripeStreamResponse
+from stripe._stripe_response import (
+    StripeResponse,
+    StripeStreamResponse,
+    StripeStreamResponseAsync,
+)
 from stripe._encode import _encode_datetime  # pyright: ignore
 from stripe._request_options import extract_options_from_dict
 from stripe._api_mode import ApiMode
@@ -471,7 +475,7 @@ class StripeObject(Dict[str, Any]):
         *,
         base_address: BaseAddress = "api",
         api_mode: ApiMode = "V1",
-    ) -> StripeStreamResponse:
+    ) -> StripeStreamResponseAsync:
         if params is None:
             params = self._retrieve_params
 

--- a/stripe/_stripe_object.py
+++ b/stripe/_stripe_object.py
@@ -480,7 +480,7 @@ class StripeObject(Dict[str, Any]):
             params = self._retrieve_params
 
         request_options, request_params = extract_options_from_dict(params)
-        return await self._requestor.request_stream_async(
+        return await self._requestor._request_stream_async(  # pyright: ignore[reportPrivateUsage]
             method,
             url,
             params=request_params,

--- a/stripe/_stripe_response.py
+++ b/stripe/_stripe_response.py
@@ -2,7 +2,7 @@
 from io import IOBase
 import json
 from collections import OrderedDict
-from typing import Mapping, Optional
+from typing import Mapping, Optional, AsyncIterable
 
 
 class StripeResponseBase(object):
@@ -44,3 +44,19 @@ class StripeStreamResponse(StripeResponseBase):
     def __init__(self, io: IOBase, code: int, headers: Mapping[str, str]):
         StripeResponseBase.__init__(self, code, headers)
         self.io = io
+
+
+class StripeStreamResponseAsync(StripeResponseBase):
+    _stream: AsyncIterable[bytes]
+
+    def __init__(
+        self,
+        stream: AsyncIterable[bytes],
+        code: int,
+        headers: Mapping[str, str],
+    ):
+        StripeResponseBase.__init__(self, code, headers)
+        self._stream = stream
+
+    def stream(self) -> AsyncIterable[bytes]:
+        return self._stream

--- a/stripe/_stripe_service.py
+++ b/stripe/_stripe_service.py
@@ -89,7 +89,7 @@ class StripeService(object):
         base_address: BaseAddress,
         api_mode: ApiMode,
     ) -> StripeStreamResponseAsync:
-        return await self._requestor.request_stream_async(
+        return await self._requestor._request_stream_async(
             method,
             url,
             params,

--- a/stripe/_stripe_service.py
+++ b/stripe/_stripe_service.py
@@ -89,7 +89,7 @@ class StripeService(object):
         base_address: BaseAddress,
         api_mode: ApiMode,
     ) -> StripeStreamResponseAsync:
-        return await self._requestor._request_stream_async(
+        return await self._requestor.request_stream_async(
             method,
             url,
             params,

--- a/stripe/_stripe_service.py
+++ b/stripe/_stripe_service.py
@@ -1,4 +1,10 @@
-from stripe._api_requestor import _APIRequestor, StripeStreamResponse
+from stripe._api_requestor import (
+    _APIRequestor,
+)
+from stripe._stripe_response import (
+    StripeStreamResponse,
+    StripeStreamResponseAsync,
+)
 from stripe._stripe_object import StripeObject
 from stripe._request_options import RequestOptions
 from stripe._base_address import BaseAddress
@@ -82,7 +88,7 @@ class StripeService(object):
         *,
         base_address: BaseAddress,
         api_mode: ApiMode,
-    ) -> StripeStreamResponse:
+    ) -> StripeStreamResponseAsync:
         return await self._requestor.request_stream_async(
             method,
             url,

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -316,7 +316,7 @@ class TestAPIRequestor(object):
                 rcode=200,
             )
 
-            resp = await requestor_streaming._request_stream_async(
+            resp = await requestor_streaming.request_stream_async(
                 meth,
                 self.valid_path,
                 {},

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1088,9 +1088,9 @@ class ClientTestBaseAsync(object):
             method, url, headers, post_data
         )
 
-    def make_request_stream(self, method, url, headers, post_data):
+    async def make_request_stream(self, method, url, headers, post_data):
         client = self.REQUEST_CLIENT(verify_ssl_certs=True)
-        return client.request_stream_with_retries_async(
+        return await client.request_stream_with_retries_async(
             method, url, headers, post_data
         )
 
@@ -1140,7 +1140,7 @@ class TestHTTPXClient(StripeClientTestCase, ClientTestBaseAsync):
 
             async_mock = AsyncMock(side_effect=do)
 
-            request_mock.AsyncClient().request = async_mock
+            request_mock.AsyncClient().send = async_mock
             return result
 
         return mock_response
@@ -1231,8 +1231,39 @@ class TestHTTPXClient(StripeClientTestCase, ClientTestBaseAsync):
     async def test_request_stream(
         self, mocker, request_mock, mock_response, check_call
     ):
-        # TODO
-        pass
+        for method in VALID_API_METHODS:
+            pass
+            # mock_response("some streamed content", 200)
+
+            # abs_url = self.valid_url
+            # data = ""
+
+            # if method != "post":
+            #     abs_url = "%s?%s" % (abs_url, data)
+            #     data = None
+
+            # headers = {"my-header": "header val"}
+
+            # print(dir(self))
+            # print("make_request_stream" in dir(self))
+            # stream, code, _ = await self.make_request_stream_async(
+            #     method, abs_url, headers, data
+            # )
+
+            # assert code == 200
+
+            # import pdb
+
+            # pdb.set_trace()
+            # # Here we need to convert and align all content on one type (string)
+            # # as some clients return a string stream others a byte stream.
+            # body_content = stream.read()
+            # if hasattr(body_content, "decode"):
+            #     body_content = body_content.decode("utf-8")
+
+            # assert body_content == "some streamed content"
+
+            # mocker.resetall()
 
     @pytest.mark.anyio
     async def test_exception(self, request_mock, mock_error):

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1141,6 +1141,7 @@ class TestHTTPXClient(StripeClientTestCase, ClientTestBaseAsync):
             async_mock = AsyncMock(side_effect=do)
 
             request_mock.AsyncClient().send = async_mock
+            request_mock.AsyncClient().request = async_mock
             return result
 
         return mock_response

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -448,7 +448,7 @@ class TestIntegration(object):
 
         chunks = []
         result = await stripe.Quote.pdf_async("qt_123")
-        async for chunk in result.stream:
+        async for chunk in result.stream():
             chunks.append(str(chunk, "utf-8"))
 
         MockServerRequestHandler.get_requests(1)


### PR DESCRIPTION
## Summary
Provides an implementation for `request_stream_async` for `HTTPClientAsync`, so e.g. `await stripe.Quote.pdf_async(...)` will work.

```python
chunks = []
result = await stripe.Quote.pdf_async("qt_123")
async for chunk in result.stream:
    chunks.append(str(chunk, "utf-8"))
```

## Details

* There's a new public type [StripeStreamResponseAsync](https://github.com/stripe/stripe-python/pull/1233/files#diff-0c0a06a2ab83d966f0031559bfbd6de9efa84df9ffc5ebd085ea1db7f555383bR49), which is the async analog of StripeStreamResponse. (This is the type that will be returned to the user when calling `stripe.Quote.pdf_async`). The difference from StripeStreamResponse is that the stream is represented by `stream: AsyncIterable[bytes]` instead of `io: IOBase`. 
  * FYI: `IOBase` implements `Iterable[bytes]` -- so there's more symmetry between `StripeStreamResponse` and `StripeResponse` than appears at first glance.
* APIRequestor has been modified to use/produce it accordingly.
* The return type of `HTTPClientAsync.request_stream_async` is now `Tuple[AsyncIterable[bytes], ...]` and an implementation is provided for HTTPXHttpClient.

I was worried about a resource leak -- inside HTTPXHttpClient it calls `response = httpx.ASyncClient().send(...)` and then takes `content = response.aiter_bytes()` and only returns `content` to the caller. Does `response` get closed properly? I manually tested, and yes, after you do an `async for` through the bytes in `content` the response gets closed automatically.



