### PR TITLE
Support AIOHTTPClient init without running event loop

### DIFF
--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -1399,6 +1399,8 @@ class AIOHTTPClient(HTTPClient):
 
     @cached_property
     def _session(self):
+        assert aiohttp is not None
+
         kwargs = {}
         if self._verify_ssl_certs:
             ssl_context = ssl.create_default_context(

--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -1,4 +1,3 @@
-from functools import cached_property
 from io import BytesIO
 import sys
 import textwrap
@@ -1397,20 +1396,23 @@ class AIOHTTPClient(HTTPClient):
 
         self._timeout = timeout
 
-    @cached_property
+    @property
     def _session(self):
         assert aiohttp is not None
 
-        kwargs = {}
-        if self._verify_ssl_certs:
-            ssl_context = ssl.create_default_context(
-                cafile=stripe.ca_bundle_path
-            )
-            kwargs["connector"] = aiohttp.TCPConnector(ssl=ssl_context)
-        else:
-            kwargs["connector"] = aiohttp.TCPConnector(verify_ssl=False)
+        if self._cached_session is None:
+            kwargs = {}
+            if self._verify_ssl_certs:
+                ssl_context = ssl.create_default_context(
+                    cafile=stripe.ca_bundle_path
+                )
+                kwargs["connector"] = aiohttp.TCPConnector(ssl=ssl_context)
+            else:
+                kwargs["connector"] = aiohttp.TCPConnector(verify_ssl=False)
 
-        return aiohttp.ClientSession(**kwargs)
+            self._cached_session = aiohttp.ClientSession(**kwargs)
+
+        return self._cached_session
 
     def sleep_async(self, secs):
         return asyncio.sleep(secs)

--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -1395,6 +1395,7 @@ class AIOHTTPClient(HTTPClient):
             )
 
         self._timeout = timeout
+        self._cached_session = None
 
     @property
     def _session(self):

--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 from io import BytesIO
 import sys
 import textwrap
@@ -1394,6 +1395,10 @@ class AIOHTTPClient(HTTPClient):
                 "Unexpected: tried to initialize AIOHTTPClient but the aiohttp module is not present."
             )
 
+        self._timeout = timeout
+
+    @cached_property
+    def _session(self):
         kwargs = {}
         if self._verify_ssl_certs:
             ssl_context = ssl.create_default_context(
@@ -1403,8 +1408,7 @@ class AIOHTTPClient(HTTPClient):
         else:
             kwargs["connector"] = aiohttp.TCPConnector(verify_ssl=False)
 
-        self._session = aiohttp.ClientSession(**kwargs)
-        self._timeout = timeout
+        return aiohttp.ClientSession(**kwargs)
 
     def sleep_async(self, secs):
         return asyncio.sleep(secs)

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -70,9 +70,7 @@ class TestNewHttpClientAsyncFallback(StripeClientTestCase):
     def test_new_http_client_async_fallback_httpx(self, request_mocks):
         self.check_default((), _http_client.HTTPXClient)
 
-    def test_new_http_client_async_fallback_aiohttp(
-        self, request_mocks
-    ):
+    def test_new_http_client_async_fallback_aiohttp(self, request_mocks):
         self.check_default(
             (("httpx"),),
             _http_client.AIOHTTPClient,

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -70,15 +70,8 @@ class TestNewHttpClientAsyncFallback(StripeClientTestCase):
     def test_new_http_client_async_fallback_httpx(self, request_mocks):
         self.check_default((), _http_client.HTTPXClient)
 
-    # Using the AIOHTTPClient constructor will complain if there's
-    # no active asyncio event loop. This test can pass in isolation
-    # but if it runs after another asyncio-enabled test that closes
-    # the asyncio event loop it will fail unless it is declared to
-    # use the asyncio backend.
-    @pytest.mark.anyio
-    @pytest.mark.parametrize("anyio_backend", ["asyncio"])
-    async def test_new_http_client_async_fallback_aiohttp(
-        self, request_mocks, anyio_backend
+    def test_new_http_client_async_fallback_aiohttp(
+        self, request_mocks
     ):
         self.check_default(
             (("httpx"),),


### PR DESCRIPTION
Lazily instantiates and caches an aiohttp `ClientSession` at the points in time that it is actually used so that `AIOHTTPClient` can be initialized without a running event loop (e.g. when setting `stripe.default_http_client = stripe.AIOHTTPClient()` at the top level of a module).

Related to issue #327.