### PR TITLE
Remove broken child methods

### DIFF
--- a/stripe/_credit_note_line_item.py
+++ b/stripe/_credit_note_line_item.py
@@ -1,19 +1,16 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 from stripe._expandable_field import ExpandableField
-from stripe._list_object import ListObject
-from stripe._listable_api_resource import ListableAPIResource
-from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
 from typing import ClassVar, List, Optional
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing_extensions import Literal, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe._discount import Discount
     from stripe._tax_rate import TaxRate
 
 
-class CreditNoteLineItem(ListableAPIResource["CreditNoteLineItem"]):
+class CreditNoteLineItem(StripeObject):
     """
     The credit note line item object
     """
@@ -70,24 +67,6 @@ class CreditNoteLineItem(ListableAPIResource["CreditNoteLineItem"]):
         taxable_amount: Optional[int]
         """
         The amount on which tax is calculated, in cents (or local equivalent).
-        """
-
-    class ListParams(RequestOptions):
-        ending_before: NotRequired["str"]
-        """
-        A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-        """
-        expand: NotRequired["List[str]"]
-        """
-        Specifies which fields in the response should be expanded.
-        """
-        limit: NotRequired["int"]
-        """
-        A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
-        """
-        starting_after: NotRequired["str"]
-        """
-        A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
         """
 
     amount: int
@@ -154,28 +133,6 @@ class CreditNoteLineItem(ListableAPIResource["CreditNoteLineItem"]):
     """
     The amount in cents (or local equivalent) representing the unit amount being credited for this line item, excluding all tax and discounts.
     """
