### PR TITLE
Remove parts of the API that is no longer publicly documented

### DIFF
--- a/stripe/_balance_transaction.py
+++ b/stripe/_balance_transaction.py
@@ -251,10 +251,6 @@ class BalanceTransaction(ListableAPIResource["BalanceTransaction"]):
         "transfer_cancel",
         "transfer_failure",
         "transfer_refund",
-        "obligation_inbound",
-        "obligation_payout",
-        "obligation_payout_failure",
-        "obligation_reversal_outbound",
     ]
     """
     Transaction type: `adjustment`, `advance`, `advance_funding`, `anticipation_repayment`, `application_fee`, `application_fee_refund`, `charge`, `climate_order_purchase`, `climate_order_refund`, `connect_collection_transfer`, `contribution`, `issuing_authorization_hold`, `issuing_authorization_release`, `issuing_dispute`, `issuing_transaction`, `obligation_outbound`, `obligation_reversal_inbound`, `payment`, `payment_failure_refund`, `payment_network_reserve_hold`, `payment_network_reserve_release`, `payment_refund`, `payment_reversal`, `payment_unreconciled`, `payout`, `payout_cancel`, `payout_failure`, `refund`, `refund_failure`, `reserve_transaction`, `reserved_funds`, `stripe_fee`, `stripe_fx_fee`, `tax_fee`, `topup`, `topup_reversal`, `transfer`, `transfer_cancel`, `transfer_failure`, or `transfer_refund`. Learn more about [balance transaction types and what they represent](https://stripe.com/docs/reports/balance-transaction-types). To classify transactions for accounting purposes, consider `reporting_category` instead.

--- a/stripe/_event.py
+++ b/stripe/_event.py
@@ -382,14 +382,6 @@ class Event(ListableAPIResource["Event"]):
         "treasury.received_credit.failed",
         "treasury.received_credit.succeeded",
         "treasury.received_debit.created",
-        "invoiceitem.updated",
-        "order.created",
-        "recipient.created",
-        "recipient.deleted",
-        "recipient.updated",
-        "sku.created",
-        "sku.deleted",
-        "sku.updated",
     ]
     """
     Description of the event (for example, `invoice.created` or `charge.refunded`).

--- a/stripe/_invoice.py
+++ b/stripe/_invoice.py
@@ -1085,7 +1085,7 @@ class Invoice(
         Configuration settings for the PaymentIntent that is generated when the invoice is finalized.
         """
         pending_invoice_items_behavior: NotRequired[
-            Literal["exclude", "include", "include_and_require"]
+            Literal["exclude", "include"]
         ]
         """
         How to handle pending invoice items on invoice creation. Defaults to `exclude` if the parameter is omitted.

--- a/stripe/_invoice_line_item.py
+++ b/stripe/_invoice_line_item.py
@@ -289,7 +289,6 @@ class InvoiceLineItem(UpdateableAPIResource["InvoiceLineItem"]):
                 "rst",
                 "sales_tax",
                 "vat",
-                "service_tax",
             ]
         ]
         """

--- a/stripe/_invoice_line_item_service.py
+++ b/stripe/_invoice_line_item_service.py
@@ -213,7 +213,6 @@ class InvoiceLineItemService(StripeService):
                 "rst",
                 "sales_tax",
                 "vat",
-                "service_tax",
             ]
         ]
         """

--- a/stripe/_invoice_service.py
+++ b/stripe/_invoice_service.py
@@ -124,7 +124,7 @@ class InvoiceService(StripeService):
         Configuration settings for the PaymentIntent that is generated when the invoice is finalized.
         """
         pending_invoice_items_behavior: NotRequired[
-            Literal["exclude", "include", "include_and_require"]
+            Literal["exclude", "include"]
         ]
         """
         How to handle pending invoice items on invoice creation. Defaults to `exclude` if the parameter is omitted.

