### PR TITLE
Beta: Support 'allow_sync_methods=False' in HTTPXClient

### DIFF
--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -1215,7 +1215,7 @@ class HTTPXClient(HTTPClient):
     def __init__(
         self,
         timeout: Optional[Union[float, "HTTPXTimeout"]] = 80,
-        allow_sync_methods=True,
+        allow_sync_methods=False,
         **kwargs
     ):
         super(HTTPXClient, self).__init__(**kwargs)
@@ -1273,7 +1273,7 @@ class HTTPXClient(HTTPClient):
     ) -> Tuple[bytes, int, Mapping[str, str]]:
         if self._client is None:
             raise RuntimeError(
-                "HTTPXClient was initialized with allow_sync_methods=False, "
+                "Stripe: HTTPXClient was initialized with allow_sync_methods=False, "
                 "so it cannot be used for synchronous requests."
             )
         args, kwargs = self._get_request_args_kwargs(
@@ -1326,7 +1326,7 @@ class HTTPXClient(HTTPClient):
     ) -> Tuple[Iterable[bytes], int, Mapping[str, str]]:
         if self._client is None:
             raise RuntimeError(
-                "HTTPXClient was initialized with allow_sync_methods=False, "
+                "Stripe: HTTPXClient was not initialized with allow_sync_methods=True, "
                 "so it cannot be used for synchronous requests."
             )
         args, kwargs = self._get_request_args_kwargs(

--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -57,6 +57,7 @@ try:
     import httpx
     import anyio
     from httpx import Timeout as HTTPXTimeout
+    from httpx import Client as HTTPXClientType
 except ImportError:
     httpx = None
     anyio = None
@@ -1209,8 +1210,13 @@ class Urllib2Client(HTTPClient):
 class HTTPXClient(HTTPClient):
     name = "httpx"
 
+    _client: Optional["HTTPXClientType"]
+
     def __init__(
-        self, timeout: Optional[Union[float, "HTTPXTimeout"]] = 80, **kwargs
+        self,
+        timeout: Optional[Union[float, "HTTPXTimeout"]] = 80,
+        allow_sync_methods=True,
+        **kwargs
     ):
         super(HTTPXClient, self).__init__(**kwargs)
 
@@ -1234,7 +1240,9 @@ class HTTPXClient(HTTPClient):
             kwargs["verify"] = False
 
         self._client_async = httpx.AsyncClient(**kwargs)
-        self._client = httpx.Client(**kwargs)
+        self._client = None
+        if allow_sync_methods:
+            self._client = httpx.Client(**kwargs)
         self._timeout = timeout
 
     def sleep_async(self, secs):
@@ -1263,6 +1271,11 @@ class HTTPXClient(HTTPClient):
         post_data=None,
         timeout: float = 80.0,
     ) -> Tuple[bytes, int, Mapping[str, str]]:
+        if self._client is None:
+            raise RuntimeError(
+                "HTTPXClient was initialized with allow_sync_methods=False, "
+                "so it cannot be used for synchronous requests."
+            )
         args, kwargs = self._get_request_args_kwargs(
             method, url, headers, post_data
         )
@@ -1311,6 +1324,11 @@ class HTTPXClient(HTTPClient):
     def request_stream(
         self, method: str, url: str, headers: Mapping[str, str], post_data=None
     ) -> Tuple[Iterable[bytes], int, Mapping[str, str]]:
+        if self._client is None:
+            raise RuntimeError(
+                "HTTPXClient was initialized with allow_sync_methods=False, "
+                "so it cannot be used for synchronous requests."
+            )
         args, kwargs = self._get_request_args_kwargs(
             method, url, headers, post_data
         )
@@ -1347,7 +1365,8 @@ class HTTPXClient(HTTPClient):
         return content, status_code, headers
 
     def close(self):
-        self._client.close()
+        if self._client is not None:
+            self._client.close()
 
     async def close_async(self):
         await self._client_async.aclose()

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1318,6 +1318,14 @@ class TestHTTPXClient(StripeClientTestCase, ClientTestBase):
         # TODO
         pass
 
+    def test_allow_sync_methods(self):
+        client = self.REQUEST_CLIENT(allow_sync_methods=False)
+        assert client._client is None
+        with pytest.raises(RuntimeError):
+            client.request("GET", "http://foo", {})
+        with pytest.raises(RuntimeError):
+            client.request_stream("GET", "http://foo", {})
+
 
 class TestHTTPXClientRetryBehavior(TestHTTPXClient):
     responses = None


### PR DESCRIPTION
## Summary
Allows initializing HTTPXClient so that synchronous method calls raise an exception.

## Motivation
I expect this to be useful for users who want to completely migrate their Stripe integrations to use async control flow. It's easy to miss migrating a method or two, especially if it's a pagination request, and then you have blocking io that you didn't intend.

Brought this up https://github.com/stripe/stripe-python/issues/327#issuecomment-1960571444 and at least one user has indicated it would be useful.

It's definitely not impossible for users to subclass HTTPXClient and implement this themselves so maybe this is feature bloat, but I think eventually suggesting this strategy in our README will be helpful, and it addresses some of the migration experience agonies that motivated https://github.com/stripe/stripe-python/pull/1247.