### PR TITLE
Make `ListObject.auto_paging_iter()` implement `AsyncIterator`

### DIFF
--- a/stripe/_any_iterator.py
+++ b/stripe/_any_iterator.py
@@ -1,0 +1,30 @@
+from typing import Any, TypeVar, Iterator, AsyncIterator
+
+T = TypeVar("T")
+
+
+class AnyIterator(Iterator[T], AsyncIterator[T]):
+    def __init__(
+        self, iterator: Iterator[T], async_iterator: AsyncIterator[T]
+    ) -> None:
+        self._iterator = iterator
+        self._async_iterator = async_iterator
+
+        self._sync_iterated = False
+        self._async_iterated = False
+
+    def __next__(self) -> T:
+        if self._async_iterated:
+            raise RuntimeError(
+                "AnyIterator error: cannot mix sync and async iteration"
+            )
+        self._sync_iterated = True
+        return self._iterator.__next__()
+
+    async def __anext__(self) -> T:
+        if self._sync_iterated:
+            raise RuntimeError(
+                "AnyIterator error: cannot mix sync and async iteration"
+            )
+        self._async_iterated = True
+        return await self._async_iterator.__anext__()

--- a/stripe/_any_iterator.py
+++ b/stripe/_any_iterator.py
@@ -1,4 +1,4 @@
-from typing import Any, TypeVar, Iterator, AsyncIterator
+from typing import TypeVar, Iterator, AsyncIterator
 
 T = TypeVar("T")
 

--- a/stripe/_any_iterator.py
+++ b/stripe/_any_iterator.py
@@ -4,6 +4,10 @@ T = TypeVar("T")
 
 
 class AnyIterator(Iterator[T], AsyncIterator[T]):
+    """
+    AnyIterator supports iteration through both `for ... in <AnyIterator>` and `async for ... in <AnyIterator> syntaxes.
+    """
+
     def __init__(
         self, iterator: Iterator[T], async_iterator: AsyncIterator[T]
     ) -> None:

