### PR TITLE
Removed deprecated parameter util

### DIFF
--- a/stripe/_util.py
+++ b/stripe/_util.py
@@ -433,36 +433,3 @@ class class_method_variant(object):
                 return class_method(*args, **kwargs)
 
         return _wrapper
-
-
-def stripe_deprecate_param_inner(params: Mapping[str, Any], parts: List[str]):
-    cur = params
-    for i, part in enumerate(parts[:-1]):
-        if type(cur[part]) is list:
-            for item in cur[part]:
-                new_i = i + 1
-                stripe_deprecate_param_inner(item, parts[new_i:])
-        if part not in cur:
-            return
-
-        cur = cur[part]
-
-    deprecated_param = parts[-1]
-    if deprecated_param in cur:
-        warnings.warn(
-            f"The {deprecated_param} parameter is deprecated and will be removed in a future version. "
-            "Please refer to the changelog for more information.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-
-def stripe_deprecate_parameter(key):
-    def stripe_deprecate_param_decorator(original_function):
-        def stripe_deprecate_param(params, *args, **kwargs):
-            stripe_deprecate_param_inner(params, key.split("."))
-            return original_function(params=params, *args, **kwargs)
-
-        return stripe_deprecate_param
-
-    return stripe_deprecate_param_decorator

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,8 +3,6 @@ from collections import namedtuple
 
 import stripe
 from stripe import util
-import pytest
-import warnings
 
 LogTestCase = namedtuple("LogTestCase", "env flag should_output")
 FmtTestCase = namedtuple("FmtTestCase", "props expected")
@@ -152,53 +150,3 @@ class TestUtil(object):
     def test_sanitize_id(self):
         sanitized_id = util.sanitize_id("cu  %x 123")
         assert sanitized_id == "cu++%25x+123"
-
-    def test_stripe_deprecate_parameter(self):
-        @util.stripe_deprecate_parameter("foo")
-        def to_be_decorated(**params):
-            pass
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
-            to_be_decorated(params={})
-
-        # assert that warnings.warn was called appropriately
-        with pytest.warns(DeprecationWarning):
-            to_be_decorated(params={"foo": True})
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
-            to_be_decorated(params={})
-
-        @util.stripe_deprecate_parameter("bar")
-        def to_be_decorated_non_existant_key(**params):
-            pass
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
-            to_be_decorated_non_existant_key(params={"foo": True})
-
-        @util.stripe_deprecate_parameter("")
-        def to_be_decorated_empty_key(**params):
-            pass
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
-            to_be_decorated_empty_key(params={"foo": True})
-
-    def test_stripe_deprecate_param_nested(self):
-        @util.stripe_deprecate_parameter("foo.bar")
-        def to_be_decorated_foo_bar(**params):
-            pass
-
-        with pytest.warns(DeprecationWarning):
-            to_be_decorated_foo_bar(params={"foo": {"bar": True}})
-
-        @util.stripe_deprecate_parameter("custom_fields.name")
-        def to_be_decorated_custom_fields_name(**params):
-            pass
-
-        with pytest.warns(DeprecationWarning):
-            to_be_decorated_custom_fields_name(
-                params={"custom_fields": [{"name": "blah"}]}
-            )


### PR DESCRIPTION
We surveyed and found out the developers rarely read warning logs. They might not find this as helpful as IDE warnings. Hence rolling it back. 

No usages in code. Does this need a changelog?