### PR TITLE
Add TaxIds API

### DIFF
--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -483,6 +483,7 @@ from stripe._tax_deducted_at_source import (
     TaxDeductedAtSource as TaxDeductedAtSource,
 )
 from stripe._tax_id import TaxId as TaxId
+from stripe._tax_id_service import TaxIdService as TaxIdService
 from stripe._tax_rate import TaxRate as TaxRate
 from stripe._tax_rate_service import TaxRateService as TaxRateService
 from stripe._tax_service import TaxService as TaxService

--- a/stripe/_stripe_client.py
+++ b/stripe/_stripe_client.py
@@ -81,6 +81,7 @@ from stripe._subscription_item_service import SubscriptionItemService
 from stripe._subscription_schedule_service import SubscriptionScheduleService
 from stripe._tax_service import TaxService
 from stripe._tax_code_service import TaxCodeService
+from stripe._tax_id_service import TaxIdService
 from stripe._tax_rate_service import TaxRateService
 from stripe._terminal_service import TerminalService
 from stripe._token_service import TokenService
@@ -222,6 +223,7 @@ class StripeClient(object):
         )
         self.tax = TaxService(self._requestor)
         self.tax_codes = TaxCodeService(self._requestor)
+        self.tax_ids = TaxIdService(self._requestor)
         self.tax_rates = TaxRateService(self._requestor)
         self.terminal = TerminalService(self._requestor)
         self.tokens = TokenService(self._requestor)

--- a/stripe/_tax_id.py
+++ b/stripe/_tax_id.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 from stripe._createable_api_resource import CreateableAPIResource
-from stripe._customer import Customer
 from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._expandable_field import ExpandableField
 from stripe._list_object import ListObject
