### PR TITLE
Remove deprecated events

### DIFF
--- a/stripe/_event.py
+++ b/stripe/_event.py
@@ -382,14 +382,6 @@ class Event(ListableAPIResource["Event"]):
         "treasury.received_credit.failed",
         "treasury.received_credit.succeeded",
         "treasury.received_debit.created",
-        "invoiceitem.updated",
-        "order.created",
-        "recipient.created",
-        "recipient.deleted",
-        "recipient.updated",
-        "sku.created",
-        "sku.deleted",
-        "sku.updated",
     ]
     """
     Description of the event (for example, `invoice.created` or `charge.refunded`).

--- a/stripe/_webhook_endpoint.py
+++ b/stripe/_webhook_endpoint.py
@@ -374,14 +374,6 @@ class WebhookEndpoint(
                 "treasury.received_credit.failed",
                 "treasury.received_credit.succeeded",
                 "treasury.received_debit.created",
-                "invoiceitem.updated",
-                "order.created",
-                "recipient.created",
-                "recipient.deleted",
-                "recipient.updated",
-                "sku.created",
-                "sku.deleted",
-                "sku.updated",
             ]
         ]
         """
@@ -660,14 +652,6 @@ class WebhookEndpoint(
                     "treasury.received_credit.failed",
                     "treasury.received_credit.succeeded",
                     "treasury.received_debit.created",
-                    "invoiceitem.updated",
-                    "order.created",
-                    "recipient.created",
-                    "recipient.deleted",
-                    "recipient.updated",
-                    "sku.created",
-                    "sku.deleted",
-                    "sku.updated",
                 ]
             ]
         ]

--- a/stripe/_webhook_endpoint_service.py
+++ b/stripe/_webhook_endpoint_service.py
@@ -355,14 +355,6 @@ class WebhookEndpointService(StripeService):
                 "treasury.received_credit.failed",
                 "treasury.received_credit.succeeded",
                 "treasury.received_debit.created",
-                "invoiceitem.updated",
-                "order.created",
-                "recipient.created",
-                "recipient.deleted",
-                "recipient.updated",
-                "sku.created",
-                "sku.deleted",
-                "sku.updated",
             ]
         ]
         """
@@ -647,14 +639,6 @@ class WebhookEndpointService(StripeService):
                     "treasury.received_credit.failed",
                     "treasury.received_credit.succeeded",
                     "treasury.received_debit.created",
-                    "invoiceitem.updated",
-                    "order.created",
-                    "recipient.created",
-                    "recipient.deleted",
-                    "recipient.updated",
-                    "sku.created",
-                    "sku.deleted",
-                    "sku.updated",
                 ]
             ]
         ]

--- a/stripe/climate/_supplier.py
+++ b/stripe/climate/_supplier.py
@@ -89,7 +89,6 @@ class Supplier(ListableAPIResource["Supplier"]):
         "biomass_carbon_removal_and_storage",
         "direct_air_capture",
         "enhanced_weathering",
-        "various",
     ]
     """
     The scientific pathway used for carbon removal.


### PR DESCRIPTION
Below Event types were removed from the API in the last year

[On Sept 22, 2023](https://docs.stripe.com/changelog#september-22,-2023)

> Remove support for values order.created, recipient.created, recipient.deleted, recipient.updated, sku.created, sku.deleted, and sku.updated from enum Event.type

[On Sept 4th, 2023](https://docs.stripe.com/changelog#september-4,-2023)

> Remove support for value invoiceitem.updated from enum Event.type

And the enum Climate.Supplier.removal_pathway was updated on [Dec 6th , 2023](https://docs.stripe.com/changelog#december-6,-2023)

> Remove support for value various from enum Climate.Supplier.removal_pathway

This PR removes the same from the SDKs

Related Jira: https://jira.corp.stripe.com/browse/DEVSDK-1740