-
-    @classmethod
-    def list(
-        cls, **params: Unpack["CreditNoteLineItem.ListParams"]
-    ) -> ListObject["CreditNoteLineItem"]:
-        """
-        When retrieving a credit note, you'll get a lines property containing the the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.
-        """
-        result = cls._static_request(
-            "get",
-            cls.class_url(),
-            params=params,
-        )
-        if not isinstance(result, ListObject):
-
-            raise TypeError(
-                "Expected list object from API, got %s"
-                % (type(result).__name__)
-            )
-
-        return result
-
     _inner_class_types = {
         "discount_amounts": DiscountAmount,
         "tax_amounts": TaxAmount,

--- a/stripe/_customer.py
+++ b/stripe/_customer.py
@@ -2061,26 +2061,6 @@ class Customer(
         )
 
     @classmethod
-    def modify_cash_balance(
-        cls,
-        customer: str,
-        **params: Unpack["Customer.ModifyCashBalanceParams"]
-    ) -> "CashBalance":
-        """
-        Changes the settings on a customer's cash balance.
-        """
-        return cast(
-            "CashBalance",
-            cls._static_request(
-                "post",
-                "/v1/customers/{customer}/cash_balance".format(
-                    customer=sanitize_id(customer)
-                ),
-                params=params,
-            ),
-        )
-
-    @classmethod
     def retrieve_cash_balance(
         cls,
         customer: str,
@@ -2093,6 +2073,26 @@ class Customer(
             "CashBalance",
             cls._static_request(
                 "get",
+                "/v1/customers/{customer}/cash_balance".format(
+                    customer=sanitize_id(customer)
+                ),
+                params=params,
+            ),
+        )
+
+    @classmethod
+    def modify_cash_balance(
+        cls,
+        customer: str,
+        **params: Unpack["Customer.ModifyCashBalanceParams"]
+    ) -> "CashBalance":
+        """
+        Changes the settings on a customer's cash balance.
+        """
+        return cast(
+            "CashBalance",
+            cls._static_request(
+                "post",
                 "/v1/customers/{customer}/cash_balance".format(
                     customer=sanitize_id(customer)
                 ),

--- a/stripe/_customer_cash_balance_transaction.py
+++ b/stripe/_customer_cash_balance_transaction.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 from stripe._expandable_field import ExpandableField
-from stripe._list_object import ListObject
-from stripe._listable_api_resource import ListableAPIResource
-from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
-from typing import ClassVar, List, Optional
-from typing_extensions import Literal, NotRequired, Unpack, TYPE_CHECKING
+from typing import ClassVar, Optional
+from typing_extensions import Literal, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from stripe._balance_transaction import BalanceTransaction
@@ -15,9 +12,7 @@ if TYPE_CHECKING:
     from stripe._refund import Refund
 
 
-class CustomerCashBalanceTransaction(
-    ListableAPIResource["CustomerCashBalanceTransaction"],
-):
+class CustomerCashBalanceTransaction(StripeObject):
     """
     Customers with certain payments enabled have a cash balance, representing funds that were paid
     by the customer to a merchant, but have not yet been allocated to a payment. Cash Balance Transactions
@@ -145,30 +140,6 @@ class CustomerCashBalanceTransaction(
         The [Payment Intent](https://stripe.com/docs/api/payment_intents/object) that funds were unapplied from.
         """
 
-    class ListParams(RequestOptions):
-        ending_before: NotRequired["str"]
-        """
-        A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-        """
-        expand: NotRequired["List[str]"]
-        """
-        Specifies which fields in the response should be expanded.
-        """
-        limit: NotRequired["int"]
-        """
-        A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
-        """
-        starting_after: NotRequired["str"]
-        """
-        A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-        """
-
-    class RetrieveParams(RequestOptions):
-        expand: NotRequired["List[str]"]
-        """
-        Specifies which fields in the response should be expanded.
-        """
-
     adjusted_for_overdraft: Optional[AdjustedForOverdraft]
     applied_to_payment: Optional[AppliedToPayment]
     created: int
@@ -221,41 +192,6 @@ class CustomerCashBalanceTransaction(
     The type of the cash balance transaction. New types may be added in future. See [Customer Balance](https://stripe.com/docs/payments/customer-balance#types) to learn more about these types.
     """
     unapplied_from_payment: Optional[UnappliedFromPayment]
-
-    @classmethod
-    def list(
-        cls, **params: Unpack["CustomerCashBalanceTransaction.ListParams"]
-    ) -> ListObject["CustomerCashBalanceTransaction"]:
-        """
-        Returns a list of transactions that modified the customer's [cash balance](https://stripe.com/docs/payments/customer-balance).
-        """
-        result = cls._static_request(
-            "get",
-            cls.class_url(),
-            params=params,
-        )
-        if not isinstance(result, ListObject):
-
-            raise TypeError(
-                "Expected list object from API, got %s"
-                % (type(result).__name__)
-            )
-
-        return result
-
-    @classmethod
-    def retrieve(
-        cls,
-        id: str,
-        **params: Unpack["CustomerCashBalanceTransaction.RetrieveParams"]
-    ) -> "CustomerCashBalanceTransaction":
-        """
-        Retrieves a specific cash balance transaction, which updated the customer's [cash balance](https://stripe.com/docs/payments/customer-balance).
-        """
-        instance = cls(id, **params)
-        instance.refresh()
-        return instance
-
     _inner_class_types = {
         "adjusted_for_overdraft": AdjustedForOverdraft,
         "applied_to_payment": AppliedToPayment,

--- a/stripe/_ephemeral_key.py
+++ b/stripe/_ephemeral_key.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe._createable_api_resource import CreateableAPIResource
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._request_options import RequestOptions
 from stripe._util import class_method_variant, sanitize_id
@@ -7,7 +8,10 @@ from typing import ClassVar, List, Optional, cast, overload
 from typing_extensions import Literal, NotRequired, Unpack
 
 
-class EphemeralKey(DeletableAPIResource["EphemeralKey"]):
+class EphemeralKey(
+    CreateableAPIResource["EphemeralKey"],
+    DeletableAPIResource["EphemeralKey"],
+):
     OBJECT_NAME: ClassVar[Literal["ephemeral_key"]] = "ephemeral_key"
 
     class DeleteParams(RequestOptions):

--- a/stripe/_usage_record.py
+++ b/stripe/_usage_record.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe._api_resource import APIResource
+from stripe._createable_api_resource import CreateableAPIResource
 from typing import ClassVar
 from typing_extensions import Literal
 
 
-class UsageRecord(APIResource["UsageRecord"]):
+class UsageRecord(CreateableAPIResource["UsageRecord"]):
     """
     Usage records allow you to report customer usage and metrics to Stripe for
     metered billing of subscription prices.

--- a/tests/test_generated_examples.py
+++ b/tests/test_generated_examples.py
@@ -726,7 +726,7 @@ class TestGeneratedExamples(object):
     def test_accounts_persons_get(
         self, http_client_mock: HTTPClientMock
     ) -> None:
-        stripe.Account.list_persons(
+        stripe.Account.persons(
             "acct_xxxxxxxxxxxxx",
             limit=3,
         )


### PR DESCRIPTION
## Changelog
* Bugfix: remove support for `CreditNoteLineItem.list` and `CustomerCashBalanceTransaction.list`. These methods were included in the library unintentionally and never functioned.