@@ -21,6 +20,7 @@ from typing_extensions import (
 if TYPE_CHECKING:
     from stripe._account import Account
     from stripe._application import Application
+    from stripe._customer import Customer
 
 
 class TaxId(
@@ -206,6 +206,12 @@ class TaxId(
         type: Literal["account", "application", "customer", "self"]
         """
         Type of owner referenced.
+        """
+
+    class RetrieveParams(RequestOptions):
+        expand: NotRequired["List[str]"]
+        """
+        Specifies which fields in the response should be expanded.
         """
 
     country: Optional[str]
@@ -400,21 +406,15 @@ class TaxId(
 
         return result
 
-    def instance_url(self):
-        token = self.id
-        customer = self.customer
-        base = Customer.class_url()
-        assert customer is not None
-        if isinstance(customer, Customer):
-            customer = customer.id
-        cust_extn = sanitize_id(customer)
-        extn = sanitize_id(token)
-        return "%s/%s/tax_ids/%s" % (base, cust_extn, extn)
-
     @classmethod
-    def retrieve(cls, id, **params):
-        raise NotImplementedError(
-            "Can't retrieve a tax id without a customer ID. Use customer.retrieve_tax_id('tax_id')"
-        )
+    def retrieve(
+        cls, id: str, **params: Unpack["TaxId.RetrieveParams"]
+    ) -> "TaxId":
+        """
+        Retrieves an account or customer tax_id object.
+        """
+        instance = cls(id, **params)
+        instance.refresh()
+        return instance
 
     _inner_class_types = {"owner": Owner, "verification": Verification}

--- a/stripe/_tax_id.py
+++ b/stripe/_tax_id.py
@@ -1,19 +1,33 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-from stripe._api_resource import APIResource
+from stripe._createable_api_resource import CreateableAPIResource
 from stripe._customer import Customer
+from stripe._deletable_api_resource import DeletableAPIResource
 from stripe._expandable_field import ExpandableField
+from stripe._list_object import ListObject
+from stripe._listable_api_resource import ListableAPIResource
+from stripe._request_options import RequestOptions
 from stripe._stripe_object import StripeObject
-from stripe._util import sanitize_id
-from typing import ClassVar, Optional
-from typing_extensions import Literal, TYPE_CHECKING
+from stripe._util import class_method_variant, sanitize_id
+from typing import ClassVar, List, Optional, cast, overload
+from typing_extensions import (
+    Literal,
+    NotRequired,
+    TypedDict,
+    Unpack,
+    TYPE_CHECKING,
+)
 
 if TYPE_CHECKING:
     from stripe._account import Account
     from stripe._application import Application
 
 
-class TaxId(APIResource["TaxId"]):
+class TaxId(
+    CreateableAPIResource["TaxId"],
+    DeletableAPIResource["TaxId"],
+    ListableAPIResource["TaxId"],
+):
     """
     You can add one or multiple tax IDs to a [customer](https://stripe.com/docs/api/customers) or account.
     Customer and account tax IDs get displayed on related invoices and credit notes.
@@ -53,6 +67,145 @@ class TaxId(APIResource["TaxId"]):
         verified_name: Optional[str]
         """
         Verified name.
+        """
+
+    class CreateParams(RequestOptions):
+        expand: NotRequired["List[str]"]
+        """
+        Specifies which fields in the response should be expanded.
+        """
+        owner: NotRequired["TaxId.CreateParamsOwner"]
+        """
+        The account or customer the tax ID belongs to. Defaults to `owner[type]=self`.
+        """
+        type: Literal[
+            "ad_nrt",
+            "ae_trn",
+            "ar_cuit",
+            "au_abn",
+            "au_arn",
+            "bg_uic",
+            "bo_tin",
+            "br_cnpj",
+            "br_cpf",
+            "ca_bn",
+            "ca_gst_hst",
+            "ca_pst_bc",
+            "ca_pst_mb",
+            "ca_pst_sk",
+            "ca_qst",
+            "ch_vat",
+            "cl_tin",
+            "cn_tin",
+            "co_nit",
+            "cr_tin",
+            "do_rcn",
+            "ec_ruc",
+            "eg_tin",
+            "es_cif",
+            "eu_oss_vat",
+            "eu_vat",
+            "gb_vat",
+            "ge_vat",
+            "hk_br",
+            "hu_tin",
+            "id_npwp",
+            "il_vat",
+            "in_gst",
+            "is_vat",
+            "jp_cn",
+            "jp_rn",
+            "jp_trn",
+            "ke_pin",
+            "kr_brn",
+            "li_uid",
+            "mx_rfc",
+            "my_frp",
+            "my_itn",
+            "my_sst",
+            "no_vat",
+            "no_voec",
+            "nz_gst",
+            "pe_ruc",
+            "ph_tin",
+            "ro_tin",
+            "rs_pib",
+            "ru_inn",
+            "ru_kpp",
+            "sa_vat",
+            "sg_gst",
+            "sg_uen",
+            "si_tin",
+            "sv_nit",
+            "th_vat",
+            "tr_tin",
+            "tw_vat",
+            "ua_vat",
+            "us_ein",
+            "uy_ruc",
+            "ve_rif",
+            "vn_tin",
+            "za_vat",
+        ]
+        """
+        Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `no_voec`, `nz_gst`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`
+        """
+        value: str
+        """
+        Value of the tax ID.
+        """
+
+    class CreateParamsOwner(TypedDict):
+        account: NotRequired["str"]
+        """
+        Account the tax ID belongs to. Required when `type=account`
+        """
+        customer: NotRequired["str"]
+        """
+        Customer the tax ID belongs to. Required when `type=customer`
+        """
+        type: Literal["account", "application", "customer", "self"]
+        """
+        Type of owner referenced.
+        """
+
+    class DeleteParams(RequestOptions):
+        pass
+
+    class ListParams(RequestOptions):
+        ending_before: NotRequired["str"]
+        """
+        A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
+        """
+        expand: NotRequired["List[str]"]
+        """
+        Specifies which fields in the response should be expanded.
+        """
+        limit: NotRequired["int"]
+        """
+        A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+        """
+        owner: NotRequired["TaxId.ListParamsOwner"]
+        """
+        The account or customer the tax ID belongs to. Defaults to `owner[type]=self`.
+        """
+        starting_after: NotRequired["str"]
+        """
+        A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
+        """
+
+    class ListParamsOwner(TypedDict):
+        account: NotRequired["str"]
+        """
+        Account the tax ID belongs to. Required when `type=account`
+        """
+        customer: NotRequired["str"]
+        """
+        Customer the tax ID belongs to. Required when `type=customer`
+        """
+        type: Literal["account", "application", "customer", "self"]
+        """
+        Type of owner referenced.
         """
 
     country: Optional[str]
@@ -168,6 +321,84 @@ class TaxId(APIResource["TaxId"]):
     """
     Always true for a deleted object
     """
+
+    @classmethod
+    def create(cls, **params: Unpack["TaxId.CreateParams"]) -> "TaxId":
+        """
+        Creates a new account or customer tax_id object.
+        """
+        return cast(
+            "TaxId",
+            cls._static_request(
+                "post",
+                cls.class_url(),
+                params=params,
+            ),
+        )
+
+    @classmethod
+    def _cls_delete(
+        cls, sid: str, **params: Unpack["TaxId.DeleteParams"]
+    ) -> "TaxId":
+        """
+        Deletes an existing account or customer tax_id object.
+        """
+        url = "%s/%s" % (cls.class_url(), sanitize_id(sid))
+        return cast(
+            "TaxId",
+            cls._static_request(
+                "delete",
+                url,
+                params=params,
+            ),
+        )
+
+    @overload
+    @staticmethod
+    def delete(sid: str, **params: Unpack["TaxId.DeleteParams"]) -> "TaxId":
+        """
+        Deletes an existing account or customer tax_id object.
+        """
+        ...
+
+    @overload
+    def delete(self, **params: Unpack["TaxId.DeleteParams"]) -> "TaxId":
+        """
+        Deletes an existing account or customer tax_id object.
+        """
+        ...
+
+    @class_method_variant("_cls_delete")
+    def delete(  # pyright: ignore[reportGeneralTypeIssues]
+        self, **params: Unpack["TaxId.DeleteParams"]
+    ) -> "TaxId":
+        """
+        Deletes an existing account or customer tax_id object.
+        """
+        return self._request_and_refresh(
+            "delete",
+            self.instance_url(),
+            params=params,
+        )
+
+    @classmethod
+    def list(cls, **params: Unpack["TaxId.ListParams"]) -> ListObject["TaxId"]:
+        """
+        Returns a list of tax IDs.
+        """
+        result = cls._static_request(
+            "get",
+            cls.class_url(),
+            params=params,
+        )
+        if not isinstance(result, ListObject):
+
+            raise TypeError(
+                "Expected list object from API, got %s"
+                % (type(result).__name__)
+            )
+
+        return result
 
     def instance_url(self):
         token = self.id

--- a/stripe/_tax_id_service.py
+++ b/stripe/_tax_id_service.py
@@ -1,0 +1,236 @@
+# -*- coding: utf-8 -*-
+# File generated from our OpenAPI spec
+from stripe._list_object import ListObject
+from stripe._request_options import RequestOptions
+from stripe._stripe_service import StripeService
+from stripe._tax_id import TaxId
+from stripe._util import sanitize_id
+from typing import List, cast
+from typing_extensions import Literal, NotRequired, TypedDict
+
+
+class TaxIdService(StripeService):
+    class CreateParams(TypedDict):
+        expand: NotRequired["List[str]"]
+        """
+        Specifies which fields in the response should be expanded.
+        """
+        owner: NotRequired["TaxIdService.CreateParamsOwner"]
+        """
+        The account or customer the tax ID belongs to. Defaults to `owner[type]=self`.
+        """
+        type: Literal[
+            "ad_nrt",
+            "ae_trn",
+            "ar_cuit",
+            "au_abn",
+            "au_arn",
+            "bg_uic",
+            "bo_tin",
+            "br_cnpj",
+            "br_cpf",
+            "ca_bn",
+            "ca_gst_hst",
+            "ca_pst_bc",
+            "ca_pst_mb",
+            "ca_pst_sk",
+            "ca_qst",
+            "ch_vat",
+            "cl_tin",
+            "cn_tin",
+            "co_nit",
+            "cr_tin",
+            "do_rcn",
+            "ec_ruc",
+            "eg_tin",
+            "es_cif",
+            "eu_oss_vat",
+            "eu_vat",
+            "gb_vat",
+            "ge_vat",
+            "hk_br",
+            "hu_tin",
+            "id_npwp",
+            "il_vat",
+            "in_gst",
+            "is_vat",
+            "jp_cn",
+            "jp_rn",
+            "jp_trn",
+            "ke_pin",
+            "kr_brn",
+            "li_uid",
+            "mx_rfc",
+            "my_frp",
+            "my_itn",
+            "my_sst",
+            "no_vat",
+            "no_voec",
+            "nz_gst",
+            "pe_ruc",
+            "ph_tin",
+            "ro_tin",
+            "rs_pib",
+            "ru_inn",
+            "ru_kpp",
+            "sa_vat",
+            "sg_gst",
+            "sg_uen",
+            "si_tin",
+            "sv_nit",
+            "th_vat",
+            "tr_tin",
+            "tw_vat",
+            "ua_vat",
+            "us_ein",
+            "uy_ruc",
+            "ve_rif",
+            "vn_tin",
+            "za_vat",
+        ]
+        """
+        Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `no_voec`, `nz_gst`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`
+        """
+        value: str
+        """
+        Value of the tax ID.
+        """
+
+    class CreateParamsOwner(TypedDict):
+        account: NotRequired["str"]
+        """
+        Account the tax ID belongs to. Required when `type=account`
+        """
+        customer: NotRequired["str"]
+        """
+        Customer the tax ID belongs to. Required when `type=customer`
+        """
+        type: Literal["account", "application", "customer", "self"]
+        """
+        Type of owner referenced.
+        """
+
+    class DeleteParams(TypedDict):
+        pass
+
+    class ListParams(TypedDict):
+        ending_before: NotRequired["str"]
+        """
+        A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
+        """
+        expand: NotRequired["List[str]"]
+        """
+        Specifies which fields in the response should be expanded.
+        """
+        limit: NotRequired["int"]
+        """
+        A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+        """
+        owner: NotRequired["TaxIdService.ListParamsOwner"]
+        """
+        The account or customer the tax ID belongs to. Defaults to `owner[type]=self`.
+        """
+        starting_after: NotRequired["str"]
+        """
+        A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
+        """
+
+    class ListParamsOwner(TypedDict):
+        account: NotRequired["str"]
+        """
+        Account the tax ID belongs to. Required when `type=account`
+        """
+        customer: NotRequired["str"]
+        """
+        Customer the tax ID belongs to. Required when `type=customer`
+        """
+        type: Literal["account", "application", "customer", "self"]
+        """
+        Type of owner referenced.
+        """
+
+    class RetrieveParams(TypedDict):
+        expand: NotRequired["List[str]"]
+        """
+        Specifies which fields in the response should be expanded.
+        """
+
+    def delete(
+        self,
+        id: str,
+        params: "TaxIdService.DeleteParams" = {},
+        options: RequestOptions = {},
+    ) -> TaxId:
+        """
+        Deletes an existing account or customer tax_id object.
+        """
+        return cast(
+            TaxId,
+            self._request(
+                "delete",
+                "/v1/tax_ids/{id}".format(id=sanitize_id(id)),
+                api_mode="V1",
+                base_address="api",
+                params=params,
+                options=options,
+            ),
+        )
+
+    def retrieve(
+        self,
+        id: str,
+        params: "TaxIdService.RetrieveParams" = {},
+        options: RequestOptions = {},
+    ) -> TaxId:
+        """
+        Retrieves an account or customer tax_id object.
+        """
+        return cast(
+            TaxId,
+            self._request(
+                "get",
+                "/v1/tax_ids/{id}".format(id=sanitize_id(id)),
+                api_mode="V1",
+                base_address="api",
+                params=params,
+                options=options,
+            ),
+        )
+
+    def list(
+        self,
+        params: "TaxIdService.ListParams" = {},
+        options: RequestOptions = {},
+    ) -> ListObject[TaxId]:
+        """
+        Returns a list of tax IDs.
+        """
+        return cast(
+            ListObject[TaxId],
+            self._request(
+                "get",
+                "/v1/tax_ids",
+                api_mode="V1",
+                base_address="api",
+                params=params,
+                options=options,
+            ),
+        )
+
+    def create(
+        self, params: "TaxIdService.CreateParams", options: RequestOptions = {}
+    ) -> TaxId:
+        """
+        Creates a new account or customer tax_id object.
+        """
+        return cast(
+            TaxId,
+            self._request(
+                "post",
+                "/v1/tax_ids",
+                api_mode="V1",
+                base_address="api",
+                params=params,
+                options=options,
+            ),
+        )

--- a/tests/api_resources/test_tax_id.py
+++ b/tests/api_resources/test_tax_id.py
@@ -15,19 +15,14 @@ class TestTaxId(object):
 
     def test_has_instance_url(self):
         resource = self.construct_resource()
-        assert (
-            resource.instance_url()
-            == "/v1/tax_ids/%s" % TEST_RESOURCE_ID
-        )
+        assert resource.instance_url() == "/v1/tax_ids/%s" % TEST_RESOURCE_ID
 
     def test_is_creatable(self, http_client_mock):
         stripe.TaxId.create(
             type="eu_vat",
             value="DE123456789",
         )
-        http_client_mock.assert_requested(
-            "post", path="/v1/tax_ids"
-        )
+        http_client_mock.assert_requested("post", path="/v1/tax_ids")
 
     def test_is_retrievable(self, http_client_mock):
         stripe.TaxId.retrieve(TEST_RESOURCE_ID)

--- a/tests/api_resources/test_tax_id.py
+++ b/tests/api_resources/test_tax_id.py
@@ -1,5 +1,3 @@
-import pytest
-
 import stripe
 
 
@@ -19,9 +17,41 @@ class TestTaxId(object):
         resource = self.construct_resource()
         assert (
             resource.instance_url()
-            == "/v1/customers/cus_123/tax_ids/%s" % TEST_RESOURCE_ID
+            == "/v1/tax_ids/%s" % TEST_RESOURCE_ID
         )
 
-    def test_is_not_retrievable(self):
-        with pytest.raises(NotImplementedError):
-            stripe.TaxId.retrieve(TEST_RESOURCE_ID)
+    def test_is_creatable(self, http_client_mock):
+        stripe.TaxId.create(
+            type="eu_vat",
+            value="DE123456789",
+        )
+        http_client_mock.assert_requested(
+            "post", path="/v1/tax_ids"
+        )
+
+    def test_is_retrievable(self, http_client_mock):
+        stripe.TaxId.retrieve(TEST_RESOURCE_ID)
+        http_client_mock.assert_requested(
+            "get", path="/v1/tax_ids/%s" % TEST_RESOURCE_ID
+        )
+
+    def test_is_deletable(self, http_client_mock):
+        resource = stripe.TaxId.retrieve(TEST_RESOURCE_ID)
+        resource.delete()
+        http_client_mock.assert_requested(
+            "delete", path="/v1/tax_ids/%s" % TEST_RESOURCE_ID
+        )
+        assert resource.deleted is True
+
+    def test_can_delete(self, http_client_mock):
+        resource = stripe.TaxId.delete(TEST_RESOURCE_ID)
+        http_client_mock.assert_requested(
+            "delete", path="/v1/tax_ids/%s" % TEST_RESOURCE_ID
+        )
+        assert resource.deleted is True
+
+    def test_is_listable(self, http_client_mock):
+        resources = stripe.TaxId.list()
+        http_client_mock.assert_requested("get", path="/v1/tax_ids")
+        assert isinstance(resources.data, list)
+        assert isinstance(resources.data[0], stripe.TaxId)


### PR DESCRIPTION
## Changelog
* Add support for `create`, `retrieve`, `delete`, and `list` methods on resource `TaxId`
* The `instance_url` function on resource `TaxId` now returns the top-level `/v1/tax_ids/{id}` path instead of the `/v1/customers/{customer}/tax_ids/{id}` path.