### PR TITLE
Add lint rule to ensure `async` functions are named `X_async`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,7 +9,7 @@ per-file-ignores =
     */__init__.py: IMP100, E402, F401
     # we test various import patterns
     tests/test_exports.py: IMP100, IMP101, IMP102
-    tests/*: IMP101, IMP102, BAN100
+    tests/*: IMP101, IMP102, BAN100, ASY100
     # backcompat with outdated import patterns
     stripe/api_resources/*: IMP100, E402, F401
 
@@ -37,4 +37,5 @@ extension =
     SPY = flake8_stripe:TypingImportsChecker
     IMP = flake8_stripe:StripeImportsChecker
     BAN = flake8_stripe:BanPublicMethodsChecker
+    ASY = flake8_stripe:AsyncNamingConventions
 paths=./flake8_stripe

--- a/flake8_stripe/flake8_stripe.py
+++ b/flake8_stripe/flake8_stripe.py
@@ -236,9 +236,15 @@ class AsyncNamingConventions:
 
     def run(self) -> Iterator[Tuple[int, int, str, type]]:
         for node in ast.walk(self.tree):
-            if isinstance(
-                node, ast.AsyncFunctionDef
-            ) and not node.name.endswith("_async"):
+            # ignore anything that isn't an async function declaration
+            if not isinstance(node, ast.AsyncFunctionDef):
+                continue
+
+            # dunders need specific names, so don't worry about them
+            if node.name.startswith("__") and node.name.endswith("__"):
+                continue
+
+            if not node.name.endswith("_async"):
                 yield (
                     node.lineno,
                     node.col_offset,

--- a/flake8_stripe/flake8_stripe.py
+++ b/flake8_stripe/flake8_stripe.py
@@ -224,3 +224,24 @@ class BanPublicMethodsChecker:
                         msg,
                         type(self),
                     )
+
+
+class AsyncNamingConventions:
+    name = __name__
+    version = "0.1.0"
+
+    def __init__(self, tree: ast.AST, filename: str):
+        self.tree = tree
+        self.filename = filename
+
+    def run(self) -> Iterator[Tuple[int, int, str, type]]:
+        for node in ast.walk(self.tree):
+            if isinstance(
+                node, ast.AsyncFunctionDef
+            ) and not node.name.endswith("_async"):
+                yield (
+                    node.lineno,
+                    node.col_offset,
+                    "ASY100 Async methods must be named X_async",
+                    type(self),
+                )

--- a/stripe/_any_iterator.py
+++ b/stripe/_any_iterator.py
@@ -25,7 +25,7 @@ class AnyIterator(Iterator[T], AsyncIterator[T]):
         self._sync_iterated = True
         return self._iterator.__next__()
 
-    async def __anext__(self) -> T:
+    async def __anext__(self) -> T:  # noqa: ASY100
         if self._sync_iterated:
             raise RuntimeError(
                 "AnyIterator error: cannot mix sync and async iteration"

--- a/stripe/_any_iterator.py
+++ b/stripe/_any_iterator.py
@@ -25,7 +25,7 @@ class AnyIterator(Iterator[T], AsyncIterator[T]):
         self._sync_iterated = True
         return self._iterator.__next__()
 
-    async def __anext__(self) -> T:  # noqa: ASY100
+    async def __anext__(self) -> T:
         if self._sync_iterated:
             raise RuntimeError(
                 "AnyIterator error: cannot mix sync and async iteration"

--- a/stripe/_stripe_response.py
+++ b/stripe/_stripe_response.py
@@ -61,5 +61,5 @@ class StripeStreamResponseAsync(StripeResponseBase):
     def stream(self) -> AsyncIterable[bytes]:
         return self._stream
 
-    async def read(self) -> bytes:
+    async def read(self) -> bytes:  # noqa: ASY100
         return b"".join([chunk async for chunk in self._stream])

--- a/stripe/_stripe_response.py
+++ b/stripe/_stripe_response.py
@@ -61,5 +61,6 @@ class StripeStreamResponseAsync(StripeResponseBase):
     def stream(self) -> AsyncIterable[bytes]:
         return self._stream
 
+    # TODO (MAJOR): rename this to `read_async`
     async def read(self) -> bytes:  # noqa: ASY100
         return b"".join([chunk async for chunk in self._stream])


### PR DESCRIPTION
This came from a discussion in https://github.com/stripe/stripe-python/pull/1165#discussion_r1427214415

I exempted 1 existing function (`StripeStreamResponseAsync.read`). We could rename it, but I don't have a good sense of how breaking that is, so it's not urgent. 

This should catch future things though!