### PR TITLE
Fix: Quote PDF retrieve base_address set to files

### DIFF
--- a/stripe/_quote.py
+++ b/stripe/_quote.py
@@ -1835,6 +1835,7 @@ class Quote(
                     quote=sanitize_id(self.get("id"))
                 ),
                 params=params,
+                base_address="files",
             ),
         )
 
@@ -1887,6 +1888,7 @@ class Quote(
                     quote=sanitize_id(self.get("id"))
                 ),
                 params=params,
+                base_address="files",
             ),
         )
 


### PR DESCRIPTION
Quote PDF urls now return a stream of bytes instead of throwing an error.

Fixes: https://github.com/stripe/stripe-python/issues/1303