--- a/stripe/_charge.py
+++ b/stripe/_charge.py
@@ -3918,9 +3918,7 @@ class Charge(
     async def search_auto_paging_iter_async(
         cls, *args, **kwargs: Unpack["Charge.SearchParams"]
     ) -> AsyncIterator["Charge"]:
-        return (
-            await cls.search_async(*args, **kwargs)
-        ).auto_paging_iter_async()
+        return (await cls.search_async(*args, **kwargs)).auto_paging_iter()
 
     def mark_as_fraudulent(self, idempotency_key=None) -> "Charge":
         params = {

--- a/stripe/_customer.py
+++ b/stripe/_customer.py
@@ -2164,9 +2164,7 @@ class Customer(
     async def search_auto_paging_iter_async(
         cls, *args, **kwargs: Unpack["Customer.SearchParams"]
     ) -> AsyncIterator["Customer"]:
-        return (
-            await cls.search_async(*args, **kwargs)
-        ).auto_paging_iter_async()
+        return (await cls.search_async(*args, **kwargs)).auto_paging_iter()
 
     @classmethod
     def create_balance_transaction(

--- a/stripe/_invoice.py
+++ b/stripe/_invoice.py
@@ -10098,9 +10098,7 @@ class Invoice(
     async def search_auto_paging_iter_async(
         cls, *args, **kwargs: Unpack["Invoice.SearchParams"]
     ) -> AsyncIterator["Invoice"]:
-        return (
-            await cls.search_async(*args, **kwargs)
-        ).auto_paging_iter_async()
+        return (await cls.search_async(*args, **kwargs)).auto_paging_iter()
 
     @classmethod
     def list_payments(

--- a/stripe/_list_object.py
+++ b/stripe/_list_object.py
@@ -16,27 +16,11 @@ from typing import (
 from stripe._api_requestor import (
     _APIRequestor,  # pyright: ignore[reportPrivateUsage]
 )
+from stripe._any_iterator import AnyIterator
 from stripe._stripe_object import StripeObject
 from stripe._request_options import RequestOptions, extract_options_from_dict
 
 from urllib.parse import quote_plus
-
-
-TIter = TypeVar("TIter", bound=StripeObject)
-
-
-class SyncAsyncIterator(Iterator[TIter], AsyncIterator[TIter]):
-    def __init__(
-        self, iterator: Iterator[TIter], async_iterator: AsyncIterator[TIter]
-    ) -> None:
-        self._iterator = iterator
-        self._async_iterator = async_iterator
-
-    def __next__(self) -> TIter:
-        return self._iterator.__next__()
-
-    async def __anext__(self) -> Any:
-        return await self._async_iterator.__anext__()
 
 
 T = TypeVar("T", bound=StripeObject)
@@ -141,8 +125,8 @@ class ListObject(StripeObject, Generic[T]):
     def __reversed__(self) -> Iterator[T]:  # pyright: ignore (see above)
         return getattr(self, "data", []).__reversed__()
 
-    def auto_paging_iter(self) -> SyncAsyncIterator[T]:
-        return SyncAsyncIterator(
+    def auto_paging_iter(self) -> AnyIterator[T]:
+        return AnyIterator(
             self._auto_paging_iter(),
             self._auto_paging_iter_async(),
         )

--- a/stripe/_list_object.py
+++ b/stripe/_list_object.py
@@ -21,6 +21,24 @@ from stripe._request_options import RequestOptions, extract_options_from_dict
 
 from urllib.parse import quote_plus
 
+
+TIter = TypeVar("TIter", bound=StripeObject)
+
+
+class SyncAsyncIterator(Iterator[TIter], AsyncIterator[TIter]):
+    def __init__(
+        self, iterator: Iterator[TIter], async_iterator: AsyncIterator[TIter]
+    ) -> None:
+        self._iterator = iterator
+        self._async_iterator = async_iterator
+
+    def __next__(self) -> TIter:
+        return self._iterator.__next__()
+
+    async def __anext__(self) -> Any:
+        return await self._async_iterator.__anext__()
+
+
 T = TypeVar("T", bound=StripeObject)
 
 
@@ -123,7 +141,13 @@ class ListObject(StripeObject, Generic[T]):
     def __reversed__(self) -> Iterator[T]:  # pyright: ignore (see above)
         return getattr(self, "data", []).__reversed__()
 
-    def auto_paging_iter(self) -> Iterator[T]:
+    def auto_paging_iter(self) -> SyncAsyncIterator[T]:
+        return SyncAsyncIterator(
+            self._auto_paging_iter(),
+            self._auto_paging_iter_async(),
+        )
+
+    def _auto_paging_iter(self) -> Iterator[T]:
         page = self
 
         while True:
@@ -142,7 +166,7 @@ class ListObject(StripeObject, Generic[T]):
             if page.is_empty:
                 break
 
-    async def auto_paging_iter_async(self) -> AsyncIterator[T]:
+    async def _auto_paging_iter_async(self) -> AsyncIterator[T]:
         page = self
 
         while True:

--- a/stripe/_listable_api_resource.py
+++ b/stripe/_listable_api_resource.py
@@ -15,6 +15,10 @@ class ListableAPIResource(APIResource[T]):
         return cls.list(**params).auto_paging_iter()
 
     @classmethod
+    async def auto_paging_iter_async(cls, **params):
+        return (await cls.list_async(**params)).auto_paging_iter()
+
+    @classmethod
     def list(cls, **params) -> ListObject[T]:
         result = cls._static_request(
             "get",

--- a/stripe/_listable_api_resource.py
+++ b/stripe/_listable_api_resource.py
@@ -15,10 +15,6 @@ class ListableAPIResource(APIResource[T]):
         return cls.list(**params).auto_paging_iter()
 
     @classmethod
-    async def auto_paging_iter_async(cls, **params):
-        return (await cls.list_async(**params)).auto_paging_iter()
-
-    @classmethod
     def list(cls, **params) -> ListObject[T]:
         result = cls._static_request(
             "get",

--- a/stripe/_payment_intent.py
+++ b/stripe/_payment_intent.py
@@ -12953,9 +12953,7 @@ class PaymentIntent(
     async def search_auto_paging_iter_async(
         cls, *args, **kwargs: Unpack["PaymentIntent.SearchParams"]
     ) -> AsyncIterator["PaymentIntent"]:
-        return (
-            await cls.search_async(*args, **kwargs)
-        ).auto_paging_iter_async()
+        return (await cls.search_async(*args, **kwargs)).auto_paging_iter()
 
     _inner_class_types = {
         "amount_details": AmountDetails,

--- a/stripe/_price.py
+++ b/stripe/_price.py
@@ -926,9 +926,7 @@ class Price(
     async def search_auto_paging_iter_async(
         cls, *args, **kwargs: Unpack["Price.SearchParams"]
     ) -> AsyncIterator["Price"]:
-        return (
-            await cls.search_async(*args, **kwargs)
-        ).auto_paging_iter_async()
+        return (await cls.search_async(*args, **kwargs)).auto_paging_iter()
 
     _inner_class_types = {
         "currency_options": CurrencyOptions,

--- a/stripe/_product.py
+++ b/stripe/_product.py
@@ -871,9 +871,7 @@ class Product(
     async def search_auto_paging_iter_async(
         cls, *args, **kwargs: Unpack["Product.SearchParams"]
     ) -> AsyncIterator["Product"]:
-        return (
-            await cls.search_async(*args, **kwargs)
-        ).auto_paging_iter_async()
+        return (await cls.search_async(*args, **kwargs)).auto_paging_iter()
 
     _inner_class_types = {
         "features": Feature,

--- a/stripe/_search_result_object.py
+++ b/stripe/_search_result_object.py
@@ -19,6 +19,7 @@ from stripe._stripe_object import StripeObject
 from stripe import _util
 import warnings
 from stripe._request_options import RequestOptions, extract_options_from_dict
+from stripe._any_iterator import AnyIterator
 
 T = TypeVar("T", bound=StripeObject)
 
@@ -91,7 +92,7 @@ class SearchResultObject(StripeObject, Generic[T]):
     def __len__(self) -> int:
         return getattr(self, "data", []).__len__()
 
-    def auto_paging_iter(self) -> Iterator[T]:
+    def _auto_paging_iter(self) -> Iterator[T]:
         page = self
 
         while True:
@@ -102,7 +103,12 @@ class SearchResultObject(StripeObject, Generic[T]):
             if page.is_empty:
                 break
 
-    async def auto_paging_iter_async(self) -> AsyncIterator[T]:
+    def auto_paging_iter(self) -> AnyIterator[T]:
+        return AnyIterator(
+            self._auto_paging_iter(), self._auto_paging_iter_async()
+        )
+
+    async def _auto_paging_iter_async(self) -> AsyncIterator[T]:
         page = self
 
         while True:

--- a/stripe/_subscription.py
+++ b/stripe/_subscription.py
@@ -2976,9 +2976,7 @@ class Subscription(
     async def search_auto_paging_iter_async(
         cls, *args, **kwargs: Unpack["Subscription.SearchParams"]
     ) -> AsyncIterator["Subscription"]:
-        return (
-            await cls.search_async(*args, **kwargs)
-        ).auto_paging_iter_async()
+        return (await cls.search_async(*args, **kwargs)).auto_paging_iter()
 
     _inner_class_types = {
         "automatic_tax": AutomaticTax,

--- a/tests/api_resources/test_list_object.py
+++ b/tests/api_resources/test_list_object.py
@@ -444,7 +444,7 @@ class TestAutoPagingAsync:
 
         http_client_mock.assert_no_request()
 
-        seen = [item["id"] async for item in lo.auto_paging_iter_async()]
+        seen = [item["id"] async for item in lo.auto_paging_iter()]
 
         assert seen == ["pm_123", "pm_124"]
 
@@ -464,7 +464,7 @@ class TestAutoPagingAsync:
             ),
         )
 
-        seen = [item["id"] async for item in lo.auto_paging_iter_async()]
+        seen = [item["id"] async for item in lo.auto_paging_iter()]
 
         http_client_mock.assert_requested(
             "get",
@@ -490,7 +490,7 @@ class TestAutoPagingAsync:
             ),
         )
 
-        seen = [item["id"] async for item in lo.auto_paging_iter_async()]
+        seen = [item["id"] async for item in lo.auto_paging_iter()]
 
         http_client_mock.assert_requested(
             "get",

--- a/tests/api_resources/test_search_result_object.py
+++ b/tests/api_resources/test_search_result_object.py
@@ -279,7 +279,7 @@ class TestAutoPagingAsync:
 
         http_client_mock.assert_no_request()
 
-        seen = [item["id"] async for item in sro.auto_paging_iter_async()]
+        seen = [item["id"] async for item in sro.auto_paging_iter()]
 
         assert seen == ["pm_123", "pm_124"]
 
@@ -300,7 +300,7 @@ class TestAutoPagingAsync:
             ),
         )
 
-        seen = [item["id"] async for item in sro.auto_paging_iter_async()]
+        seen = [item["id"] async for item in sro.auto_paging_iter()]
 
         http_client_mock.assert_requested(
             "get",


### PR DESCRIPTION
## Summary
This PR gets rid of `.auto_paging_iter_async()` and makes `.auto_paging_iter()` capable of asynchronous iteration.

**Not included:** the analog for SearchResult. Want feedback on this approach before I apply it everywhere.

## Motivation
We got some feedback from internal users that it error-prone figuring out how to migrate sync code that used `.auto_paging_iter`, e.g.
```diff
- print(", ".join([cus.id for cus in stripe.Customer.list().auto_paging_iter()]))
+ print(", ".join([cus.id async for cus in stripe.Customer.list_async().auto_paging_iter_async()]))
```

There are 3 things you have to change, and so 2^3 - 2 = 6 ways to incorrectly/partially migrate this (minus one for the correct migration, minus one for making no change at all). Here are 3:
```python
# This throws
print(", ".join([cus.id async for cus in stripe.Customer.list_async().auto_paging_iter()]))
# This succeeds but will make synchronous calls
print(", ".join([cus.id for cus in stripe.Customer.list_async().auto_paging_iter()]))
# This succeeds but makes a synchronous call.
print(", ".join([cus.id async for cus in stripe.Customer.list().auto_paging_iter_async()]))
```

I experimented a little bit with [introducing ListObjectAsync and SearchResultAsync](https://github.com/stripe/stripe-python/compare/richardm-async-list-object?expand=1), this added *a lot* of complexity and would have resulted in

```python
# This throws and gives a type error
print(", ".join([cus.id async for cus in stripe.Customer.list_async().auto_paging_iter()]))
# This throws and gives a type error
print(", ".join([cus.id for cus in stripe.Customer.list_async().auto_paging_iter()]))
# This succeeds but makes a synchronous call.
print(", ".join([cus.id async for cus in stripe.Customer.list().auto_paging_iter_async()]))
```

This PR, on the other hand, makes it so that it is not a mistake to use `async for` along with `.auto_paging_iter()`. So it reduces the possible ways to migrate incorrectly to 2^2 - 2 = 2.

```python
# This succeeds but makes synchronous calls
print(", ".join([cus.id for cus in stripe.Customer.list_async().auto_paging_iter()]))
# This succeeds but makes a synchronous call.
print(", ".join([cus.id async for cus in stripe.Customer.list().auto_paging_iter()]))
```

As a follow-up, we could consider adding (and recommending) an option like `stripe.default_http_client = stripe.HTTPXClient(disable_sync=True)` that would cause these to begin throwing exceptions if the user wanted.