--- a/stripe/_payment_intent.py
+++ b/stripe/_payment_intent.py
@@ -3230,12 +3230,6 @@ class PaymentIntent(
         """
         Request ability to [increment](https://stripe.com/docs/terminal/features/incremental-authorizations) this PaymentIntent if the combination of MCC and card brand is eligible. Check [incremental_authorization_supported](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card_present-incremental_authorization_supported) in the [Confirm](https://stripe.com/docs/api/payment_intents/confirm) response to verify support.
         """
-        request_incremental_authorization: NotRequired[
-            Literal["if_available", "never"]
-        ]
-        """
-        This field was released by mistake and will be removed in the next major version
-        """
 
     class ConfirmParamsPaymentMethodOptionsCardThreeDSecure(TypedDict):
         ares_trans_status: NotRequired[
@@ -5371,12 +5365,6 @@ class PaymentIntent(
         """
         Request ability to [increment](https://stripe.com/docs/terminal/features/incremental-authorizations) this PaymentIntent if the combination of MCC and card brand is eligible. Check [incremental_authorization_supported](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card_present-incremental_authorization_supported) in the [Confirm](https://stripe.com/docs/api/payment_intents/confirm) response to verify support.
         """
-        request_incremental_authorization: NotRequired[
-            Literal["if_available", "never"]
-        ]
-        """
-        This field was released by mistake and will be removed in the next major version
-        """
 
     class CreateParamsPaymentMethodOptionsCardThreeDSecure(TypedDict):
         ares_trans_status: NotRequired[
@@ -7507,12 +7495,6 @@ class PaymentIntent(
         request_incremental_authorization_support: NotRequired[bool]
         """
         Request ability to [increment](https://stripe.com/docs/terminal/features/incremental-authorizations) this PaymentIntent if the combination of MCC and card brand is eligible. Check [incremental_authorization_supported](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card_present-incremental_authorization_supported) in the [Confirm](https://stripe.com/docs/api/payment_intents/confirm) response to verify support.
-        """
-        request_incremental_authorization: NotRequired[
-            Literal["if_available", "never"]
-        ]
-        """
-        This field was released by mistake and will be removed in the next major version
         """
 
     class ModifyParamsPaymentMethodOptionsCardThreeDSecure(TypedDict):

--- a/stripe/_payment_intent_service.py
+++ b/stripe/_payment_intent_service.py
@@ -1419,12 +1419,6 @@ class PaymentIntentService(StripeService):
         """
         Request ability to [increment](https://stripe.com/docs/terminal/features/incremental-authorizations) this PaymentIntent if the combination of MCC and card brand is eligible. Check [incremental_authorization_supported](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card_present-incremental_authorization_supported) in the [Confirm](https://stripe.com/docs/api/payment_intents/confirm) response to verify support.
         """
-        request_incremental_authorization: NotRequired[
-            Literal["if_available", "never"]
-        ]
-        """
-        This field was released by mistake and will be removed in the next major version
-        """
 
     class ConfirmParamsPaymentMethodOptionsCardThreeDSecure(TypedDict):
         ares_trans_status: NotRequired[
@@ -3583,12 +3577,6 @@ class PaymentIntentService(StripeService):
         request_incremental_authorization_support: NotRequired[bool]
         """
         Request ability to [increment](https://stripe.com/docs/terminal/features/incremental-authorizations) this PaymentIntent if the combination of MCC and card brand is eligible. Check [incremental_authorization_supported](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card_present-incremental_authorization_supported) in the [Confirm](https://stripe.com/docs/api/payment_intents/confirm) response to verify support.
-        """
-        request_incremental_authorization: NotRequired[
-            Literal["if_available", "never"]
-        ]
-        """
-        This field was released by mistake and will be removed in the next major version
         """
 
     class CreateParamsPaymentMethodOptionsCardThreeDSecure(TypedDict):
@@ -5772,12 +5760,6 @@ class PaymentIntentService(StripeService):
         request_incremental_authorization_support: NotRequired[bool]
         """
         Request ability to [increment](https://stripe.com/docs/terminal/features/incremental-authorizations) this PaymentIntent if the combination of MCC and card brand is eligible. Check [incremental_authorization_supported](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card_present-incremental_authorization_supported) in the [Confirm](https://stripe.com/docs/api/payment_intents/confirm) response to verify support.
-        """
-        request_incremental_authorization: NotRequired[
-            Literal["if_available", "never"]
-        ]
-        """
-        This field was released by mistake and will be removed in the next major version
         """
 
     class UpdateParamsPaymentMethodOptionsCardThreeDSecure(TypedDict):

--- a/stripe/_payment_method_configuration.py
+++ b/stripe/_payment_method_configuration.py
@@ -785,116 +785,6 @@ class PaymentMethodConfiguration(
         display_preference: DisplayPreference
         _inner_class_types = {"display_preference": DisplayPreference}
 
-    class IdBankTransfer(StripeObject):
-        class DisplayPreference(StripeObject):
-            overridable: Optional[bool]
-            """
-            For child configs, whether or not the account's preference will be observed. If `false`, the parent configuration's default is used.
-            """
-            preference: Literal["none", "off", "on"]
-            """
-            The account's display preference.
-            """
-            value: Literal["off", "on"]
-            """
-            The effective display preference value.
-            """
-
-        available: bool
-        """
-        Whether this payment method may be offered at checkout. True if `display_preference` is `on` and the payment method's capability is active.
-        """
-        display_preference: DisplayPreference
-        _inner_class_types = {"display_preference": DisplayPreference}
-
-    class Multibanco(StripeObject):
-        class DisplayPreference(StripeObject):
-            overridable: Optional[bool]
-            """
-            For child configs, whether or not the account's preference will be observed. If `false`, the parent configuration's default is used.
-            """
-            preference: Literal["none", "off", "on"]
-            """
-            The account's display preference.
-            """
-            value: Literal["off", "on"]
-            """
-            The effective display preference value.
-            """
-
-        available: bool
-        """
-        Whether this payment method may be offered at checkout. True if `display_preference` is `on` and the payment method's capability is active.
-        """
-        display_preference: DisplayPreference
-        _inner_class_types = {"display_preference": DisplayPreference}
-
-    class Netbanking(StripeObject):
-        class DisplayPreference(StripeObject):
-            overridable: Optional[bool]
-            """
-            For child configs, whether or not the account's preference will be observed. If `false`, the parent configuration's default is used.
-            """
-            preference: Literal["none", "off", "on"]
-            """
-            The account's display preference.
-            """
-            value: Literal["off", "on"]
-            """
-            The effective display preference value.
-            """
-
-        available: bool
-        """
-        Whether this payment method may be offered at checkout. True if `display_preference` is `on` and the payment method's capability is active.
-        """
-        display_preference: DisplayPreference
-        _inner_class_types = {"display_preference": DisplayPreference}
-
-    class PayByBank(StripeObject):
-        class DisplayPreference(StripeObject):
-            overridable: Optional[bool]
-            """
-            For child configs, whether or not the account's preference will be observed. If `false`, the parent configuration's default is used.
-            """
-            preference: Literal["none", "off", "on"]
-            """
-            The account's display preference.
-            """
-            value: Literal["off", "on"]
-            """
-            The effective display preference value.
-            """
-
-        available: bool
-        """
-        Whether this payment method may be offered at checkout. True if `display_preference` is `on` and the payment method's capability is active.
-        """
-        display_preference: DisplayPreference
-        _inner_class_types = {"display_preference": DisplayPreference}
-
-    class Upi(StripeObject):
-        class DisplayPreference(StripeObject):
-            overridable: Optional[bool]
-            """
-            For child configs, whether or not the account's preference will be observed. If `false`, the parent configuration's default is used.
-            """
-            preference: Literal["none", "off", "on"]
-            """
-            The account's display preference.
-            """
-            value: Literal["off", "on"]
-            """
-            The effective display preference value.
-            """
-
-        available: bool
-        """
-        Whether this payment method may be offered at checkout. True if `display_preference` is `on` and the payment method's capability is active.
-        """
-        display_preference: DisplayPreference
-        _inner_class_types = {"display_preference": DisplayPreference}
-
     class CreateParams(RequestOptions):
         acss_debit: NotRequired[
             "PaymentMethodConfiguration.CreateParamsAcssDebit"
@@ -2325,11 +2215,6 @@ class PaymentMethodConfiguration(
     sofort: Optional[Sofort]
     us_bank_account: Optional[UsBankAccount]
     wechat_pay: Optional[WechatPay]
-    id_bank_transfer: Optional[IdBankTransfer]
-    multibanco: Optional[Multibanco]
-    netbanking: Optional[Netbanking]
-    pay_by_bank: Optional[PayByBank]
-    upi: Optional[Upi]
 
     @classmethod
     def create(
@@ -2435,9 +2320,4 @@ class PaymentMethodConfiguration(
         "sofort": Sofort,
         "us_bank_account": UsBankAccount,
         "wechat_pay": WechatPay,
-        "id_bank_transfer": IdBankTransfer,
-        "multibanco": Multibanco,
-        "netbanking": Netbanking,
-        "pay_by_bank": PayByBank,
-        "upi": Upi,
     }

--- a/stripe/_setup_intent.py
+++ b/stripe/_setup_intent.py
@@ -520,7 +520,7 @@ class SetupIntent(
             Selected network to process this SetupIntent on. Depends on the available networks of the card attached to the setup intent. Can be only set confirm-time.
             """
             request_three_d_secure: Optional[
-                Literal["any", "automatic", "challenge", "challenge_only"]
+                Literal["any", "automatic", "challenge"]
             ]
             """
             We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. If not provided, this value defaults to `automatic`. Read our guide on [manually requesting 3D Secure](https://stripe.com/docs/payments/3d-secure/authentication-flow#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine.

--- a/stripe/_tax_rate.py
+++ b/stripe/_tax_rate.py
@@ -78,7 +78,6 @@ class TaxRate(
                 "rst",
                 "sales_tax",
                 "vat",
-                "service_tax",
             ]
         ]
         """
@@ -180,7 +179,6 @@ class TaxRate(
                 "rst",
                 "sales_tax",
                 "vat",
-                "service_tax",
             ]
         ]
         """
@@ -271,7 +269,6 @@ class TaxRate(
             "rst",
             "sales_tax",
             "vat",
-            "service_tax",
         ]
     ]
     """

--- a/stripe/_tax_rate_service.py
+++ b/stripe/_tax_rate_service.py
@@ -65,7 +65,6 @@ class TaxRateService(StripeService):
                 "rst",
                 "sales_tax",
                 "vat",
-                "service_tax",
             ]
         ]
         """
@@ -173,7 +172,6 @@ class TaxRateService(StripeService):
                 "rst",
                 "sales_tax",
                 "vat",
-                "service_tax",
             ]
         ]
         """

--- a/stripe/_webhook_endpoint.py
+++ b/stripe/_webhook_endpoint.py
@@ -374,14 +374,6 @@ class WebhookEndpoint(
                 "treasury.received_credit.failed",
                 "treasury.received_credit.succeeded",
                 "treasury.received_debit.created",
-                "invoiceitem.updated",
-                "order.created",
-                "recipient.created",
-                "recipient.deleted",
-                "recipient.updated",
-                "sku.created",
-                "sku.deleted",
-                "sku.updated",
             ]
         ]
         """
@@ -660,14 +652,6 @@ class WebhookEndpoint(
                     "treasury.received_credit.failed",
                     "treasury.received_credit.succeeded",
                     "treasury.received_debit.created",
-                    "invoiceitem.updated",
-                    "order.created",
-                    "recipient.created",
-                    "recipient.deleted",
-                    "recipient.updated",
-                    "sku.created",
-                    "sku.deleted",
-                    "sku.updated",
                 ]
             ]
         ]

--- a/stripe/_webhook_endpoint_service.py
+++ b/stripe/_webhook_endpoint_service.py
@@ -355,14 +355,6 @@ class WebhookEndpointService(StripeService):
                 "treasury.received_credit.failed",
                 "treasury.received_credit.succeeded",
                 "treasury.received_debit.created",
-                "invoiceitem.updated",
-                "order.created",
-                "recipient.created",
-                "recipient.deleted",
-                "recipient.updated",
-                "sku.created",
-                "sku.deleted",
-                "sku.updated",
             ]
         ]
         """
@@ -647,14 +639,6 @@ class WebhookEndpointService(StripeService):
                     "treasury.received_credit.failed",
                     "treasury.received_credit.succeeded",
                     "treasury.received_debit.created",
-                    "invoiceitem.updated",
-                    "order.created",
-                    "recipient.created",
-                    "recipient.deleted",
-                    "recipient.updated",
-                    "sku.created",
-                    "sku.deleted",
-                    "sku.updated",
                 ]
             ]
         ]

--- a/stripe/climate/_supplier.py
+++ b/stripe/climate/_supplier.py
@@ -89,7 +89,6 @@ class Supplier(ListableAPIResource["Supplier"]):
         "biomass_carbon_removal_and_storage",
         "direct_air_capture",
         "enhanced_weathering",
-        "various",
     ]
     """
     The scientific pathway used for carbon removal.

--- a/stripe/reporting/_report_run.py
+++ b/stripe/reporting/_report_run.py
@@ -149,7 +149,6 @@ class ReportRun(
                 "transfer",
                 "transfer_reversal",
                 "unreconciled_customer_funds",
-                "obligation",
             ]
         ]
         """

--- a/stripe/reporting/_report_run_service.py
+++ b/stripe/reporting/_report_run_service.py
@@ -88,7 +88,6 @@ class ReportRunService(StripeService):
                 "transfer",
                 "transfer_reversal",
                 "unreconciled_customer_funds",
-                "obligation",
             ]
         ]
         """


### PR DESCRIPTION
This PR contains the changes generated after removing the shared overrides from our code generator that were added for backcompat

## Changelog

 * Remove the below deprecated values for `BalanceTransaction.type`
    * `obligation_inbound`
    * `obligation_payout`
    * `obligation_payout_failure`
    * `obligation_reversal_outbound`
 * Remove the below deprecated events from `Event.type`, `WebhookEndpoint.CreateParams.enabled_events`, `WebhookEndpoint.ModifyParams.enabled_events`, `WebhookEndpointService.CreateParams.enabled_events`, `WebhookEndpointService.ModifyParams.enabled_events`
   * `invoiceitem.updated`
   * `order.created`
   * `recipient.created`
   * `recipient.deleted`
   * `recipient.updated`
   * `sku.created`
   * `sku.deleted`
   * `sku.updated`
 * Remove the deprecated value `include_and_require` for `Invoice.CreateParams.pending_invoice_items_behavior` and `InvoiceService.CreateParams.pending_invoice_items_behavior`
 * Remove the deprecated value `service_tax` for 
   * `TaxRate.RetrieveParams.tax_type`
   * `TaxRate.CreateParams.tax_type`
   * `TaxRate.ModifyParams.tax_type`
   * `TaxRateService.CreateParams.tax_type`
   * `TaxRateService.UpdateParams.tax_type`
   * `InvoiceLineItem.ModifyParamsTaxAmountTaxRateData.tax_type`
   * `InvoiceLineItemService.UpdateParamsTaxAmountTaxRateData.tax_type` 
 * Remove `request_incremental_authorization` from 
   * `PaymentIntent.ConfirmParamsPaymentMethodOptionsCardPresent`
   * `PaymentIntent.CreateParamsPaymentMethodOptionsCardPresent` 
   * `PaymentIntent.ModifyParamsPaymentMethodOptionsCardPresent`
   * `PaymentIntentService.ConfirmParamsPaymentMethodOptionsCardPresent`
   * `PaymentIntentService.CreateParamsPaymentMethodOptionsCardPresent` 
   * `PaymentIntentService.ModifyParamsPaymentMethodOptionsCardPresent`
 * Remove support for `id_bank_transfer`, `multibanco`, `netbanking`, `pay_by_bank`, and `upi` on `PaymentMethodConfiguration`
 * Remove the deprecated value `challenge_only` from `SetupIntent.PaymentMethodOptions.Card.request_three_d_secure`
 * Remove deprecated value `various` for `Climate.Supplier.removal_pathway` 
 * Remove the deprecated value `obligation` for `ReportRun.CreateParamsParameters.reporting_category` and `ReportRunService.CreateParamsParameters.reporting_category`
 

 
 