### PR TITLE
Switch from `black` to `ruff` for formatting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,7 +4,9 @@
 # length, but can go over in some cases.
 # W503 goes against PEP8 rules. It's disabled by default, but must be disabled
 # explicitly when using `ignore`.
-ignore = E501, W503
+# E704 is disabled in the default configuration, but by specifying `ignore`, we wipe that out.
+# ruff formatting creates code that violates it, so we have to disable it manually
+ignore = E501, W503, E704
 per-file-ignores =
     */__init__.py: IMP100, E402, F401
     # we test various import patterns

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# mass formatted w/ ruff (2024-05-10)
+c46b4b950ea77e9d18ab98885cda721b3de247c0

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,5 +3,6 @@
     "ms-python.python",
     "EditorConfig.editorconfig",
     "ms-python.flake8",
+    "charliermarsh.ruff"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ Run the linter with:
 make lint
 ```
 
-The library uses [Black][black] for code formatting. Code must be formatted
+The library uses [Ruff][ruff] for code formatting. Code must be formatted
 with Black before PRs are submitted, otherwise CI will fail. Run the formatter
 with:
 
@@ -378,7 +378,7 @@ make fmt
 ```
 
 [api-keys]: https://dashboard.stripe.com/account/apikeys
-[black]: https://github.com/ambv/black
+[ruff]: https://github.com/astral-sh/ruff
 [connect]: https://stripe.com/connect
 [poetry]: https://github.com/sdispater/poetry
 [stripe-mock]: https://github.com/stripe/stripe-mock

--- a/examples/oauth.py
+++ b/examples/oauth.py
@@ -33,9 +33,7 @@ def callback():
 <p>Success! Account <code>{stripe_user_id}</code> is connected.</p>
 <p>Click <a href="/deauthorize?stripe_user_id={stripe_user_id}">here</a> to
 disconnect the account.</p>
-""".format(
-        stripe_user_id=resp["stripe_user_id"]
-    )
+""".format(stripe_user_id=resp["stripe_user_id"])
 
 
 @app.route("/deauthorize")
@@ -49,9 +47,7 @@ def deauthorize():
     return """
 <p>Success! Account <code>{stripe_user_id}</code> is disconnected.</p>
 <p>Click <a href="/">here</a> to restart the OAuth flow.</p>
-""".format(
-        stripe_user_id=stripe_user_id
-    )
+""".format(stripe_user_id=stripe_user_id)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,33 +1,18 @@
-[tool.black]
+[tool.ruff]
+# same as our black config
 line-length = 79
-target-version = [
-  "py35",
-  "py36",
-  "py37",
-  "py38",
-  "py39",
-  "py310",
-  #   "py311",  # black 21.12b0 doesn't
-  #   "py312",  # support these targets
-]
-exclude = '''
-/(
-    \.eggs/
-  | \.git/
-  | \.tox/
-  | \.venv/
-  | _build/
-  | build/
-  | dist/
-  | venv/
-)
-'''
+extend-exclude = ["build"]
+
+[tool.ruff.format]
+# currently the default value, but opt-out in the future
+docstring-code-format = false
+
 [tool.pyright]
 include = [
   "stripe",
   "tests/test_generated_examples.py",
   "tests/test_exports.py",
-  "tests/test_http_client.py"
+  "tests/test_http_client.py",
 ]
 exclude = ["build", "**/__pycache__"]
 reportMissingTypeArgument = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ tox == 4.5.0
 #Virtualenv 20.22.0 dropped support for all Python versions smaller or equal to Python 3.6.
 virtualenv<20.22.0
 pyright == 1.1.336
-black == 22.8.0
+ruff == 0.4.4
 flake8
 mypy == 1.7.0
 

--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -528,5 +528,4 @@ from stripe._webhook_endpoint import WebhookEndpoint as WebhookEndpoint
 from stripe._webhook_endpoint_service import (
     WebhookEndpointService as WebhookEndpointService,
 )
-
 # The end of the section generated from our OpenAPI spec

--- a/stripe/_account.py
+++ b/stripe/_account.py
@@ -4004,7 +4004,6 @@ class Account(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -4025,7 +4024,6 @@ class Account(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -4322,7 +4320,7 @@ class Account(
         cls,
         account: str,
         capability: str,
-        **params: Unpack["Account.RetrieveCapabilityParams"]
+        **params: Unpack["Account.RetrieveCapabilityParams"],
     ) -> "Capability":
         """
         Retrieves information about the specified Account Capability.
@@ -4344,7 +4342,7 @@ class Account(
         cls,
         account: str,
         capability: str,
-        **params: Unpack["Account.RetrieveCapabilityParams"]
+        **params: Unpack["Account.RetrieveCapabilityParams"],
     ) -> "Capability":
         """
         Retrieves information about the specified Account Capability.
@@ -4366,7 +4364,7 @@ class Account(
         cls,
         account: str,
         capability: str,
-        **params: Unpack["Account.ModifyCapabilityParams"]
+        **params: Unpack["Account.ModifyCapabilityParams"],
     ) -> "Capability":
         """
         Updates an existing Account Capability. Request or remove a capability by updating its requested parameter.
@@ -4388,7 +4386,7 @@ class Account(
         cls,
         account: str,
         capability: str,
-        **params: Unpack["Account.ModifyCapabilityParams"]
+        **params: Unpack["Account.ModifyCapabilityParams"],
     ) -> "Capability":
         """
         Updates an existing Account Capability. Request or remove a capability by updating its requested parameter.
@@ -4445,7 +4443,7 @@ class Account(
     def create_external_account(
         cls,
         account: str,
-        **params: Unpack["Account.CreateExternalAccountParams"]
+        **params: Unpack["Account.CreateExternalAccountParams"],
     ) -> Union["BankAccount", "Card"]:
         """
         Create an external account for a given account.
@@ -4465,7 +4463,7 @@ class Account(
     async def create_external_account_async(
         cls,
         account: str,
-        **params: Unpack["Account.CreateExternalAccountParams"]
+        **params: Unpack["Account.CreateExternalAccountParams"],
     ) -> Union["BankAccount", "Card"]:
         """
         Create an external account for a given account.
@@ -4486,7 +4484,7 @@ class Account(
         cls,
         account: str,
         id: str,
-        **params: Unpack["Account.RetrieveExternalAccountParams"]
+        **params: Unpack["Account.RetrieveExternalAccountParams"],
     ) -> Union["BankAccount", "Card"]:
         """
         Retrieve a specified external account for a given account.
@@ -4507,7 +4505,7 @@ class Account(
         cls,
         account: str,
         id: str,
-        **params: Unpack["Account.RetrieveExternalAccountParams"]
+        **params: Unpack["Account.RetrieveExternalAccountParams"],
     ) -> Union["BankAccount", "Card"]:
         """
         Retrieve a specified external account for a given account.
@@ -4528,7 +4526,7 @@ class Account(
         cls,
         account: str,
         id: str,
-        **params: Unpack["Account.ModifyExternalAccountParams"]
+        **params: Unpack["Account.ModifyExternalAccountParams"],
     ) -> Union["BankAccount", "Card"]:
         """
         Updates the metadata, account holder name, account holder type of a bank account belonging to
@@ -4556,7 +4554,7 @@ class Account(
         cls,
         account: str,
         id: str,
-        **params: Unpack["Account.ModifyExternalAccountParams"]
+        **params: Unpack["Account.ModifyExternalAccountParams"],
     ) -> Union["BankAccount", "Card"]:
         """
         Updates the metadata, account holder name, account holder type of a bank account belonging to
@@ -4584,7 +4582,7 @@ class Account(
         cls,
         account: str,
         id: str,
-        **params: Unpack["Account.DeleteExternalAccountParams"]
+        **params: Unpack["Account.DeleteExternalAccountParams"],
     ) -> Union["BankAccount", "Card"]:
         """
         Delete a specified external account for a given account.
@@ -4605,7 +4603,7 @@ class Account(
         cls,
         account: str,
         id: str,
-        **params: Unpack["Account.DeleteExternalAccountParams"]
+        **params: Unpack["Account.DeleteExternalAccountParams"],
     ) -> Union["BankAccount", "Card"]:
         """
         Delete a specified external account for a given account.
@@ -4625,7 +4623,7 @@ class Account(
     def list_external_accounts(
         cls,
         account: str,
-        **params: Unpack["Account.ListExternalAccountsParams"]
+        **params: Unpack["Account.ListExternalAccountsParams"],
     ) -> ListObject[Union["BankAccount", "Card"]]:
         """
         List external accounts for an account.
@@ -4645,7 +4643,7 @@ class Account(
     async def list_external_accounts_async(
         cls,
         account: str,
-        **params: Unpack["Account.ListExternalAccountsParams"]
+        **params: Unpack["Account.ListExternalAccountsParams"],
     ) -> ListObject[Union["BankAccount", "Card"]]:
         """
         List external accounts for an account.
@@ -4742,7 +4740,7 @@ class Account(
         cls,
         account: str,
         person: str,
-        **params: Unpack["Account.RetrievePersonParams"]
+        **params: Unpack["Account.RetrievePersonParams"],
     ) -> "Person":
         """
         Retrieves an existing person.
@@ -4763,7 +4761,7 @@ class Account(
         cls,
         account: str,
         person: str,
-        **params: Unpack["Account.RetrievePersonParams"]
+        **params: Unpack["Account.RetrievePersonParams"],
     ) -> "Person":
         """
         Retrieves an existing person.
@@ -4784,7 +4782,7 @@ class Account(
         cls,
         account: str,
         person: str,
-        **params: Unpack["Account.ModifyPersonParams"]
+        **params: Unpack["Account.ModifyPersonParams"],
     ) -> "Person":
         """
         Updates an existing person.
@@ -4805,7 +4803,7 @@ class Account(
         cls,
         account: str,
         person: str,
-        **params: Unpack["Account.ModifyPersonParams"]
+        **params: Unpack["Account.ModifyPersonParams"],
     ) -> "Person":
         """
         Updates an existing person.
@@ -4826,7 +4824,7 @@ class Account(
         cls,
         account: str,
         person: str,
-        **params: Unpack["Account.DeletePersonParams"]
+        **params: Unpack["Account.DeletePersonParams"],
     ) -> "Person":
         """
         Deletes an existing person's relationship to the account's legal entity. Any person with a relationship for an account can be deleted through the API, except if the person is the account_opener. If your integration is using the executive parameter, you cannot delete the only verified executive on file.
@@ -4847,7 +4845,7 @@ class Account(
         cls,
         account: str,
         person: str,
-        **params: Unpack["Account.DeletePersonParams"]
+        **params: Unpack["Account.DeletePersonParams"],
     ) -> "Person":
         """
         Deletes an existing person's relationship to the account's legal entity. Any person with a relationship for an account can be deleted through the API, except if the person is the account_opener. If your integration is using the executive parameter, you cannot delete the only verified executive on file.

--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -511,9 +511,9 @@ class _APIRequestor(object):
                 generator = MultipartDataGenerator()
                 generator.add_params(params or {})
                 post_data = generator.get_post_data()
-                headers[
-                    "Content-Type"
-                ] = "multipart/form-data; boundary=%s" % (generator.boundary,)
+                headers["Content-Type"] = (
+                    "multipart/form-data; boundary=%s" % (generator.boundary,)
+                )
             else:
                 post_data = encoded_body
         else:

--- a/stripe/_apple_pay_domain.py
+++ b/stripe/_apple_pay_domain.py
@@ -217,7 +217,6 @@ class ApplePayDomain(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -238,7 +237,6 @@ class ApplePayDomain(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_application_fee.py
+++ b/stripe/_application_fee.py
@@ -209,7 +209,6 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -230,7 +229,6 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -483,7 +481,7 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
         cls,
         fee: str,
         id: str,
-        **params: Unpack["ApplicationFee.RetrieveRefundParams"]
+        **params: Unpack["ApplicationFee.RetrieveRefundParams"],
     ) -> "ApplicationFeeRefund":
         """
         By default, you can see the 10 most recent refunds stored directly on the application fee object, but you can also retrieve details about a specific refund stored on the application fee.
@@ -504,7 +502,7 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
         cls,
         fee: str,
         id: str,
-        **params: Unpack["ApplicationFee.RetrieveRefundParams"]
+        **params: Unpack["ApplicationFee.RetrieveRefundParams"],
     ) -> "ApplicationFeeRefund":
         """
         By default, you can see the 10 most recent refunds stored directly on the application fee object, but you can also retrieve details about a specific refund stored on the application fee.
@@ -525,7 +523,7 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
         cls,
         fee: str,
         id: str,
-        **params: Unpack["ApplicationFee.ModifyRefundParams"]
+        **params: Unpack["ApplicationFee.ModifyRefundParams"],
     ) -> "ApplicationFeeRefund":
         """
         Updates the specified application fee refund by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
@@ -548,7 +546,7 @@ class ApplicationFee(ListableAPIResource["ApplicationFee"]):
         cls,
         fee: str,
         id: str,
-        **params: Unpack["ApplicationFee.ModifyRefundParams"]
+        **params: Unpack["ApplicationFee.ModifyRefundParams"],
     ) -> "ApplicationFeeRefund":
         """
         Updates the specified application fee refund by setting the values of the parameters passed. Any parameters not provided will be left unchanged.

--- a/stripe/_balance_transaction.py
+++ b/stripe/_balance_transaction.py
@@ -44,9 +44,9 @@ class BalanceTransaction(ListableAPIResource["BalanceTransaction"]):
     Related guide: [Balance transaction types](https://stripe.com/docs/reports/balance-transaction-types)
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["balance_transaction"]
-    ] = "balance_transaction"
+    OBJECT_NAME: ClassVar[Literal["balance_transaction"]] = (
+        "balance_transaction"
+    )
 
     class FeeDetail(StripeObject):
         amount: int
@@ -271,7 +271,6 @@ class BalanceTransaction(ListableAPIResource["BalanceTransaction"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -294,7 +293,6 @@ class BalanceTransaction(ListableAPIResource["BalanceTransaction"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_charge.py
+++ b/stripe/_charge.py
@@ -2486,7 +2486,6 @@ class Charge(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -2507,7 +2506,6 @@ class Charge(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -2632,7 +2630,7 @@ class Charge(
         cls,
         charge: str,
         refund: str,
-        **params: Unpack["Charge.RetrieveRefundParams"]
+        **params: Unpack["Charge.RetrieveRefundParams"],
     ) -> "Refund":
         """
         Retrieves the details of an existing refund.
@@ -2653,7 +2651,7 @@ class Charge(
         cls,
         charge: str,
         refund: str,
-        **params: Unpack["Charge.RetrieveRefundParams"]
+        **params: Unpack["Charge.RetrieveRefundParams"],
     ) -> "Refund":
         """
         Retrieves the details of an existing refund.

--- a/stripe/_connect_collection_transfer.py
+++ b/stripe/_connect_collection_transfer.py
@@ -10,9 +10,9 @@ if TYPE_CHECKING:
 
 
 class ConnectCollectionTransfer(StripeObject):
-    OBJECT_NAME: ClassVar[
-        Literal["connect_collection_transfer"]
-    ] = "connect_collection_transfer"
+    OBJECT_NAME: ClassVar[Literal["connect_collection_transfer"]] = (
+        "connect_collection_transfer"
+    )
     amount: int
     """
     Amount transferred, in cents (or local equivalent).

--- a/stripe/_country_spec.py
+++ b/stripe/_country_spec.py
@@ -112,7 +112,6 @@ class CountrySpec(ListableAPIResource["CountrySpec"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -133,7 +132,6 @@ class CountrySpec(ListableAPIResource["CountrySpec"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_coupon.py
+++ b/stripe/_coupon.py
@@ -392,7 +392,6 @@ class Coupon(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -413,7 +412,6 @@ class Coupon(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_credit_note.py
+++ b/stripe/_credit_note.py
@@ -819,7 +819,6 @@ class CreditNote(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -840,7 +839,6 @@ class CreditNote(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_credit_note_line_item.py
+++ b/stripe/_credit_note_line_item.py
@@ -15,9 +15,9 @@ class CreditNoteLineItem(StripeObject):
     The credit note line item object
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["credit_note_line_item"]
-    ] = "credit_note_line_item"
+    OBJECT_NAME: ClassVar[Literal["credit_note_line_item"]] = (
+        "credit_note_line_item"
+    )
 
     class DiscountAmount(StripeObject):
         amount: int

--- a/stripe/_customer.py
+++ b/stripe/_customer.py
@@ -1469,7 +1469,7 @@ class Customer(
     def _cls_create_funding_instructions(
         cls,
         customer: str,
-        **params: Unpack["Customer.CreateFundingInstructionsParams"]
+        **params: Unpack["Customer.CreateFundingInstructionsParams"],
     ) -> "FundingInstructions":
         """
         Retrieve funding instructions for a customer cash balance. If funding instructions do not yet exist for the customer, new
@@ -1491,7 +1491,7 @@ class Customer(
     @staticmethod
     def create_funding_instructions(
         customer: str,
-        **params: Unpack["Customer.CreateFundingInstructionsParams"]
+        **params: Unpack["Customer.CreateFundingInstructionsParams"],
     ) -> "FundingInstructions":
         """
         Retrieve funding instructions for a customer cash balance. If funding instructions do not yet exist for the customer, new
@@ -1535,7 +1535,7 @@ class Customer(
     async def _cls_create_funding_instructions_async(
         cls,
         customer: str,
-        **params: Unpack["Customer.CreateFundingInstructionsParams"]
+        **params: Unpack["Customer.CreateFundingInstructionsParams"],
     ) -> "FundingInstructions":
         """
         Retrieve funding instructions for a customer cash balance. If funding instructions do not yet exist for the customer, new
@@ -1557,7 +1557,7 @@ class Customer(
     @staticmethod
     async def create_funding_instructions_async(
         customer: str,
-        **params: Unpack["Customer.CreateFundingInstructionsParams"]
+        **params: Unpack["Customer.CreateFundingInstructionsParams"],
     ) -> "FundingInstructions":
         """
         Retrieve funding instructions for a customer cash balance. If funding instructions do not yet exist for the customer, new
@@ -1816,7 +1816,6 @@ class Customer(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -1837,7 +1836,6 @@ class Customer(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -1849,7 +1847,7 @@ class Customer(
     def _cls_list_payment_methods(
         cls,
         customer: str,
-        **params: Unpack["Customer.ListPaymentMethodsParams"]
+        **params: Unpack["Customer.ListPaymentMethodsParams"],
     ) -> ListObject["PaymentMethod"]:
         """
         Returns a list of PaymentMethods for a given Customer
@@ -1906,7 +1904,7 @@ class Customer(
     async def _cls_list_payment_methods_async(
         cls,
         customer: str,
-        **params: Unpack["Customer.ListPaymentMethodsParams"]
+        **params: Unpack["Customer.ListPaymentMethodsParams"],
     ) -> ListObject["PaymentMethod"]:
         """
         Returns a list of PaymentMethods for a given Customer
@@ -2024,7 +2022,7 @@ class Customer(
         cls,
         customer: str,
         payment_method: str,
-        **params: Unpack["Customer.RetrievePaymentMethodParams"]
+        **params: Unpack["Customer.RetrievePaymentMethodParams"],
     ) -> "PaymentMethod":
         """
         Retrieves a PaymentMethod object for a given Customer.
@@ -2046,7 +2044,7 @@ class Customer(
     def retrieve_payment_method(
         customer: str,
         payment_method: str,
-        **params: Unpack["Customer.RetrievePaymentMethodParams"]
+        **params: Unpack["Customer.RetrievePaymentMethodParams"],
     ) -> "PaymentMethod":
         """
         Retrieves a PaymentMethod object for a given Customer.
@@ -2057,7 +2055,7 @@ class Customer(
     def retrieve_payment_method(
         self,
         payment_method: str,
-        **params: Unpack["Customer.RetrievePaymentMethodParams"]
+        **params: Unpack["Customer.RetrievePaymentMethodParams"],
     ) -> "PaymentMethod":
         """
         Retrieves a PaymentMethod object for a given Customer.
@@ -2068,7 +2066,7 @@ class Customer(
     def retrieve_payment_method(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         payment_method: str,
-        **params: Unpack["Customer.RetrievePaymentMethodParams"]
+        **params: Unpack["Customer.RetrievePaymentMethodParams"],
     ) -> "PaymentMethod":
         """
         Retrieves a PaymentMethod object for a given Customer.
@@ -2090,7 +2088,7 @@ class Customer(
         cls,
         customer: str,
         payment_method: str,
-        **params: Unpack["Customer.RetrievePaymentMethodParams"]
+        **params: Unpack["Customer.RetrievePaymentMethodParams"],
     ) -> "PaymentMethod":
         """
         Retrieves a PaymentMethod object for a given Customer.
@@ -2112,7 +2110,7 @@ class Customer(
     async def retrieve_payment_method_async(
         customer: str,
         payment_method: str,
-        **params: Unpack["Customer.RetrievePaymentMethodParams"]
+        **params: Unpack["Customer.RetrievePaymentMethodParams"],
     ) -> "PaymentMethod":
         """
         Retrieves a PaymentMethod object for a given Customer.
@@ -2123,7 +2121,7 @@ class Customer(
     async def retrieve_payment_method_async(
         self,
         payment_method: str,
-        **params: Unpack["Customer.RetrievePaymentMethodParams"]
+        **params: Unpack["Customer.RetrievePaymentMethodParams"],
     ) -> "PaymentMethod":
         """
         Retrieves a PaymentMethod object for a given Customer.
@@ -2134,7 +2132,7 @@ class Customer(
     async def retrieve_payment_method_async(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         payment_method: str,
-        **params: Unpack["Customer.RetrievePaymentMethodParams"]
+        **params: Unpack["Customer.RetrievePaymentMethodParams"],
     ) -> "PaymentMethod":
         """
         Retrieves a PaymentMethod object for a given Customer.
@@ -2193,7 +2191,7 @@ class Customer(
     def create_balance_transaction(
         cls,
         customer: str,
-        **params: Unpack["Customer.CreateBalanceTransactionParams"]
+        **params: Unpack["Customer.CreateBalanceTransactionParams"],
     ) -> "CustomerBalanceTransaction":
         """
         Creates an immutable transaction that updates the customer's credit [balance](https://stripe.com/docs/billing/customer/balance).
@@ -2213,7 +2211,7 @@ class Customer(
     async def create_balance_transaction_async(
         cls,
         customer: str,
-        **params: Unpack["Customer.CreateBalanceTransactionParams"]
+        **params: Unpack["Customer.CreateBalanceTransactionParams"],
     ) -> "CustomerBalanceTransaction":
         """
         Creates an immutable transaction that updates the customer's credit [balance](https://stripe.com/docs/billing/customer/balance).
@@ -2234,7 +2232,7 @@ class Customer(
         cls,
         customer: str,
         transaction: str,
-        **params: Unpack["Customer.RetrieveBalanceTransactionParams"]
+        **params: Unpack["Customer.RetrieveBalanceTransactionParams"],
     ) -> "CustomerBalanceTransaction":
         """
         Retrieves a specific customer balance transaction that updated the customer's [balances](https://stripe.com/docs/billing/customer/balance).
@@ -2256,7 +2254,7 @@ class Customer(
         cls,
         customer: str,
         transaction: str,
-        **params: Unpack["Customer.RetrieveBalanceTransactionParams"]
+        **params: Unpack["Customer.RetrieveBalanceTransactionParams"],
     ) -> "CustomerBalanceTransaction":
         """
         Retrieves a specific customer balance transaction that updated the customer's [balances](https://stripe.com/docs/billing/customer/balance).
@@ -2278,7 +2276,7 @@ class Customer(
         cls,
         customer: str,
         transaction: str,
-        **params: Unpack["Customer.ModifyBalanceTransactionParams"]
+        **params: Unpack["Customer.ModifyBalanceTransactionParams"],
     ) -> "CustomerBalanceTransaction":
         """
         Most credit balance transaction fields are immutable, but you may update its description and metadata.
@@ -2300,7 +2298,7 @@ class Customer(
         cls,
         customer: str,
         transaction: str,
-        **params: Unpack["Customer.ModifyBalanceTransactionParams"]
+        **params: Unpack["Customer.ModifyBalanceTransactionParams"],
     ) -> "CustomerBalanceTransaction":
         """
         Most credit balance transaction fields are immutable, but you may update its description and metadata.
@@ -2321,7 +2319,7 @@ class Customer(
     def list_balance_transactions(
         cls,
         customer: str,
-        **params: Unpack["Customer.ListBalanceTransactionsParams"]
+        **params: Unpack["Customer.ListBalanceTransactionsParams"],
     ) -> ListObject["CustomerBalanceTransaction"]:
         """
         Returns a list of transactions that updated the customer's [balances](https://stripe.com/docs/billing/customer/balance).
@@ -2341,7 +2339,7 @@ class Customer(
     async def list_balance_transactions_async(
         cls,
         customer: str,
-        **params: Unpack["Customer.ListBalanceTransactionsParams"]
+        **params: Unpack["Customer.ListBalanceTransactionsParams"],
     ) -> ListObject["CustomerBalanceTransaction"]:
         """
         Returns a list of transactions that updated the customer's [balances](https://stripe.com/docs/billing/customer/balance).
@@ -2362,7 +2360,7 @@ class Customer(
         cls,
         customer: str,
         transaction: str,
-        **params: Unpack["Customer.RetrieveCashBalanceTransactionParams"]
+        **params: Unpack["Customer.RetrieveCashBalanceTransactionParams"],
     ) -> "CustomerCashBalanceTransaction":
         """
         Retrieves a specific cash balance transaction, which updated the customer's [cash balance](https://stripe.com/docs/payments/customer-balance).
@@ -2384,7 +2382,7 @@ class Customer(
         cls,
         customer: str,
         transaction: str,
-        **params: Unpack["Customer.RetrieveCashBalanceTransactionParams"]
+        **params: Unpack["Customer.RetrieveCashBalanceTransactionParams"],
     ) -> "CustomerCashBalanceTransaction":
         """
         Retrieves a specific cash balance transaction, which updated the customer's [cash balance](https://stripe.com/docs/payments/customer-balance).
@@ -2405,7 +2403,7 @@ class Customer(
     def list_cash_balance_transactions(
         cls,
         customer: str,
-        **params: Unpack["Customer.ListCashBalanceTransactionsParams"]
+        **params: Unpack["Customer.ListCashBalanceTransactionsParams"],
     ) -> ListObject["CustomerCashBalanceTransaction"]:
         """
         Returns a list of transactions that modified the customer's [cash balance](https://stripe.com/docs/payments/customer-balance).
@@ -2425,7 +2423,7 @@ class Customer(
     async def list_cash_balance_transactions_async(
         cls,
         customer: str,
-        **params: Unpack["Customer.ListCashBalanceTransactionsParams"]
+        **params: Unpack["Customer.ListCashBalanceTransactionsParams"],
     ) -> ListObject["CustomerCashBalanceTransaction"]:
         """
         Returns a list of transactions that modified the customer's [cash balance](https://stripe.com/docs/payments/customer-balance).
@@ -2490,7 +2488,7 @@ class Customer(
         cls,
         customer: str,
         id: str,
-        **params: Unpack["Customer.RetrieveSourceParams"]
+        **params: Unpack["Customer.RetrieveSourceParams"],
     ) -> Union["Account", "BankAccount", "Card", "Source"]:
         """
         Retrieve a specified source for a given customer.
@@ -2511,7 +2509,7 @@ class Customer(
         cls,
         customer: str,
         id: str,
-        **params: Unpack["Customer.RetrieveSourceParams"]
+        **params: Unpack["Customer.RetrieveSourceParams"],
     ) -> Union["Account", "BankAccount", "Card", "Source"]:
         """
         Retrieve a specified source for a given customer.
@@ -2532,7 +2530,7 @@ class Customer(
         cls,
         customer: str,
         id: str,
-        **params: Unpack["Customer.ModifySourceParams"]
+        **params: Unpack["Customer.ModifySourceParams"],
     ) -> Union["Account", "BankAccount", "Card", "Source"]:
         """
         Update a specified source for a given customer.
@@ -2553,7 +2551,7 @@ class Customer(
         cls,
         customer: str,
         id: str,
-        **params: Unpack["Customer.ModifySourceParams"]
+        **params: Unpack["Customer.ModifySourceParams"],
     ) -> Union["Account", "BankAccount", "Card", "Source"]:
         """
         Update a specified source for a given customer.
@@ -2574,7 +2572,7 @@ class Customer(
         cls,
         customer: str,
         id: str,
-        **params: Unpack["Customer.DeleteSourceParams"]
+        **params: Unpack["Customer.DeleteSourceParams"],
     ) -> Union["Account", "BankAccount", "Card", "Source"]:
         """
         Delete a specified source for a given customer.
@@ -2595,7 +2593,7 @@ class Customer(
         cls,
         customer: str,
         id: str,
-        **params: Unpack["Customer.DeleteSourceParams"]
+        **params: Unpack["Customer.DeleteSourceParams"],
     ) -> Union["Account", "BankAccount", "Card", "Source"]:
         """
         Delete a specified source for a given customer.
@@ -2688,7 +2686,7 @@ class Customer(
         cls,
         customer: str,
         id: str,
-        **params: Unpack["Customer.RetrieveTaxIdParams"]
+        **params: Unpack["Customer.RetrieveTaxIdParams"],
     ) -> "TaxId":
         """
         Retrieves the tax_id object with the given identifier.
@@ -2709,7 +2707,7 @@ class Customer(
         cls,
         customer: str,
         id: str,
-        **params: Unpack["Customer.RetrieveTaxIdParams"]
+        **params: Unpack["Customer.RetrieveTaxIdParams"],
     ) -> "TaxId":
         """
         Retrieves the tax_id object with the given identifier.
@@ -2730,7 +2728,7 @@ class Customer(
         cls,
         customer: str,
         id: str,
-        **params: Unpack["Customer.DeleteTaxIdParams"]
+        **params: Unpack["Customer.DeleteTaxIdParams"],
     ) -> "TaxId":
         """
         Deletes an existing tax_id object.
@@ -2751,7 +2749,7 @@ class Customer(
         cls,
         customer: str,
         id: str,
-        **params: Unpack["Customer.DeleteTaxIdParams"]
+        **params: Unpack["Customer.DeleteTaxIdParams"],
     ) -> "TaxId":
         """
         Deletes an existing tax_id object.
@@ -2807,7 +2805,7 @@ class Customer(
     def retrieve_cash_balance(
         cls,
         customer: str,
-        **params: Unpack["Customer.RetrieveCashBalanceParams"]
+        **params: Unpack["Customer.RetrieveCashBalanceParams"],
     ) -> "CashBalance":
         """
         Retrieves a customer's cash balance.
@@ -2827,7 +2825,7 @@ class Customer(
     async def retrieve_cash_balance_async(
         cls,
         customer: str,
-        **params: Unpack["Customer.RetrieveCashBalanceParams"]
+        **params: Unpack["Customer.RetrieveCashBalanceParams"],
     ) -> "CashBalance":
         """
         Retrieves a customer's cash balance.
@@ -2847,7 +2845,7 @@ class Customer(
     def modify_cash_balance(
         cls,
         customer: str,
-        **params: Unpack["Customer.ModifyCashBalanceParams"]
+        **params: Unpack["Customer.ModifyCashBalanceParams"],
     ) -> "CashBalance":
         """
         Changes the settings on a customer's cash balance.
@@ -2867,7 +2865,7 @@ class Customer(
     async def modify_cash_balance_async(
         cls,
         customer: str,
-        **params: Unpack["Customer.ModifyCashBalanceParams"]
+        **params: Unpack["Customer.ModifyCashBalanceParams"],
     ) -> "CashBalance":
         """
         Changes the settings on a customer's cash balance.
@@ -2890,7 +2888,7 @@ class Customer(
         def _cls_fund_cash_balance(
             cls,
             customer: str,
-            **params: Unpack["Customer.FundCashBalanceParams"]
+            **params: Unpack["Customer.FundCashBalanceParams"],
         ) -> "CustomerCashBalanceTransaction":
             """
             Create an incoming testmode bank transfer
@@ -2947,7 +2945,7 @@ class Customer(
         async def _cls_fund_cash_balance_async(
             cls,
             customer: str,
-            **params: Unpack["Customer.FundCashBalanceParams"]
+            **params: Unpack["Customer.FundCashBalanceParams"],
         ) -> "CustomerCashBalanceTransaction":
             """
             Create an incoming testmode bank transfer

--- a/stripe/_customer_balance_transaction.py
+++ b/stripe/_customer_balance_transaction.py
@@ -22,9 +22,9 @@ class CustomerBalanceTransaction(APIResource["CustomerBalanceTransaction"]):
     Related guide: [Customer balance](https://stripe.com/docs/billing/customer/balance)
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["customer_balance_transaction"]
-    ] = "customer_balance_transaction"
+    OBJECT_NAME: ClassVar[Literal["customer_balance_transaction"]] = (
+        "customer_balance_transaction"
+    )
     amount: int
     """
     The amount of the transaction. A negative value is a credit for the customer's balance, and a positive value is a debit to the customer's `balance`.

--- a/stripe/_customer_cash_balance_transaction.py
+++ b/stripe/_customer_cash_balance_transaction.py
@@ -20,9 +20,9 @@ class CustomerCashBalanceTransaction(StripeObject):
     to payments, and refunds to the customer.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["customer_cash_balance_transaction"]
-    ] = "customer_cash_balance_transaction"
+    OBJECT_NAME: ClassVar[Literal["customer_cash_balance_transaction"]] = (
+        "customer_cash_balance_transaction"
+    )
 
     class AdjustedForOverdraft(StripeObject):
         balance_transaction: ExpandableField["BalanceTransaction"]

--- a/stripe/_customer_funding_instructions_service.py
+++ b/stripe/_customer_funding_instructions_service.py
@@ -10,7 +10,9 @@ from typing_extensions import Literal, NotRequired, TypedDict
 
 class CustomerFundingInstructionsService(StripeService):
     class CreateParams(TypedDict):
-        bank_transfer: "CustomerFundingInstructionsService.CreateParamsBankTransfer"
+        bank_transfer: (
+            "CustomerFundingInstructionsService.CreateParamsBankTransfer"
+        )
         """
         Additional parameters for `bank_transfer` funding types
         """

--- a/stripe/_dispute.py
+++ b/stripe/_dispute.py
@@ -583,7 +583,6 @@ class Dispute(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -604,7 +603,6 @@ class Dispute(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_error_object.py
+++ b/stripe/_error_object.py
@@ -56,7 +56,7 @@ class ErrorObject(StripeObject):
         partial=False,
         last_response=None,
         requestor,
-        api_mode: ApiMode
+        api_mode: ApiMode,
     ) -> None:
         # Unlike most other API resources, the API will omit attributes in
         # error objects when they have a null value. We manually set default

--- a/stripe/_event.py
+++ b/stripe/_event.py
@@ -401,7 +401,6 @@ class Event(ListableAPIResource["Event"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -422,7 +421,6 @@ class Event(ListableAPIResource["Event"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_exchange_rate.py
+++ b/stripe/_exchange_rate.py
@@ -89,7 +89,6 @@ class ExchangeRate(ListableAPIResource["ExchangeRate"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -110,7 +109,6 @@ class ExchangeRate(ListableAPIResource["ExchangeRate"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_file.py
+++ b/stripe/_file.py
@@ -251,7 +251,6 @@ class File(CreateableAPIResource["File"], ListableAPIResource["File"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -272,7 +271,6 @@ class File(CreateableAPIResource["File"], ListableAPIResource["File"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_file_link.py
+++ b/stripe/_file_link.py
@@ -199,7 +199,6 @@ class FileLink(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -220,7 +219,6 @@ class FileLink(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_funding_instructions.py
+++ b/stripe/_funding_instructions.py
@@ -14,9 +14,9 @@ class FundingInstructions(StripeObject):
     Related guide: [Customer balance funding instructions](https://stripe.com/docs/payments/customer-balance/funding-instructions)
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["funding_instructions"]
-    ] = "funding_instructions"
+    OBJECT_NAME: ClassVar[Literal["funding_instructions"]] = (
+        "funding_instructions"
+    )
 
     class BankTransfer(StripeObject):
         class FinancialAddress(StripeObject):

--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -162,9 +162,7 @@ class HTTPClient(object):
         if proxy:
             if isinstance(proxy, str):
                 proxy = {"http": proxy, "https": proxy}
-            if not isinstance(
-                proxy, dict
-            ):  # pyright: ignore[reportUnnecessaryIsInstance]
+            if not isinstance(proxy, dict):  # pyright: ignore[reportUnnecessaryIsInstance]
                 raise ValueError(
                     "Proxy(ies) must be specified as either a string "
                     "URL or a dict() with string URL under the"
@@ -399,7 +397,7 @@ class HTTPClient(object):
         headers: Optional[Mapping[str, str]],
         post_data: Any = None,
         *,
-        _usage: Optional[List[str]] = None
+        _usage: Optional[List[str]] = None,
     ) -> Tuple[str, int, Mapping[str, str]]:
         raise NotImplementedError(
             "HTTPClient subclasses must implement `request`"
@@ -412,7 +410,7 @@ class HTTPClient(object):
         headers: Optional[Mapping[str, str]],
         post_data: Any = None,
         *,
-        _usage: Optional[List[str]] = None
+        _usage: Optional[List[str]] = None,
     ) -> Tuple[Any, int, Mapping[str, str]]:
         raise NotImplementedError(
             "HTTPClient subclasses must implement `request_stream`"
@@ -431,7 +429,7 @@ class HTTPClient(object):
         post_data=None,
         max_network_retries: Optional[int] = None,
         *,
-        _usage: Optional[List[str]] = None
+        _usage: Optional[List[str]] = None,
     ) -> Tuple[Any, int, Any]:
         return await self._request_with_retries_internal_async(
             method,
@@ -451,7 +449,7 @@ class HTTPClient(object):
         post_data=None,
         max_network_retries=None,
         *,
-        _usage: Optional[List[str]] = None
+        _usage: Optional[List[str]] = None,
     ) -> Tuple[AsyncIterable[bytes], int, Any]:
         return await self._request_with_retries_internal_async(
             method,
@@ -473,9 +471,8 @@ class HTTPClient(object):
         is_streaming: Literal[False],
         max_network_retries: Optional[int],
         *,
-        _usage: Optional[List[str]] = None
-    ) -> Tuple[Any, int, Mapping[str, str]]:
-        ...
+        _usage: Optional[List[str]] = None,
+    ) -> Tuple[Any, int, Mapping[str, str]]: ...
 
     @overload
     async def _request_with_retries_internal_async(
@@ -487,9 +484,8 @@ class HTTPClient(object):
         is_streaming: Literal[True],
         max_network_retries: Optional[int],
         *,
-        _usage: Optional[List[str]] = None
-    ) -> Tuple[AsyncIterable[bytes], int, Mapping[str, str]]:
-        ...
+        _usage: Optional[List[str]] = None,
+    ) -> Tuple[AsyncIterable[bytes], int, Mapping[str, str]]: ...
 
     async def _request_with_retries_internal_async(
         self,
@@ -500,7 +496,7 @@ class HTTPClient(object):
         is_streaming: bool,
         max_network_retries: Optional[int],
         *,
-        _usage: Optional[List[str]] = None
+        _usage: Optional[List[str]] = None,
     ) -> Tuple[Any, int, Mapping[str, str]]:
         headers = self._add_telemetry_header(headers)
 
@@ -599,7 +595,7 @@ class RequestsClient(HTTPClient):
         verify_ssl_certs: bool = True,
         proxy: Optional[Union[str, HTTPClient._Proxy]] = None,
         async_fallback_client: Optional[HTTPClient] = None,
-        **kwargs
+        **kwargs,
     ):
         super(RequestsClient, self).__init__(
             verify_ssl_certs=verify_ssl_certs,
@@ -642,8 +638,7 @@ class RequestsClient(HTTPClient):
         headers: Optional[Mapping[str, str]],
         post_data,
         is_streaming: Literal[True],
-    ) -> Tuple[Any, int, Mapping[str, str]]:
-        ...
+    ) -> Tuple[Any, int, Mapping[str, str]]: ...
 
     @overload
     def _request_internal(
@@ -653,8 +648,7 @@ class RequestsClient(HTTPClient):
         headers: Optional[Mapping[str, str]],
         post_data,
         is_streaming: Literal[False],
-    ) -> Tuple[bytes, int, Mapping[str, str]]:
-        ...
+    ) -> Tuple[bytes, int, Mapping[str, str]]: ...
 
     def _request_internal(
         self,
@@ -832,8 +826,7 @@ class UrlFetchClient(HTTPClient):
         headers: Mapping[str, str],
         post_data,
         is_streaming: Literal[True],
-    ) -> Tuple[BytesIO, int, Any]:
-        ...
+    ) -> Tuple[BytesIO, int, Any]: ...
 
     @overload
     def _request_internal(
@@ -843,8 +836,7 @@ class UrlFetchClient(HTTPClient):
         headers: Mapping[str, str],
         post_data,
         is_streaming: Literal[False],
-    ) -> Tuple[str, int, Any]:
-        ...
+    ) -> Tuple[str, int, Any]: ...
 
     def _request_internal(
         self,
@@ -970,8 +962,7 @@ class PycurlClient(HTTPClient):
         headers: Mapping[str, str],
         post_data,
         is_streaming: Literal[True],
-    ) -> Tuple[BytesIO, int, Any]:
-        ...
+    ) -> Tuple[BytesIO, int, Any]: ...
 
     @overload
     def _request_internal(
@@ -981,8 +972,7 @@ class PycurlClient(HTTPClient):
         headers: Mapping[str, str],
         post_data,
         is_streaming: Literal[False],
-    ) -> Tuple[str, int, Mapping[str, str]]:
-        ...
+    ) -> Tuple[str, int, Mapping[str, str]]: ...
 
     def _request_internal(
         self,
@@ -1149,8 +1139,7 @@ class Urllib2Client(HTTPClient):
         headers: Mapping[str, str],
         post_data,
         is_streaming: Literal[False],
-    ) -> Tuple[str, int, Any]:
-        ...
+    ) -> Tuple[str, int, Any]: ...
 
     @overload
     def _request_internal(
@@ -1160,8 +1149,7 @@ class Urllib2Client(HTTPClient):
         headers: Mapping[str, str],
         post_data,
         is_streaming: Literal[True],
-    ) -> Tuple[HTTPResponse, int, Any]:
-        ...
+    ) -> Tuple[HTTPResponse, int, Any]: ...
 
     def _request_internal(
         self,
@@ -1227,7 +1215,7 @@ class HTTPXClient(HTTPClient):
         self,
         timeout: Optional[Union[float, "HTTPXTimeout"]] = 80,
         allow_sync_methods=False,
-        **kwargs
+        **kwargs,
     ):
         super(HTTPXClient, self).__init__(**kwargs)
 

--- a/stripe/_invoice.py
+++ b/stripe/_invoice.py
@@ -4425,7 +4425,9 @@ class Invoice(
         """
         The ID of the product that this price will belong to.
         """
-        recurring: "Invoice.UpcomingLinesParamsSubscriptionItemPriceDataRecurring"
+        recurring: (
+            "Invoice.UpcomingLinesParamsSubscriptionItemPriceDataRecurring"
+        )
         """
         The recurring components of a price such as `interval` and `interval_count`.
         """
@@ -5253,7 +5255,9 @@ class Invoice(
         """
         The ID of the product that this price will belong to.
         """
-        recurring: "Invoice.UpcomingParamsScheduleDetailsPhaseItemPriceDataRecurring"
+        recurring: (
+            "Invoice.UpcomingParamsScheduleDetailsPhaseItemPriceDataRecurring"
+        )
         """
         The recurring components of a price such as `interval` and `interval_count`.
         """
@@ -5423,7 +5427,9 @@ class Invoice(
         """
         The ID of the product that this price will belong to.
         """
-        recurring: "Invoice.UpcomingParamsSubscriptionDetailsItemPriceDataRecurring"
+        recurring: (
+            "Invoice.UpcomingParamsSubscriptionDetailsItemPriceDataRecurring"
+        )
         """
         The recurring components of a price such as `interval` and `interval_count`.
         """
@@ -6203,7 +6209,6 @@ class Invoice(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -6224,7 +6229,6 @@ class Invoice(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_invoice_item.py
+++ b/stripe/_invoice_item.py
@@ -603,7 +603,6 @@ class InvoiceItem(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -624,7 +623,6 @@ class InvoiceItem(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_invoice_line_item_service.py
+++ b/stripe/_invoice_line_item_service.py
@@ -163,7 +163,9 @@ class InvoiceLineItemService(StripeService):
         """
         The amount, in cents (or local equivalent), of the tax.
         """
-        tax_rate_data: "InvoiceLineItemService.UpdateParamsTaxAmountTaxRateData"
+        tax_rate_data: (
+            "InvoiceLineItemService.UpdateParamsTaxAmountTaxRateData"
+        )
         """
         Data to find or create a TaxRate object.
 

--- a/stripe/_invoice_service.py
+++ b/stripe/_invoice_service.py
@@ -782,7 +782,9 @@ class InvoiceService(StripeService):
         """
 
     class CreatePreviewParamsCustomerDetailsShipping(TypedDict):
-        address: "InvoiceService.CreatePreviewParamsCustomerDetailsShippingAddress"
+        address: (
+            "InvoiceService.CreatePreviewParamsCustomerDetailsShippingAddress"
+        )
         """
         Customer shipping address.
         """
@@ -2862,7 +2864,9 @@ class InvoiceService(StripeService):
         """
         The ID of the product that this price will belong to.
         """
-        recurring: "InvoiceService.UpcomingParamsSubscriptionItemPriceDataRecurring"
+        recurring: (
+            "InvoiceService.UpcomingParamsSubscriptionItemPriceDataRecurring"
+        )
         """
         The recurring components of a price such as `interval` and `interval_count`.
         """

--- a/stripe/_list_object.py
+++ b/stripe/_list_object.py
@@ -190,7 +190,6 @@ class ListObject(StripeObject, Generic[T]):
     def _get_filters_for_next_page(
         self, params: RequestOptions
     ) -> Mapping[str, Any]:
-
         last_id = getattr(self.data[-1], "id")
         if not last_id:
             raise ValueError(

--- a/stripe/_payment_intent.py
+++ b/stripe/_payment_intent.py
@@ -4237,7 +4237,9 @@ class PaymentIntent(
         """
 
     class CreateParamsMandateData(TypedDict):
-        customer_acceptance: "PaymentIntent.CreateParamsMandateDataCustomerAcceptance"
+        customer_acceptance: (
+            "PaymentIntent.CreateParamsMandateDataCustomerAcceptance"
+        )
         """
         This hash contains details about the customer acceptance of the Mandate.
         """
@@ -8679,7 +8681,7 @@ class PaymentIntent(
     def _cls_apply_customer_balance(
         cls,
         intent: str,
-        **params: Unpack["PaymentIntent.ApplyCustomerBalanceParams"]
+        **params: Unpack["PaymentIntent.ApplyCustomerBalanceParams"],
     ) -> "PaymentIntent":
         """
         Manually reconcile the remaining amount for a customer_balance PaymentIntent.
@@ -8699,7 +8701,7 @@ class PaymentIntent(
     @staticmethod
     def apply_customer_balance(
         intent: str,
-        **params: Unpack["PaymentIntent.ApplyCustomerBalanceParams"]
+        **params: Unpack["PaymentIntent.ApplyCustomerBalanceParams"],
     ) -> "PaymentIntent":
         """
         Manually reconcile the remaining amount for a customer_balance PaymentIntent.
@@ -8737,7 +8739,7 @@ class PaymentIntent(
     async def _cls_apply_customer_balance_async(
         cls,
         intent: str,
-        **params: Unpack["PaymentIntent.ApplyCustomerBalanceParams"]
+        **params: Unpack["PaymentIntent.ApplyCustomerBalanceParams"],
     ) -> "PaymentIntent":
         """
         Manually reconcile the remaining amount for a customer_balance PaymentIntent.
@@ -8757,7 +8759,7 @@ class PaymentIntent(
     @staticmethod
     async def apply_customer_balance_async(
         intent: str,
-        **params: Unpack["PaymentIntent.ApplyCustomerBalanceParams"]
+        **params: Unpack["PaymentIntent.ApplyCustomerBalanceParams"],
     ) -> "PaymentIntent":
         """
         Manually reconcile the remaining amount for a customer_balance PaymentIntent.
@@ -9407,7 +9409,7 @@ class PaymentIntent(
     def _cls_increment_authorization(
         cls,
         intent: str,
-        **params: Unpack["PaymentIntent.IncrementAuthorizationParams"]
+        **params: Unpack["PaymentIntent.IncrementAuthorizationParams"],
     ) -> "PaymentIntent":
         """
         Perform an incremental authorization on an eligible
@@ -9450,7 +9452,7 @@ class PaymentIntent(
     @staticmethod
     def increment_authorization(
         intent: str,
-        **params: Unpack["PaymentIntent.IncrementAuthorizationParams"]
+        **params: Unpack["PaymentIntent.IncrementAuthorizationParams"],
     ) -> "PaymentIntent":
         """
         Perform an incremental authorization on an eligible
@@ -9557,7 +9559,7 @@ class PaymentIntent(
     async def _cls_increment_authorization_async(
         cls,
         intent: str,
-        **params: Unpack["PaymentIntent.IncrementAuthorizationParams"]
+        **params: Unpack["PaymentIntent.IncrementAuthorizationParams"],
     ) -> "PaymentIntent":
         """
         Perform an incremental authorization on an eligible
@@ -9600,7 +9602,7 @@ class PaymentIntent(
     @staticmethod
     async def increment_authorization_async(
         intent: str,
-        **params: Unpack["PaymentIntent.IncrementAuthorizationParams"]
+        **params: Unpack["PaymentIntent.IncrementAuthorizationParams"],
     ) -> "PaymentIntent":
         """
         Perform an incremental authorization on an eligible
@@ -9716,7 +9718,6 @@ class PaymentIntent(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -9737,7 +9738,6 @@ class PaymentIntent(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -9825,7 +9825,7 @@ class PaymentIntent(
     def _cls_verify_microdeposits(
         cls,
         intent: str,
-        **params: Unpack["PaymentIntent.VerifyMicrodepositsParams"]
+        **params: Unpack["PaymentIntent.VerifyMicrodepositsParams"],
     ) -> "PaymentIntent":
         """
         Verifies microdeposits on a PaymentIntent object.
@@ -9845,7 +9845,7 @@ class PaymentIntent(
     @staticmethod
     def verify_microdeposits(
         intent: str,
-        **params: Unpack["PaymentIntent.VerifyMicrodepositsParams"]
+        **params: Unpack["PaymentIntent.VerifyMicrodepositsParams"],
     ) -> "PaymentIntent":
         """
         Verifies microdeposits on a PaymentIntent object.
@@ -9883,7 +9883,7 @@ class PaymentIntent(
     async def _cls_verify_microdeposits_async(
         cls,
         intent: str,
-        **params: Unpack["PaymentIntent.VerifyMicrodepositsParams"]
+        **params: Unpack["PaymentIntent.VerifyMicrodepositsParams"],
     ) -> "PaymentIntent":
         """
         Verifies microdeposits on a PaymentIntent object.
@@ -9903,7 +9903,7 @@ class PaymentIntent(
     @staticmethod
     async def verify_microdeposits_async(
         intent: str,
-        **params: Unpack["PaymentIntent.VerifyMicrodepositsParams"]
+        **params: Unpack["PaymentIntent.VerifyMicrodepositsParams"],
     ) -> "PaymentIntent":
         """
         Verifies microdeposits on a PaymentIntent object.

--- a/stripe/_payment_intent_service.py
+++ b/stripe/_payment_intent_service.py
@@ -2395,7 +2395,9 @@ class PaymentIntentService(StripeService):
         """
 
     class CreateParamsMandateData(TypedDict):
-        customer_acceptance: "PaymentIntentService.CreateParamsMandateDataCustomerAcceptance"
+        customer_acceptance: (
+            "PaymentIntentService.CreateParamsMandateDataCustomerAcceptance"
+        )
         """
         This hash contains details about the customer acceptance of the Mandate.
         """

--- a/stripe/_payment_link.py
+++ b/stripe/_payment_link.py
@@ -1208,7 +1208,9 @@ class PaymentLink(
         """
 
     class CreateParamsRestrictions(TypedDict):
-        completed_sessions: "PaymentLink.CreateParamsRestrictionsCompletedSessions"
+        completed_sessions: (
+            "PaymentLink.CreateParamsRestrictionsCompletedSessions"
+        )
         """
         Configuration for the `completed_sessions` restriction type.
         """
@@ -1517,7 +1519,9 @@ class PaymentLink(
         """
 
     class CreateParamsSubscriptionDataTrialSettings(TypedDict):
-        end_behavior: "PaymentLink.CreateParamsSubscriptionDataTrialSettingsEndBehavior"
+        end_behavior: (
+            "PaymentLink.CreateParamsSubscriptionDataTrialSettingsEndBehavior"
+        )
         """
         Defines how the subscription should behave when the user's free trial ends.
         """
@@ -1992,7 +1996,9 @@ class PaymentLink(
         """
 
     class ModifyParamsRestrictions(TypedDict):
-        completed_sessions: "PaymentLink.ModifyParamsRestrictionsCompletedSessions"
+        completed_sessions: (
+            "PaymentLink.ModifyParamsRestrictionsCompletedSessions"
+        )
         """
         Configuration for the `completed_sessions` restriction type.
         """
@@ -2287,7 +2293,9 @@ class PaymentLink(
         """
 
     class ModifyParamsSubscriptionDataTrialSettings(TypedDict):
-        end_behavior: "PaymentLink.ModifyParamsSubscriptionDataTrialSettingsEndBehavior"
+        end_behavior: (
+            "PaymentLink.ModifyParamsSubscriptionDataTrialSettingsEndBehavior"
+        )
         """
         Defines how the subscription should behave when the user's free trial ends.
         """
@@ -2501,7 +2509,6 @@ class PaymentLink(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -2522,7 +2529,6 @@ class PaymentLink(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -2534,7 +2540,7 @@ class PaymentLink(
     def _cls_list_line_items(
         cls,
         payment_link: str,
-        **params: Unpack["PaymentLink.ListLineItemsParams"]
+        **params: Unpack["PaymentLink.ListLineItemsParams"],
     ) -> ListObject["LineItem"]:
         """
         When retrieving a payment link, there is an includable line_items property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.
@@ -2591,7 +2597,7 @@ class PaymentLink(
     async def _cls_list_line_items_async(
         cls,
         payment_link: str,
-        **params: Unpack["PaymentLink.ListLineItemsParams"]
+        **params: Unpack["PaymentLink.ListLineItemsParams"],
     ) -> ListObject["LineItem"]:
         """
         When retrieving a payment link, there is an includable line_items property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.

--- a/stripe/_payment_link_service.py
+++ b/stripe/_payment_link_service.py
@@ -562,7 +562,9 @@ class PaymentLinkService(StripeService):
         """
 
     class CreateParamsRestrictions(TypedDict):
-        completed_sessions: "PaymentLinkService.CreateParamsRestrictionsCompletedSessions"
+        completed_sessions: (
+            "PaymentLinkService.CreateParamsRestrictionsCompletedSessions"
+        )
         """
         Configuration for the `completed_sessions` restriction type.
         """
@@ -1346,7 +1348,9 @@ class PaymentLinkService(StripeService):
         """
 
     class UpdateParamsRestrictions(TypedDict):
-        completed_sessions: "PaymentLinkService.UpdateParamsRestrictionsCompletedSessions"
+        completed_sessions: (
+            "PaymentLinkService.UpdateParamsRestrictionsCompletedSessions"
+        )
         """
         Configuration for the `completed_sessions` restriction type.
         """

--- a/stripe/_payment_method.py
+++ b/stripe/_payment_method.py
@@ -1915,7 +1915,7 @@ class PaymentMethod(
     def _cls_attach(
         cls,
         payment_method: str,
-        **params: Unpack["PaymentMethod.AttachParams"]
+        **params: Unpack["PaymentMethod.AttachParams"],
     ) -> "PaymentMethod":
         """
         Attaches a PaymentMethod object to a Customer.
@@ -2020,7 +2020,7 @@ class PaymentMethod(
     async def _cls_attach_async(
         cls,
         payment_method: str,
-        **params: Unpack["PaymentMethod.AttachParams"]
+        **params: Unpack["PaymentMethod.AttachParams"],
     ) -> "PaymentMethod":
         """
         Attaches a PaymentMethod object to a Customer.
@@ -2161,7 +2161,7 @@ class PaymentMethod(
     def _cls_detach(
         cls,
         payment_method: str,
-        **params: Unpack["PaymentMethod.DetachParams"]
+        **params: Unpack["PaymentMethod.DetachParams"],
     ) -> "PaymentMethod":
         """
         Detaches a PaymentMethod object from a Customer. After a PaymentMethod is detached, it can no longer be used for a payment or re-attached to a Customer.
@@ -2218,7 +2218,7 @@ class PaymentMethod(
     async def _cls_detach_async(
         cls,
         payment_method: str,
-        **params: Unpack["PaymentMethod.DetachParams"]
+        **params: Unpack["PaymentMethod.DetachParams"],
     ) -> "PaymentMethod":
         """
         Detaches a PaymentMethod object from a Customer. After a PaymentMethod is detached, it can no longer be used for a payment or re-attached to a Customer.
@@ -2284,7 +2284,6 @@ class PaymentMethod(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -2305,7 +2304,6 @@ class PaymentMethod(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_payment_method_configuration.py
+++ b/stripe/_payment_method_configuration.py
@@ -33,9 +33,9 @@ class PaymentMethodConfiguration(
     - [Multiple configurations for your Connect accounts](https://stripe.com/docs/connect/multiple-payment-method-configurations)
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["payment_method_configuration"]
-    ] = "payment_method_configuration"
+    OBJECT_NAME: ClassVar[Literal["payment_method_configuration"]] = (
+        "payment_method_configuration"
+    )
 
     class AcssDebit(StripeObject):
         class DisplayPreference(StripeObject):
@@ -2517,7 +2517,6 @@ class PaymentMethodConfiguration(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -2538,7 +2537,6 @@ class PaymentMethodConfiguration(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -2550,7 +2548,7 @@ class PaymentMethodConfiguration(
     def modify(
         cls,
         id: str,
-        **params: Unpack["PaymentMethodConfiguration.ModifyParams"]
+        **params: Unpack["PaymentMethodConfiguration.ModifyParams"],
     ) -> "PaymentMethodConfiguration":
         """
         Update payment method configuration
@@ -2569,7 +2567,7 @@ class PaymentMethodConfiguration(
     async def modify_async(
         cls,
         id: str,
-        **params: Unpack["PaymentMethodConfiguration.ModifyParams"]
+        **params: Unpack["PaymentMethodConfiguration.ModifyParams"],
     ) -> "PaymentMethodConfiguration":
         """
         Update payment method configuration
@@ -2588,7 +2586,7 @@ class PaymentMethodConfiguration(
     def retrieve(
         cls,
         id: str,
-        **params: Unpack["PaymentMethodConfiguration.RetrieveParams"]
+        **params: Unpack["PaymentMethodConfiguration.RetrieveParams"],
     ) -> "PaymentMethodConfiguration":
         """
         Retrieve payment method configuration
@@ -2601,7 +2599,7 @@ class PaymentMethodConfiguration(
     async def retrieve_async(
         cls,
         id: str,
-        **params: Unpack["PaymentMethodConfiguration.RetrieveParams"]
+        **params: Unpack["PaymentMethodConfiguration.RetrieveParams"],
     ) -> "PaymentMethodConfiguration":
         """
         Retrieve payment method configuration

--- a/stripe/_payment_method_domain.py
+++ b/stripe/_payment_method_domain.py
@@ -23,9 +23,9 @@ class PaymentMethodDomain(
     Related guides: [Payment method domains](https://stripe.com/docs/payments/payment-methods/pmd-registration).
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["payment_method_domain"]
-    ] = "payment_method_domain"
+    OBJECT_NAME: ClassVar[Literal["payment_method_domain"]] = (
+        "payment_method_domain"
+    )
 
     class ApplePay(StripeObject):
         class StatusDetails(StripeObject):
@@ -243,7 +243,6 @@ class PaymentMethodDomain(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -264,7 +263,6 @@ class PaymentMethodDomain(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -332,7 +330,7 @@ class PaymentMethodDomain(
     def _cls_validate(
         cls,
         payment_method_domain: str,
-        **params: Unpack["PaymentMethodDomain.ValidateParams"]
+        **params: Unpack["PaymentMethodDomain.ValidateParams"],
     ) -> "PaymentMethodDomain":
         """
         Some payment methods such as Apple Pay require additional steps to verify a domain. If the requirements weren't satisfied when the domain was created, the payment method will be inactive on the domain.
@@ -357,7 +355,7 @@ class PaymentMethodDomain(
     @staticmethod
     def validate(
         payment_method_domain: str,
-        **params: Unpack["PaymentMethodDomain.ValidateParams"]
+        **params: Unpack["PaymentMethodDomain.ValidateParams"],
     ) -> "PaymentMethodDomain":
         """
         Some payment methods such as Apple Pay require additional steps to verify a domain. If the requirements weren't satisfied when the domain was created, the payment method will be inactive on the domain.
@@ -410,7 +408,7 @@ class PaymentMethodDomain(
     async def _cls_validate_async(
         cls,
         payment_method_domain: str,
-        **params: Unpack["PaymentMethodDomain.ValidateParams"]
+        **params: Unpack["PaymentMethodDomain.ValidateParams"],
     ) -> "PaymentMethodDomain":
         """
         Some payment methods such as Apple Pay require additional steps to verify a domain. If the requirements weren't satisfied when the domain was created, the payment method will be inactive on the domain.
@@ -435,7 +433,7 @@ class PaymentMethodDomain(
     @staticmethod
     async def validate_async(
         payment_method_domain: str,
-        **params: Unpack["PaymentMethodDomain.ValidateParams"]
+        **params: Unpack["PaymentMethodDomain.ValidateParams"],
     ) -> "PaymentMethodDomain":
         """
         Some payment methods such as Apple Pay require additional steps to verify a domain. If the requirements weren't satisfied when the domain was created, the payment method will be inactive on the domain.

--- a/stripe/_payout.py
+++ b/stripe/_payout.py
@@ -436,7 +436,6 @@ class Payout(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -457,7 +456,6 @@ class Payout(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_plan.py
+++ b/stripe/_plan.py
@@ -523,7 +523,6 @@ class Plan(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -544,7 +543,6 @@ class Plan(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_price.py
+++ b/stripe/_price.py
@@ -781,7 +781,6 @@ class Price(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -802,7 +801,6 @@ class Price(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_product.py
+++ b/stripe/_product.py
@@ -722,7 +722,6 @@ class Product(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -743,7 +742,6 @@ class Product(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -850,7 +848,7 @@ class Product(
         cls,
         product: str,
         id: str,
-        **params: Unpack["Product.DeleteFeatureParams"]
+        **params: Unpack["Product.DeleteFeatureParams"],
     ) -> "ProductFeature":
         """
         Deletes the feature attachment to a product
@@ -871,7 +869,7 @@ class Product(
         cls,
         product: str,
         id: str,
-        **params: Unpack["Product.DeleteFeatureParams"]
+        **params: Unpack["Product.DeleteFeatureParams"],
     ) -> "ProductFeature":
         """
         Deletes the feature attachment to a product
@@ -964,7 +962,7 @@ class Product(
         cls,
         product: str,
         id: str,
-        **params: Unpack["Product.RetrieveFeatureParams"]
+        **params: Unpack["Product.RetrieveFeatureParams"],
     ) -> "ProductFeature":
         """
         Retrieves a product_feature, which represents a feature attachment to a product
@@ -985,7 +983,7 @@ class Product(
         cls,
         product: str,
         id: str,
-        **params: Unpack["Product.RetrieveFeatureParams"]
+        **params: Unpack["Product.RetrieveFeatureParams"],
     ) -> "ProductFeature":
         """
         Retrieves a product_feature, which represents a feature attachment to a product

--- a/stripe/_promotion_code.py
+++ b/stripe/_promotion_code.py
@@ -315,7 +315,6 @@ class PromotionCode(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -336,7 +335,6 @@ class PromotionCode(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_quote.py
+++ b/stripe/_quote.py
@@ -1501,7 +1501,6 @@ class Quote(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -1522,7 +1521,6 @@ class Quote(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -1534,7 +1532,7 @@ class Quote(
     def _cls_list_computed_upfront_line_items(
         cls,
         quote: str,
-        **params: Unpack["Quote.ListComputedUpfrontLineItemsParams"]
+        **params: Unpack["Quote.ListComputedUpfrontLineItemsParams"],
     ) -> ListObject["LineItem"]:
         """
         When retrieving a quote, there is an includable [computed.upfront.line_items](https://stripe.com/docs/api/quotes/object#quote_object-computed-upfront-line_items) property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of upfront line items.
@@ -1554,7 +1552,7 @@ class Quote(
     @staticmethod
     def list_computed_upfront_line_items(
         quote: str,
-        **params: Unpack["Quote.ListComputedUpfrontLineItemsParams"]
+        **params: Unpack["Quote.ListComputedUpfrontLineItemsParams"],
     ) -> ListObject["LineItem"]:
         """
         When retrieving a quote, there is an includable [computed.upfront.line_items](https://stripe.com/docs/api/quotes/object#quote_object-computed-upfront-line_items) property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of upfront line items.
@@ -1592,7 +1590,7 @@ class Quote(
     async def _cls_list_computed_upfront_line_items_async(
         cls,
         quote: str,
-        **params: Unpack["Quote.ListComputedUpfrontLineItemsParams"]
+        **params: Unpack["Quote.ListComputedUpfrontLineItemsParams"],
     ) -> ListObject["LineItem"]:
         """
         When retrieving a quote, there is an includable [computed.upfront.line_items](https://stripe.com/docs/api/quotes/object#quote_object-computed-upfront-line_items) property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of upfront line items.
@@ -1612,7 +1610,7 @@ class Quote(
     @staticmethod
     async def list_computed_upfront_line_items_async(
         quote: str,
-        **params: Unpack["Quote.ListComputedUpfrontLineItemsParams"]
+        **params: Unpack["Quote.ListComputedUpfrontLineItemsParams"],
     ) -> ListObject["LineItem"]:
         """
         When retrieving a quote, there is an includable [computed.upfront.line_items](https://stripe.com/docs/api/quotes/object#quote_object-computed-upfront-line_items) property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of upfront line items.

--- a/stripe/_refund.py
+++ b/stripe/_refund.py
@@ -706,7 +706,6 @@ class Refund(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -727,7 +726,6 @@ class Refund(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_request_options.py
+++ b/stripe/_request_options.py
@@ -45,7 +45,7 @@ def merge_options(
 
 
 def extract_options_from_dict(
-    d: Optional[Mapping[str, Any]]
+    d: Optional[Mapping[str, Any]],
 ) -> Tuple[RequestOptions, Dict[str, Any]]:
     """
     Extracts a RequestOptions object from a dict, and returns a tuple of

--- a/stripe/_reserve_transaction.py
+++ b/stripe/_reserve_transaction.py
@@ -6,9 +6,9 @@ from typing_extensions import Literal
 
 
 class ReserveTransaction(StripeObject):
-    OBJECT_NAME: ClassVar[
-        Literal["reserve_transaction"]
-    ] = "reserve_transaction"
+    OBJECT_NAME: ClassVar[Literal["reserve_transaction"]] = (
+        "reserve_transaction"
+    )
     amount: int
     currency: str
     """

--- a/stripe/_review.py
+++ b/stripe/_review.py
@@ -304,7 +304,6 @@ class Review(ListableAPIResource["Review"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -325,7 +324,6 @@ class Review(ListableAPIResource["Review"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_setup_attempt.py
+++ b/stripe/_setup_attempt.py
@@ -809,7 +809,6 @@ class SetupAttempt(ListableAPIResource["SetupAttempt"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -830,7 +829,6 @@ class SetupAttempt(ListableAPIResource["SetupAttempt"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_setup_intent.py
+++ b/stripe/_setup_intent.py
@@ -1760,7 +1760,9 @@ class SetupIntent(
         """
 
     class CreateParamsMandateData(TypedDict):
-        customer_acceptance: "SetupIntent.CreateParamsMandateDataCustomerAcceptance"
+        customer_acceptance: (
+            "SetupIntent.CreateParamsMandateDataCustomerAcceptance"
+        )
         """
         This hash contains details about the customer acceptance of the Mandate.
         """
@@ -4318,7 +4320,6 @@ class SetupIntent(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -4339,7 +4340,6 @@ class SetupIntent(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -4415,7 +4415,7 @@ class SetupIntent(
     def _cls_verify_microdeposits(
         cls,
         intent: str,
-        **params: Unpack["SetupIntent.VerifyMicrodepositsParams"]
+        **params: Unpack["SetupIntent.VerifyMicrodepositsParams"],
     ) -> "SetupIntent":
         """
         Verifies microdeposits on a SetupIntent object.
@@ -4472,7 +4472,7 @@ class SetupIntent(
     async def _cls_verify_microdeposits_async(
         cls,
         intent: str,
-        **params: Unpack["SetupIntent.VerifyMicrodepositsParams"]
+        **params: Unpack["SetupIntent.VerifyMicrodepositsParams"],
     ) -> "SetupIntent":
         """
         Verifies microdeposits on a SetupIntent object.

--- a/stripe/_setup_intent_service.py
+++ b/stripe/_setup_intent_service.py
@@ -1189,7 +1189,9 @@ class SetupIntentService(StripeService):
         """
 
     class CreateParamsMandateData(TypedDict):
-        customer_acceptance: "SetupIntentService.CreateParamsMandateDataCustomerAcceptance"
+        customer_acceptance: (
+            "SetupIntentService.CreateParamsMandateDataCustomerAcceptance"
+        )
         """
         This hash contains details about the customer acceptance of the Mandate.
         """

--- a/stripe/_shipping_rate.py
+++ b/stripe/_shipping_rate.py
@@ -379,7 +379,6 @@ class ShippingRate(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -400,7 +399,6 @@ class ShippingRate(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_source.py
+++ b/stripe/_source.py
@@ -1147,7 +1147,7 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
     def _cls_list_source_transactions(
         cls,
         source: str,
-        **params: Unpack["Source.ListSourceTransactionsParams"]
+        **params: Unpack["Source.ListSourceTransactionsParams"],
     ) -> ListObject["SourceTransaction"]:
         """
         List source transactions for a given source.
@@ -1204,7 +1204,7 @@ class Source(CreateableAPIResource["Source"], UpdateableAPIResource["Source"]):
     async def _cls_list_source_transactions_async(
         cls,
         source: str,
-        **params: Unpack["Source.ListSourceTransactionsParams"]
+        **params: Unpack["Source.ListSourceTransactionsParams"],
     ) -> ListObject["SourceTransaction"]:
         """
         List source transactions for a given source.

--- a/stripe/_source_mandate_notification.py
+++ b/stripe/_source_mandate_notification.py
@@ -15,9 +15,9 @@ class SourceMandateNotification(StripeObject):
     deliver an email to the customer.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["source_mandate_notification"]
-    ] = "source_mandate_notification"
+    OBJECT_NAME: ClassVar[Literal["source_mandate_notification"]] = (
+        "source_mandate_notification"
+    )
 
     class AcssDebit(StripeObject):
         statement_descriptor: Optional[str]

--- a/stripe/_stripe_client.py
+++ b/stripe/_stripe_client.py
@@ -97,7 +97,6 @@ from stripe._topup_service import TopupService
 from stripe._transfer_service import TransferService
 from stripe._treasury_service import TreasuryService
 from stripe._webhook_endpoint_service import WebhookEndpointService
-
 # services: The end of the section generated from our OpenAPI spec
 
 

--- a/stripe/_stripe_object.py
+++ b/stripe/_stripe_object.py
@@ -38,15 +38,13 @@ if TYPE_CHECKING:
 @overload
 def _compute_diff(
     current: Dict[str, Any], previous: Optional[Dict[str, Any]]
-) -> Dict[str, Any]:
-    ...
+) -> Dict[str, Any]: ...
 
 
 @overload
 def _compute_diff(
     current: object, previous: Optional[Dict[str, Any]]
-) -> object:
-    ...
+) -> object: ...
 
 
 def _compute_diff(
@@ -101,7 +99,7 @@ class StripeObject(Dict[str, Any]):
         *,
         _requestor: Optional["_APIRequestor"] = None,
         # TODO: is a more specific type possible here?
-        **params: Any
+        **params: Any,
     ):
         super(StripeObject, self).__init__()
 
@@ -522,7 +520,7 @@ class StripeObject(Dict[str, Any]):
 
     def _to_dict_recursive(self) -> Dict[str, Any]:
         def maybe_to_dict_recursive(
-            value: Optional[Union[StripeObject, Dict[str, Any]]]
+            value: Optional[Union[StripeObject, Dict[str, Any]]],
         ) -> Optional[Dict[str, Any]]:
             if value is None:
                 return None

--- a/stripe/_subscription.py
+++ b/stripe/_subscription.py
@@ -2194,7 +2194,7 @@ class Subscription(
     def _cls_cancel(
         cls,
         subscription_exposed_id: str,
-        **params: Unpack["Subscription.CancelParams"]
+        **params: Unpack["Subscription.CancelParams"],
     ) -> "Subscription":
         """
         Cancels a customer's subscription immediately. The customer will not be charged again for the subscription.
@@ -2220,7 +2220,7 @@ class Subscription(
     @staticmethod
     def cancel(
         subscription_exposed_id: str,
-        **params: Unpack["Subscription.CancelParams"]
+        **params: Unpack["Subscription.CancelParams"],
     ) -> "Subscription":
         """
         Cancels a customer's subscription immediately. The customer will not be charged again for the subscription.
@@ -2270,7 +2270,7 @@ class Subscription(
     async def _cls_cancel_async(
         cls,
         subscription_exposed_id: str,
-        **params: Unpack["Subscription.CancelParams"]
+        **params: Unpack["Subscription.CancelParams"],
     ) -> "Subscription":
         """
         Cancels a customer's subscription immediately. The customer will not be charged again for the subscription.
@@ -2296,7 +2296,7 @@ class Subscription(
     @staticmethod
     async def cancel_async(
         subscription_exposed_id: str,
-        **params: Unpack["Subscription.CancelParams"]
+        **params: Unpack["Subscription.CancelParams"],
     ) -> "Subscription":
         """
         Cancels a customer's subscription immediately. The customer will not be charged again for the subscription.
@@ -2390,7 +2390,7 @@ class Subscription(
     def _cls_delete_discount(
         cls,
         subscription_exposed_id: str,
-        **params: Unpack["Subscription.DeleteDiscountParams"]
+        **params: Unpack["Subscription.DeleteDiscountParams"],
     ) -> "Discount":
         """
         Removes the currently applied discount on a subscription.
@@ -2412,7 +2412,7 @@ class Subscription(
     @staticmethod
     def delete_discount(
         subscription_exposed_id: str,
-        **params: Unpack["Subscription.DeleteDiscountParams"]
+        **params: Unpack["Subscription.DeleteDiscountParams"],
     ) -> "Discount":
         """
         Removes the currently applied discount on a subscription.
@@ -2450,7 +2450,7 @@ class Subscription(
     async def _cls_delete_discount_async(
         cls,
         subscription_exposed_id: str,
-        **params: Unpack["Subscription.DeleteDiscountParams"]
+        **params: Unpack["Subscription.DeleteDiscountParams"],
     ) -> "Discount":
         """
         Removes the currently applied discount on a subscription.
@@ -2472,7 +2472,7 @@ class Subscription(
     @staticmethod
     async def delete_discount_async(
         subscription_exposed_id: str,
-        **params: Unpack["Subscription.DeleteDiscountParams"]
+        **params: Unpack["Subscription.DeleteDiscountParams"],
     ) -> "Discount":
         """
         Removes the currently applied discount on a subscription.
@@ -2519,7 +2519,6 @@ class Subscription(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -2540,7 +2539,6 @@ class Subscription(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_subscription_item.py
+++ b/stripe/_subscription_item.py
@@ -595,7 +595,6 @@ class SubscriptionItem(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -616,7 +615,6 @@ class SubscriptionItem(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -684,7 +682,7 @@ class SubscriptionItem(
     def create_usage_record(
         cls,
         subscription_item: str,
-        **params: Unpack["SubscriptionItem.CreateUsageRecordParams"]
+        **params: Unpack["SubscriptionItem.CreateUsageRecordParams"],
     ) -> "UsageRecord":
         """
         Creates a usage record for a specified subscription item and date, and fills it with a quantity.
@@ -710,7 +708,7 @@ class SubscriptionItem(
     async def create_usage_record_async(
         cls,
         subscription_item: str,
-        **params: Unpack["SubscriptionItem.CreateUsageRecordParams"]
+        **params: Unpack["SubscriptionItem.CreateUsageRecordParams"],
     ) -> "UsageRecord":
         """
         Creates a usage record for a specified subscription item and date, and fills it with a quantity.
@@ -736,7 +734,7 @@ class SubscriptionItem(
     def list_usage_record_summaries(
         cls,
         subscription_item: str,
-        **params: Unpack["SubscriptionItem.ListUsageRecordSummariesParams"]
+        **params: Unpack["SubscriptionItem.ListUsageRecordSummariesParams"],
     ) -> ListObject["UsageRecordSummary"]:
         """
         For the specified subscription item, returns a list of summary objects. Each object in the list provides usage information that's been summarized from multiple usage records and over a subscription billing period (e.g., 15 usage records in the month of September).
@@ -758,7 +756,7 @@ class SubscriptionItem(
     async def list_usage_record_summaries_async(
         cls,
         subscription_item: str,
-        **params: Unpack["SubscriptionItem.ListUsageRecordSummariesParams"]
+        **params: Unpack["SubscriptionItem.ListUsageRecordSummariesParams"],
     ) -> ListObject["UsageRecordSummary"]:
         """
         For the specified subscription item, returns a list of summary objects. Each object in the list provides usage information that's been summarized from multiple usage records and over a subscription billing period (e.g., 15 usage records in the month of September).

--- a/stripe/_subscription_schedule.py
+++ b/stripe/_subscription_schedule.py
@@ -44,9 +44,9 @@ class SubscriptionSchedule(
     Related guide: [Subscription schedules](https://stripe.com/docs/billing/subscriptions/subscription-schedules)
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["subscription_schedule"]
-    ] = "subscription_schedule"
+    OBJECT_NAME: ClassVar[Literal["subscription_schedule"]] = (
+        "subscription_schedule"
+    )
 
     class CurrentPhase(StripeObject):
         end_date: int
@@ -913,7 +913,9 @@ class SubscriptionSchedule(
         """
         The ID of the product that this price will belong to.
         """
-        recurring: "SubscriptionSchedule.CreateParamsPhaseItemPriceDataRecurring"
+        recurring: (
+            "SubscriptionSchedule.CreateParamsPhaseItemPriceDataRecurring"
+        )
         """
         The recurring components of a price such as `interval` and `interval_count`.
         """
@@ -1541,7 +1543,9 @@ class SubscriptionSchedule(
         """
         The ID of the product that this price will belong to.
         """
-        recurring: "SubscriptionSchedule.ModifyParamsPhaseItemPriceDataRecurring"
+        recurring: (
+            "SubscriptionSchedule.ModifyParamsPhaseItemPriceDataRecurring"
+        )
         """
         The recurring components of a price such as `interval` and `interval_count`.
         """
@@ -1672,7 +1676,7 @@ class SubscriptionSchedule(
     def _cls_cancel(
         cls,
         schedule: str,
-        **params: Unpack["SubscriptionSchedule.CancelParams"]
+        **params: Unpack["SubscriptionSchedule.CancelParams"],
     ) -> "SubscriptionSchedule":
         """
         Cancels a subscription schedule and its associated subscription immediately (if the subscription schedule has an active subscription). A subscription schedule can only be canceled if its status is not_started or active.
@@ -1729,7 +1733,7 @@ class SubscriptionSchedule(
     async def _cls_cancel_async(
         cls,
         schedule: str,
-        **params: Unpack["SubscriptionSchedule.CancelParams"]
+        **params: Unpack["SubscriptionSchedule.CancelParams"],
     ) -> "SubscriptionSchedule":
         """
         Cancels a subscription schedule and its associated subscription immediately (if the subscription schedule has an active subscription). A subscription schedule can only be canceled if its status is not_started or active.
@@ -1827,7 +1831,6 @@ class SubscriptionSchedule(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -1848,7 +1851,6 @@ class SubscriptionSchedule(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -1894,7 +1896,7 @@ class SubscriptionSchedule(
     def _cls_release(
         cls,
         schedule: str,
-        **params: Unpack["SubscriptionSchedule.ReleaseParams"]
+        **params: Unpack["SubscriptionSchedule.ReleaseParams"],
     ) -> "SubscriptionSchedule":
         """
         Releases the subscription schedule immediately, which will stop scheduling of its phases, but leave any existing subscription in place. A schedule can only be released if its status is not_started or active. If the subscription schedule is currently associated with a subscription, releasing it will remove its subscription property and set the subscription's ID to the released_subscription property.
@@ -1951,7 +1953,7 @@ class SubscriptionSchedule(
     async def _cls_release_async(
         cls,
         schedule: str,
-        **params: Unpack["SubscriptionSchedule.ReleaseParams"]
+        **params: Unpack["SubscriptionSchedule.ReleaseParams"],
     ) -> "SubscriptionSchedule":
         """
         Releases the subscription schedule immediately, which will stop scheduling of its phases, but leave any existing subscription in place. A schedule can only be released if its status is not_started or active. If the subscription schedule is currently associated with a subscription, releasing it will remove its subscription property and set the subscription's ID to the released_subscription property.

--- a/stripe/_subscription_service.py
+++ b/stripe/_subscription_service.py
@@ -718,7 +718,9 @@ class SubscriptionService(StripeService):
         """
 
     class CreateParamsTrialSettings(TypedDict):
-        end_behavior: "SubscriptionService.CreateParamsTrialSettingsEndBehavior"
+        end_behavior: (
+            "SubscriptionService.CreateParamsTrialSettingsEndBehavior"
+        )
         """
         Defines how the subscription should behave when the user's free trial ends.
         """
@@ -1585,7 +1587,9 @@ class SubscriptionService(StripeService):
         """
 
     class UpdateParamsTrialSettings(TypedDict):
-        end_behavior: "SubscriptionService.UpdateParamsTrialSettingsEndBehavior"
+        end_behavior: (
+            "SubscriptionService.UpdateParamsTrialSettingsEndBehavior"
+        )
         """
         Defines how the subscription should behave when the user's free trial ends.
         """

--- a/stripe/_tax_code.py
+++ b/stripe/_tax_code.py
@@ -68,7 +68,6 @@ class TaxCode(ListableAPIResource["TaxCode"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -89,7 +88,6 @@ class TaxCode(ListableAPIResource["TaxCode"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_tax_deducted_at_source.py
+++ b/stripe/_tax_deducted_at_source.py
@@ -6,9 +6,9 @@ from typing_extensions import Literal
 
 
 class TaxDeductedAtSource(StripeObject):
-    OBJECT_NAME: ClassVar[
-        Literal["tax_deducted_at_source"]
-    ] = "tax_deducted_at_source"
+    OBJECT_NAME: ClassVar[Literal["tax_deducted_at_source"]] = (
+        "tax_deducted_at_source"
+    )
     id: str
     """
     Unique identifier for the object.

--- a/stripe/_tax_id.py
+++ b/stripe/_tax_id.py
@@ -471,7 +471,6 @@ class TaxId(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -492,7 +491,6 @@ class TaxId(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_tax_rate.py
+++ b/stripe/_tax_rate.py
@@ -318,7 +318,6 @@ class TaxRate(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -339,7 +338,6 @@ class TaxRate(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_topup.py
+++ b/stripe/_topup.py
@@ -372,7 +372,6 @@ class Topup(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -393,7 +392,6 @@ class Topup(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/_transfer.py
+++ b/stripe/_transfer.py
@@ -319,7 +319,6 @@ class Transfer(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -340,7 +339,6 @@ class Transfer(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -453,7 +451,7 @@ class Transfer(
         cls,
         transfer: str,
         id: str,
-        **params: Unpack["Transfer.RetrieveReversalParams"]
+        **params: Unpack["Transfer.RetrieveReversalParams"],
     ) -> "Reversal":
         """
         By default, you can see the 10 most recent reversals stored directly on the transfer object, but you can also retrieve details about a specific reversal stored on the transfer.
@@ -474,7 +472,7 @@ class Transfer(
         cls,
         transfer: str,
         id: str,
-        **params: Unpack["Transfer.RetrieveReversalParams"]
+        **params: Unpack["Transfer.RetrieveReversalParams"],
     ) -> "Reversal":
         """
         By default, you can see the 10 most recent reversals stored directly on the transfer object, but you can also retrieve details about a specific reversal stored on the transfer.
@@ -495,7 +493,7 @@ class Transfer(
         cls,
         transfer: str,
         id: str,
-        **params: Unpack["Transfer.ModifyReversalParams"]
+        **params: Unpack["Transfer.ModifyReversalParams"],
     ) -> "Reversal":
         """
         Updates the specified reversal by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
@@ -518,7 +516,7 @@ class Transfer(
         cls,
         transfer: str,
         id: str,
-        **params: Unpack["Transfer.ModifyReversalParams"]
+        **params: Unpack["Transfer.ModifyReversalParams"],
     ) -> "Reversal":
         """
         Updates the specified reversal by setting the values of the parameters passed. Any parameters not provided will be left unchanged.

--- a/stripe/_usage_record_summary.py
+++ b/stripe/_usage_record_summary.py
@@ -6,9 +6,9 @@ from typing_extensions import Literal
 
 
 class UsageRecordSummary(StripeObject):
-    OBJECT_NAME: ClassVar[
-        Literal["usage_record_summary"]
-    ] = "usage_record_summary"
+    OBJECT_NAME: ClassVar[Literal["usage_record_summary"]] = (
+        "usage_record_summary"
+    )
 
     class Period(StripeObject):
         end: Optional[int]

--- a/stripe/_util.py
+++ b/stripe/_util.py
@@ -212,8 +212,7 @@ def convert_to_stripe_object(
     klass_: Optional[Type["StripeObject"]] = None,
     *,
     api_mode: ApiMode = "V1",
-) -> "StripeObject":
-    ...
+) -> "StripeObject": ...
 
 
 @overload
@@ -226,8 +225,7 @@ def convert_to_stripe_object(
     klass_: Optional[Type["StripeObject"]] = None,
     *,
     api_mode: ApiMode = "V1",
-) -> List["StripeObject"]:
-    ...
+) -> List["StripeObject"]: ...
 
 
 def convert_to_stripe_object(
@@ -263,8 +261,7 @@ def _convert_to_stripe_object(
     klass_: Optional[Type["StripeObject"]] = None,
     requestor: "_APIRequestor",
     api_mode: ApiMode,
-) -> "StripeObject":
-    ...
+) -> "StripeObject": ...
 
 
 @overload
@@ -275,8 +272,7 @@ def _convert_to_stripe_object(
     klass_: Optional[Type["StripeObject"]] = None,
     requestor: "_APIRequestor",
     api_mode: ApiMode,
-) -> List["StripeObject"]:
-    ...
+) -> List["StripeObject"]: ...
 
 
 def _convert_to_stripe_object(
@@ -368,17 +364,15 @@ def convert_to_dict(obj):
 @overload
 def populate_headers(
     idempotency_key: str,
-) -> Dict[str, str]:
-    ...
+) -> Dict[str, str]: ...
 
 
 @overload
-def populate_headers(idempotency_key: None) -> None:
-    ...
+def populate_headers(idempotency_key: None) -> None: ...
 
 
 def populate_headers(
-    idempotency_key: Union[str, None]
+    idempotency_key: Union[str, None],
 ) -> Union[Dict[str, str], None]:
     if idempotency_key is not None:
         return {"Idempotency-Key": idempotency_key}

--- a/stripe/_verify_mixin.py
+++ b/stripe/_verify_mixin.py
@@ -5,16 +5,14 @@ from stripe._stripe_object import StripeObject
 
 
 class _Verifiable(Protocol):
-    def instance_url(self) -> str:
-        ...
+    def instance_url(self) -> str: ...
 
     def _request(
         self,
         method: str,
         url: str,
         params: Dict[str, Any],
-    ) -> StripeObject:
-        ...
+    ) -> StripeObject: ...
 
 
 class VerifyMixin(object):

--- a/stripe/_webhook_endpoint.py
+++ b/stripe/_webhook_endpoint.py
@@ -880,7 +880,6 @@ class WebhookEndpoint(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -901,7 +900,6 @@ class WebhookEndpoint(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/app_info.py
+++ b/stripe/app_info.py
@@ -7,6 +7,7 @@ From:
 To:
   from stripe import AppInfo
 """
+
 from typing_extensions import TYPE_CHECKING
 
 # No deprecation warning is raised here, because it would happen

--- a/stripe/apps/_secret.py
+++ b/stripe/apps/_secret.py
@@ -285,7 +285,6 @@ class Secret(CreateableAPIResource["Secret"], ListableAPIResource["Secret"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -306,7 +305,6 @@ class Secret(CreateableAPIResource["Secret"], ListableAPIResource["Secret"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/billing/_meter.py
+++ b/stripe/billing/_meter.py
@@ -389,7 +389,6 @@ class Meter(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -410,7 +409,6 @@ class Meter(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/billing/_meter_event.py
+++ b/stripe/billing/_meter_event.py
@@ -12,9 +12,9 @@ class MeterEvent(CreateableAPIResource["MeterEvent"]):
     Meter events are associated with billing meters, which define the shape of the event's payload and how those events are aggregated for billing.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["billing.meter_event"]
-    ] = "billing.meter_event"
+    OBJECT_NAME: ClassVar[Literal["billing.meter_event"]] = (
+        "billing.meter_event"
+    )
 
     class CreateParams(RequestOptions):
         event_name: str

--- a/stripe/billing/_meter_event_adjustment.py
+++ b/stripe/billing/_meter_event_adjustment.py
@@ -12,9 +12,9 @@ class MeterEventAdjustment(CreateableAPIResource["MeterEventAdjustment"]):
     A billing meter event adjustment is a resource that allows you to cancel a meter event. For example, you might create a billing meter event adjustment to cancel a meter event that was created in error or attached to the wrong customer.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["billing.meter_event_adjustment"]
-    ] = "billing.meter_event_adjustment"
+    OBJECT_NAME: ClassVar[Literal["billing.meter_event_adjustment"]] = (
+        "billing.meter_event_adjustment"
+    )
 
     class Cancel(StripeObject):
         identifier: Optional[str]

--- a/stripe/billing/_meter_event_summary.py
+++ b/stripe/billing/_meter_event_summary.py
@@ -11,9 +11,9 @@ class MeterEventSummary(StripeObject):
     usage was accrued by a customer for that period.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["billing.meter_event_summary"]
-    ] = "billing.meter_event_summary"
+    OBJECT_NAME: ClassVar[Literal["billing.meter_event_summary"]] = (
+        "billing.meter_event_summary"
+    )
     aggregated_value: float
     """
     Aggregated value of all the events within `start_time` (inclusive) and `end_time` (inclusive). The aggregation strategy is defined on meter via `default_aggregation`.

--- a/stripe/billing_portal/_configuration.py
+++ b/stripe/billing_portal/_configuration.py
@@ -30,9 +30,9 @@ class Configuration(
     A portal configuration describes the functionality and behavior of a portal session.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["billing_portal.configuration"]
-    ] = "billing_portal.configuration"
+    OBJECT_NAME: ClassVar[Literal["billing_portal.configuration"]] = (
+        "billing_portal.configuration"
+    )
 
     class BusinessProfile(StripeObject):
         headline: Optional[str]
@@ -656,7 +656,6 @@ class Configuration(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -677,7 +676,6 @@ class Configuration(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/billing_portal/_session.py
+++ b/stripe/billing_portal/_session.py
@@ -35,9 +35,9 @@ class Session(CreateableAPIResource["Session"]):
     Learn more in the [integration guide](https://stripe.com/docs/billing/subscriptions/integrating-customer-portal).
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["billing_portal.session"]
-    ] = "billing_portal.session"
+    OBJECT_NAME: ClassVar[Literal["billing_portal.session"]] = (
+        "billing_portal.session"
+    )
 
     class Flow(StripeObject):
         class AfterCompletion(StripeObject):

--- a/stripe/checkout/_session.py
+++ b/stripe/checkout/_session.py
@@ -3578,7 +3578,9 @@ class Session(
         """
 
     class CreateParamsSubscriptionDataTrialSettings(TypedDict):
-        end_behavior: "Session.CreateParamsSubscriptionDataTrialSettingsEndBehavior"
+        end_behavior: (
+            "Session.CreateParamsSubscriptionDataTrialSettingsEndBehavior"
+        )
         """
         Defines how the subscription should behave when the user's free trial ends.
         """
@@ -4133,7 +4135,6 @@ class Session(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -4154,7 +4155,6 @@ class Session(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/climate/_order.py
+++ b/stripe/climate/_order.py
@@ -435,7 +435,6 @@ class Order(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -457,7 +456,6 @@ class Order(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/climate/_product.py
+++ b/stripe/climate/_product.py
@@ -109,7 +109,6 @@ class Product(ListableAPIResource["Product"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -130,7 +129,6 @@ class Product(ListableAPIResource["Product"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/climate/_supplier.py
+++ b/stripe/climate/_supplier.py
@@ -107,7 +107,6 @@ class Supplier(ListableAPIResource["Supplier"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -128,7 +127,6 @@ class Supplier(ListableAPIResource["Supplier"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/entitlements/_active_entitlement.py
+++ b/stripe/entitlements/_active_entitlement.py
@@ -16,9 +16,9 @@ class ActiveEntitlement(ListableAPIResource["ActiveEntitlement"]):
     An active entitlement describes access to a feature for a customer.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["entitlements.active_entitlement"]
-    ] = "entitlements.active_entitlement"
+    OBJECT_NAME: ClassVar[Literal["entitlements.active_entitlement"]] = (
+        "entitlements.active_entitlement"
+    )
 
     class ListParams(RequestOptions):
         customer: str
@@ -82,7 +82,6 @@ class ActiveEntitlement(ListableAPIResource["ActiveEntitlement"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -103,7 +102,6 @@ class ActiveEntitlement(ListableAPIResource["ActiveEntitlement"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/entitlements/_feature.py
+++ b/stripe/entitlements/_feature.py
@@ -20,9 +20,9 @@ class Feature(
     Features can be assigned to products, and when those products are purchased, Stripe will create an entitlement to the feature for the purchasing customer.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["entitlements.feature"]
-    ] = "entitlements.feature"
+    OBJECT_NAME: ClassVar[Literal["entitlements.feature"]] = (
+        "entitlements.feature"
+    )
 
     class CreateParams(RequestOptions):
         expand: NotRequired[List[str]]
@@ -156,7 +156,6 @@ class Feature(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -177,7 +176,6 @@ class Feature(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/financial_connections/_account.py
+++ b/stripe/financial_connections/_account.py
@@ -29,9 +29,9 @@ class Account(ListableAPIResource["Account"]):
     A Financial Connections Account represents an account that exists outside of Stripe, to which you have been granted some degree of access.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["financial_connections.account"]
-    ] = "financial_connections.account"
+    OBJECT_NAME: ClassVar[Literal["financial_connections.account"]] = (
+        "financial_connections.account"
+    )
 
     class AccountHolder(StripeObject):
         account: Optional[ExpandableField["AccountResource"]]
@@ -458,7 +458,6 @@ class Account(ListableAPIResource["Account"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -479,7 +478,6 @@ class Account(ListableAPIResource["Account"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/financial_connections/_account_owner.py
+++ b/stripe/financial_connections/_account_owner.py
@@ -10,9 +10,9 @@ class AccountOwner(StripeObject):
     Describes an owner of an account.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["financial_connections.account_owner"]
-    ] = "financial_connections.account_owner"
+    OBJECT_NAME: ClassVar[Literal["financial_connections.account_owner"]] = (
+        "financial_connections.account_owner"
+    )
     email: Optional[str]
     """
     The email address of the owner.

--- a/stripe/financial_connections/_session.py
+++ b/stripe/financial_connections/_session.py
@@ -27,9 +27,9 @@ class Session(CreateableAPIResource["Session"]):
     A Financial Connections Session is the secure way to programmatically launch the client-side Stripe.js modal that lets your users link their accounts.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["financial_connections.session"]
-    ] = "financial_connections.session"
+    OBJECT_NAME: ClassVar[Literal["financial_connections.session"]] = (
+        "financial_connections.session"
+    )
 
     class AccountHolder(StripeObject):
         account: Optional[ExpandableField["AccountResource"]]

--- a/stripe/financial_connections/_transaction.py
+++ b/stripe/financial_connections/_transaction.py
@@ -13,9 +13,9 @@ class Transaction(ListableAPIResource["Transaction"]):
     A Transaction represents a real transaction that affects a Financial Connections Account balance.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["financial_connections.transaction"]
-    ] = "financial_connections.transaction"
+    OBJECT_NAME: ClassVar[Literal["financial_connections.transaction"]] = (
+        "financial_connections.transaction"
+    )
 
     class StatusTransitions(StripeObject):
         posted_at: Optional[int]
@@ -148,7 +148,6 @@ class Transaction(ListableAPIResource["Transaction"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -169,7 +168,6 @@ class Transaction(ListableAPIResource["Transaction"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/forwarding/_request.py
+++ b/stripe/forwarding/_request.py
@@ -271,7 +271,6 @@ class Request(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -292,7 +291,6 @@ class Request(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/identity/_verification_report.py
+++ b/stripe/identity/_verification_report.py
@@ -23,9 +23,9 @@ class VerificationReport(ListableAPIResource["VerificationReport"]):
     Related guides: [Accessing verification results](https://stripe.com/docs/identity/verification-sessions#results).
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["identity.verification_report"]
-    ] = "identity.verification_report"
+    OBJECT_NAME: ClassVar[Literal["identity.verification_report"]] = (
+        "identity.verification_report"
+    )
 
     class Document(StripeObject):
         class Address(StripeObject):
@@ -476,7 +476,6 @@ class VerificationReport(ListableAPIResource["VerificationReport"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -497,7 +496,6 @@ class VerificationReport(ListableAPIResource["VerificationReport"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/identity/_verification_session.py
+++ b/stripe/identity/_verification_session.py
@@ -40,9 +40,9 @@ class VerificationSession(
     Related guide: [The Verification Sessions API](https://stripe.com/docs/identity/verification-sessions)
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["identity.verification_session"]
-    ] = "identity.verification_session"
+    OBJECT_NAME: ClassVar[Literal["identity.verification_session"]] = (
+        "identity.verification_session"
+    )
 
     class LastError(StripeObject):
         code: Optional[
@@ -670,7 +670,6 @@ class VerificationSession(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -691,7 +690,6 @@ class VerificationSession(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/issuing/_authorization.py
+++ b/stripe/issuing/_authorization.py
@@ -38,9 +38,9 @@ class Authorization(
     Related guide: [Issued card authorizations](https://stripe.com/docs/issuing/purchases/authorizations)
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["issuing.authorization"]
-    ] = "issuing.authorization"
+    OBJECT_NAME: ClassVar[Literal["issuing.authorization"]] = (
+        "issuing.authorization"
+    )
 
     class AmountDetails(StripeObject):
         atm_fee: Optional[int]
@@ -1109,7 +1109,7 @@ class Authorization(
     def _cls_approve(
         cls,
         authorization: str,
-        **params: Unpack["Authorization.ApproveParams"]
+        **params: Unpack["Authorization.ApproveParams"],
     ) -> "Authorization":
         """
         [Deprecated] Approves a pending Issuing Authorization object. This request should be made within the timeout window of the [real-time authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations) flow.
@@ -1170,7 +1170,7 @@ class Authorization(
     async def _cls_approve_async(
         cls,
         authorization: str,
-        **params: Unpack["Authorization.ApproveParams"]
+        **params: Unpack["Authorization.ApproveParams"],
     ) -> "Authorization":
         """
         [Deprecated] Approves a pending Issuing Authorization object. This request should be made within the timeout window of the [real-time authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations) flow.
@@ -1231,7 +1231,7 @@ class Authorization(
     def _cls_decline(
         cls,
         authorization: str,
-        **params: Unpack["Authorization.DeclineParams"]
+        **params: Unpack["Authorization.DeclineParams"],
     ) -> "Authorization":
         """
         [Deprecated] Declines a pending Issuing Authorization object. This request should be made within the timeout window of the [real time authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations) flow.
@@ -1292,7 +1292,7 @@ class Authorization(
     async def _cls_decline_async(
         cls,
         authorization: str,
-        **params: Unpack["Authorization.DeclineParams"]
+        **params: Unpack["Authorization.DeclineParams"],
     ) -> "Authorization":
         """
         [Deprecated] Declines a pending Issuing Authorization object. This request should be made within the timeout window of the [real time authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations) flow.
@@ -1362,7 +1362,6 @@ class Authorization(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -1383,7 +1382,6 @@ class Authorization(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -1454,7 +1452,7 @@ class Authorization(
         def _cls_capture(
             cls,
             authorization: str,
-            **params: Unpack["Authorization.CaptureParams"]
+            **params: Unpack["Authorization.CaptureParams"],
         ) -> "Authorization":
             """
             Capture a test-mode authorization.
@@ -1511,7 +1509,7 @@ class Authorization(
         async def _cls_capture_async(
             cls,
             authorization: str,
-            **params: Unpack["Authorization.CaptureParams"]
+            **params: Unpack["Authorization.CaptureParams"],
         ) -> "Authorization":
             """
             Capture a test-mode authorization.
@@ -1600,7 +1598,7 @@ class Authorization(
         def _cls_expire(
             cls,
             authorization: str,
-            **params: Unpack["Authorization.ExpireParams"]
+            **params: Unpack["Authorization.ExpireParams"],
         ) -> "Authorization":
             """
             Expire a test-mode Authorization.
@@ -1657,7 +1655,7 @@ class Authorization(
         async def _cls_expire_async(
             cls,
             authorization: str,
-            **params: Unpack["Authorization.ExpireParams"]
+            **params: Unpack["Authorization.ExpireParams"],
         ) -> "Authorization":
             """
             Expire a test-mode Authorization.
@@ -1714,7 +1712,7 @@ class Authorization(
         def _cls_increment(
             cls,
             authorization: str,
-            **params: Unpack["Authorization.IncrementParams"]
+            **params: Unpack["Authorization.IncrementParams"],
         ) -> "Authorization":
             """
             Increment a test-mode Authorization.
@@ -1734,7 +1732,7 @@ class Authorization(
         @staticmethod
         def increment(
             authorization: str,
-            **params: Unpack["Authorization.IncrementParams"]
+            **params: Unpack["Authorization.IncrementParams"],
         ) -> "Authorization":
             """
             Increment a test-mode Authorization.
@@ -1772,7 +1770,7 @@ class Authorization(
         async def _cls_increment_async(
             cls,
             authorization: str,
-            **params: Unpack["Authorization.IncrementParams"]
+            **params: Unpack["Authorization.IncrementParams"],
         ) -> "Authorization":
             """
             Increment a test-mode Authorization.
@@ -1792,7 +1790,7 @@ class Authorization(
         @staticmethod
         async def increment_async(
             authorization: str,
-            **params: Unpack["Authorization.IncrementParams"]
+            **params: Unpack["Authorization.IncrementParams"],
         ) -> "Authorization":
             """
             Increment a test-mode Authorization.
@@ -1830,7 +1828,7 @@ class Authorization(
         def _cls_reverse(
             cls,
             authorization: str,
-            **params: Unpack["Authorization.ReverseParams"]
+            **params: Unpack["Authorization.ReverseParams"],
         ) -> "Authorization":
             """
             Reverse a test-mode Authorization.
@@ -1887,7 +1885,7 @@ class Authorization(
         async def _cls_reverse_async(
             cls,
             authorization: str,
-            **params: Unpack["Authorization.ReverseParams"]
+            **params: Unpack["Authorization.ReverseParams"],
         ) -> "Authorization":
             """
             Reverse a test-mode Authorization.

--- a/stripe/issuing/_card.py
+++ b/stripe/issuing/_card.py
@@ -3395,7 +3395,6 @@ class Card(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -3416,7 +3415,6 @@ class Card(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/issuing/_cardholder.py
+++ b/stripe/issuing/_cardholder.py
@@ -3531,7 +3531,6 @@ class Cardholder(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -3552,7 +3551,6 @@ class Cardholder(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/issuing/_dispute.py
+++ b/stripe/issuing/_dispute.py
@@ -911,7 +911,6 @@ class Dispute(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -932,7 +931,6 @@ class Dispute(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/issuing/_personalization_design.py
+++ b/stripe/issuing/_personalization_design.py
@@ -33,9 +33,9 @@ class PersonalizationDesign(
     A Personalization Design is a logical grouping of a Physical Bundle, card logo, and carrier text that represents a product line.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["issuing.personalization_design"]
-    ] = "issuing.personalization_design"
+    OBJECT_NAME: ClassVar[Literal["issuing.personalization_design"]] = (
+        "issuing.personalization_design"
+    )
 
     class CarrierText(StripeObject):
         footer_body: Optional[str]
@@ -429,7 +429,6 @@ class PersonalizationDesign(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -450,7 +449,6 @@ class PersonalizationDesign(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -521,7 +519,7 @@ class PersonalizationDesign(
         def _cls_activate(
             cls,
             personalization_design: str,
-            **params: Unpack["PersonalizationDesign.ActivateParams"]
+            **params: Unpack["PersonalizationDesign.ActivateParams"],
         ) -> "PersonalizationDesign":
             """
             Updates the status of the specified testmode personalization design object to active.
@@ -543,7 +541,7 @@ class PersonalizationDesign(
         @staticmethod
         def activate(
             personalization_design: str,
-            **params: Unpack["PersonalizationDesign.ActivateParams"]
+            **params: Unpack["PersonalizationDesign.ActivateParams"],
         ) -> "PersonalizationDesign":
             """
             Updates the status of the specified testmode personalization design object to active.
@@ -583,7 +581,7 @@ class PersonalizationDesign(
         async def _cls_activate_async(
             cls,
             personalization_design: str,
-            **params: Unpack["PersonalizationDesign.ActivateParams"]
+            **params: Unpack["PersonalizationDesign.ActivateParams"],
         ) -> "PersonalizationDesign":
             """
             Updates the status of the specified testmode personalization design object to active.
@@ -605,7 +603,7 @@ class PersonalizationDesign(
         @staticmethod
         async def activate_async(
             personalization_design: str,
-            **params: Unpack["PersonalizationDesign.ActivateParams"]
+            **params: Unpack["PersonalizationDesign.ActivateParams"],
         ) -> "PersonalizationDesign":
             """
             Updates the status of the specified testmode personalization design object to active.
@@ -645,7 +643,7 @@ class PersonalizationDesign(
         def _cls_deactivate(
             cls,
             personalization_design: str,
-            **params: Unpack["PersonalizationDesign.DeactivateParams"]
+            **params: Unpack["PersonalizationDesign.DeactivateParams"],
         ) -> "PersonalizationDesign":
             """
             Updates the status of the specified testmode personalization design object to inactive.
@@ -667,7 +665,7 @@ class PersonalizationDesign(
         @staticmethod
         def deactivate(
             personalization_design: str,
-            **params: Unpack["PersonalizationDesign.DeactivateParams"]
+            **params: Unpack["PersonalizationDesign.DeactivateParams"],
         ) -> "PersonalizationDesign":
             """
             Updates the status of the specified testmode personalization design object to inactive.
@@ -707,7 +705,7 @@ class PersonalizationDesign(
         async def _cls_deactivate_async(
             cls,
             personalization_design: str,
-            **params: Unpack["PersonalizationDesign.DeactivateParams"]
+            **params: Unpack["PersonalizationDesign.DeactivateParams"],
         ) -> "PersonalizationDesign":
             """
             Updates the status of the specified testmode personalization design object to inactive.
@@ -729,7 +727,7 @@ class PersonalizationDesign(
         @staticmethod
         async def deactivate_async(
             personalization_design: str,
-            **params: Unpack["PersonalizationDesign.DeactivateParams"]
+            **params: Unpack["PersonalizationDesign.DeactivateParams"],
         ) -> "PersonalizationDesign":
             """
             Updates the status of the specified testmode personalization design object to inactive.
@@ -769,7 +767,7 @@ class PersonalizationDesign(
         def _cls_reject(
             cls,
             personalization_design: str,
-            **params: Unpack["PersonalizationDesign.RejectParams"]
+            **params: Unpack["PersonalizationDesign.RejectParams"],
         ) -> "PersonalizationDesign":
             """
             Updates the status of the specified testmode personalization design object to rejected.
@@ -791,7 +789,7 @@ class PersonalizationDesign(
         @staticmethod
         def reject(
             personalization_design: str,
-            **params: Unpack["PersonalizationDesign.RejectParams"]
+            **params: Unpack["PersonalizationDesign.RejectParams"],
         ) -> "PersonalizationDesign":
             """
             Updates the status of the specified testmode personalization design object to rejected.
@@ -831,7 +829,7 @@ class PersonalizationDesign(
         async def _cls_reject_async(
             cls,
             personalization_design: str,
-            **params: Unpack["PersonalizationDesign.RejectParams"]
+            **params: Unpack["PersonalizationDesign.RejectParams"],
         ) -> "PersonalizationDesign":
             """
             Updates the status of the specified testmode personalization design object to rejected.
@@ -853,7 +851,7 @@ class PersonalizationDesign(
         @staticmethod
         async def reject_async(
             personalization_design: str,
-            **params: Unpack["PersonalizationDesign.RejectParams"]
+            **params: Unpack["PersonalizationDesign.RejectParams"],
         ) -> "PersonalizationDesign":
             """
             Updates the status of the specified testmode personalization design object to rejected.

--- a/stripe/issuing/_physical_bundle.py
+++ b/stripe/issuing/_physical_bundle.py
@@ -13,9 +13,9 @@ class PhysicalBundle(ListableAPIResource["PhysicalBundle"]):
     A Physical Bundle represents the bundle of physical items - card stock, carrier letter, and envelope - that is shipped to a cardholder when you create a physical card.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["issuing.physical_bundle"]
-    ] = "issuing.physical_bundle"
+    OBJECT_NAME: ClassVar[Literal["issuing.physical_bundle"]] = (
+        "issuing.physical_bundle"
+    )
 
     class Features(StripeObject):
         card_logo: Literal["optional", "required", "unsupported"]
@@ -102,7 +102,6 @@ class PhysicalBundle(ListableAPIResource["PhysicalBundle"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -123,7 +122,6 @@ class PhysicalBundle(ListableAPIResource["PhysicalBundle"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/issuing/_token.py
+++ b/stripe/issuing/_token.py
@@ -317,7 +317,6 @@ class Token(ListableAPIResource["Token"], UpdateableAPIResource["Token"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -338,7 +337,6 @@ class Token(ListableAPIResource["Token"], UpdateableAPIResource["Token"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/issuing/_transaction.py
+++ b/stripe/issuing/_transaction.py
@@ -39,9 +39,9 @@ class Transaction(
     Related guide: [Issued card transactions](https://stripe.com/docs/issuing/purchases/transactions)
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["issuing.transaction"]
-    ] = "issuing.transaction"
+    OBJECT_NAME: ClassVar[Literal["issuing.transaction"]] = (
+        "issuing.transaction"
+    )
 
     class AmountDetails(StripeObject):
         atm_fee: Optional[int]
@@ -1399,7 +1399,6 @@ class Transaction(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -1420,7 +1419,6 @@ class Transaction(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/radar/_early_fraud_warning.py
+++ b/stripe/radar/_early_fraud_warning.py
@@ -26,9 +26,9 @@ class EarlyFraudWarning(ListableAPIResource["EarlyFraudWarning"]):
     Related guide: [Early fraud warnings](https://stripe.com/docs/disputes/measuring#early-fraud-warnings)
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["radar.early_fraud_warning"]
-    ] = "radar.early_fraud_warning"
+    OBJECT_NAME: ClassVar[Literal["radar.early_fraud_warning"]] = (
+        "radar.early_fraud_warning"
+    )
 
     class ListParams(RequestOptions):
         charge: NotRequired[str]
@@ -130,7 +130,6 @@ class EarlyFraudWarning(ListableAPIResource["EarlyFraudWarning"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -151,7 +150,6 @@ class EarlyFraudWarning(ListableAPIResource["EarlyFraudWarning"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/radar/_value_list.py
+++ b/stripe/radar/_value_list.py
@@ -341,7 +341,6 @@ class ValueList(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -362,7 +361,6 @@ class ValueList(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/radar/_value_list_item.py
+++ b/stripe/radar/_value_list_item.py
@@ -21,9 +21,9 @@ class ValueListItem(
     Related guide: [Managing list items](https://stripe.com/docs/radar/lists#managing-list-items)
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["radar.value_list_item"]
-    ] = "radar.value_list_item"
+    OBJECT_NAME: ClassVar[Literal["radar.value_list_item"]] = (
+        "radar.value_list_item"
+    )
 
     class CreateParams(RequestOptions):
         expand: NotRequired[List[str]]
@@ -272,7 +272,6 @@ class ValueListItem(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -293,7 +292,6 @@ class ValueListItem(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/reporting/_report_run.py
+++ b/stripe/reporting/_report_run.py
@@ -33,9 +33,9 @@ class ReportRun(
     data), and will error when queried without a [live-mode API key](https://stripe.com/docs/keys#test-live-modes).
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["reporting.report_run"]
-    ] = "reporting.report_run"
+    OBJECT_NAME: ClassVar[Literal["reporting.report_run"]] = (
+        "reporting.report_run"
+    )
 
     class Parameters(StripeObject):
         columns: Optional[List[str]]
@@ -892,7 +892,6 @@ class ReportRun(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -913,7 +912,6 @@ class ReportRun(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/reporting/_report_type.py
+++ b/stripe/reporting/_report_type.py
@@ -19,9 +19,9 @@ class ReportType(ListableAPIResource["ReportType"]):
     data), and will error when queried without a [live-mode API key](https://stripe.com/docs/keys#test-live-modes).
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["reporting.report_type"]
-    ] = "reporting.report_type"
+    OBJECT_NAME: ClassVar[Literal["reporting.report_type"]] = (
+        "reporting.report_type"
+    )
 
     class ListParams(RequestOptions):
         expand: NotRequired[List[str]]
@@ -85,7 +85,6 @@ class ReportType(ListableAPIResource["ReportType"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -106,7 +105,6 @@ class ReportType(ListableAPIResource["ReportType"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/sigma/_scheduled_query_run.py
+++ b/stripe/sigma/_scheduled_query_run.py
@@ -19,9 +19,9 @@ class ScheduledQueryRun(ListableAPIResource["ScheduledQueryRun"]):
     retrieve the query results.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["scheduled_query_run"]
-    ] = "scheduled_query_run"
+    OBJECT_NAME: ClassVar[Literal["scheduled_query_run"]] = (
+        "scheduled_query_run"
+    )
 
     class Error(StripeObject):
         message: str
@@ -108,7 +108,6 @@ class ScheduledQueryRun(ListableAPIResource["ScheduledQueryRun"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -129,7 +128,6 @@ class ScheduledQueryRun(ListableAPIResource["ScheduledQueryRun"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/tax/_calculation.py
+++ b/stripe/tax/_calculation.py
@@ -740,7 +740,7 @@ class Calculation(CreateableAPIResource["Calculation"]):
     def _cls_list_line_items(
         cls,
         calculation: str,
-        **params: Unpack["Calculation.ListLineItemsParams"]
+        **params: Unpack["Calculation.ListLineItemsParams"],
     ) -> ListObject["CalculationLineItem"]:
         """
         Retrieves the line items of a persisted tax calculation as a collection.
@@ -797,7 +797,7 @@ class Calculation(CreateableAPIResource["Calculation"]):
     async def _cls_list_line_items_async(
         cls,
         calculation: str,
-        **params: Unpack["Calculation.ListLineItemsParams"]
+        **params: Unpack["Calculation.ListLineItemsParams"],
     ) -> ListObject["CalculationLineItem"]:
         """
         Retrieves the line items of a persisted tax calculation as a collection.

--- a/stripe/tax/_calculation_line_item.py
+++ b/stripe/tax/_calculation_line_item.py
@@ -6,9 +6,9 @@ from typing_extensions import Literal
 
 
 class CalculationLineItem(StripeObject):
-    OBJECT_NAME: ClassVar[
-        Literal["tax.calculation_line_item"]
-    ] = "tax.calculation_line_item"
+    OBJECT_NAME: ClassVar[Literal["tax.calculation_line_item"]] = (
+        "tax.calculation_line_item"
+    )
 
     class TaxBreakdown(StripeObject):
         class Jurisdiction(StripeObject):

--- a/stripe/tax/_registration.py
+++ b/stripe/tax/_registration.py
@@ -1805,7 +1805,6 @@ class Registration(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -1826,7 +1825,6 @@ class Registration(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/tax/_transaction.py
+++ b/stripe/tax/_transaction.py
@@ -556,7 +556,7 @@ class Transaction(APIResource["Transaction"]):
     def _cls_list_line_items(
         cls,
         transaction: str,
-        **params: Unpack["Transaction.ListLineItemsParams"]
+        **params: Unpack["Transaction.ListLineItemsParams"],
     ) -> ListObject["TransactionLineItem"]:
         """
         Retrieves the line items of a committed standalone transaction as a collection.
@@ -613,7 +613,7 @@ class Transaction(APIResource["Transaction"]):
     async def _cls_list_line_items_async(
         cls,
         transaction: str,
-        **params: Unpack["Transaction.ListLineItemsParams"]
+        **params: Unpack["Transaction.ListLineItemsParams"],
     ) -> ListObject["TransactionLineItem"]:
         """
         Retrieves the line items of a committed standalone transaction as a collection.

--- a/stripe/tax/_transaction_line_item.py
+++ b/stripe/tax/_transaction_line_item.py
@@ -6,9 +6,9 @@ from typing_extensions import Literal
 
 
 class TransactionLineItem(StripeObject):
-    OBJECT_NAME: ClassVar[
-        Literal["tax.transaction_line_item"]
-    ] = "tax.transaction_line_item"
+    OBJECT_NAME: ClassVar[Literal["tax.transaction_line_item"]] = (
+        "tax.transaction_line_item"
+    )
 
     class Reversal(StripeObject):
         original_line_item: str

--- a/stripe/terminal/_configuration.py
+++ b/stripe/terminal/_configuration.py
@@ -32,9 +32,9 @@ class Configuration(
     A Configurations object represents how features should be configured for terminal readers.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["terminal.configuration"]
-    ] = "terminal.configuration"
+    OBJECT_NAME: ClassVar[Literal["terminal.configuration"]] = (
+        "terminal.configuration"
+    )
 
     class BbposWiseposE(StripeObject):
         splashscreen: Optional[ExpandableField["File"]]
@@ -1085,7 +1085,6 @@ class Configuration(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -1106,7 +1105,6 @@ class Configuration(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/terminal/_connection_token.py
+++ b/stripe/terminal/_connection_token.py
@@ -13,9 +13,9 @@ class ConnectionToken(CreateableAPIResource["ConnectionToken"]):
     Related guide: [Fleet management](https://stripe.com/docs/terminal/fleet/locations)
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["terminal.connection_token"]
-    ] = "terminal.connection_token"
+    OBJECT_NAME: ClassVar[Literal["terminal.connection_token"]] = (
+        "terminal.connection_token"
+    )
 
     class CreateParams(RequestOptions):
         expand: NotRequired[List[str]]

--- a/stripe/terminal/_location.py
+++ b/stripe/terminal/_location.py
@@ -346,7 +346,6 @@ class Location(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -367,7 +366,6 @@ class Location(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/terminal/_reader.py
+++ b/stripe/terminal/_reader.py
@@ -824,7 +824,6 @@ class Reader(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -845,7 +844,6 @@ class Reader(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -1356,7 +1354,7 @@ class Reader(
         def _cls_present_payment_method(
             cls,
             reader: str,
-            **params: Unpack["Reader.PresentPaymentMethodParams"]
+            **params: Unpack["Reader.PresentPaymentMethodParams"],
         ) -> "Reader":
             """
             Presents a payment method on a simulated reader. Can be used to simulate accepting a payment, saving a card or refunding a transaction.
@@ -1413,7 +1411,7 @@ class Reader(
         async def _cls_present_payment_method_async(
             cls,
             reader: str,
-            **params: Unpack["Reader.PresentPaymentMethodParams"]
+            **params: Unpack["Reader.PresentPaymentMethodParams"],
         ) -> "Reader":
             """
             Presents a payment method on a simulated reader. Can be used to simulate accepting a payment, saving a card or refunding a transaction.

--- a/stripe/test_helpers/_test_clock.py
+++ b/stripe/test_helpers/_test_clock.py
@@ -21,9 +21,9 @@ class TestClock(
     you can either validate the current state of your scenario (and test your assumptions), change the current state of your scenario (and test more complex scenarios), or keep advancing forward in time.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["test_helpers.test_clock"]
-    ] = "test_helpers.test_clock"
+    OBJECT_NAME: ClassVar[Literal["test_helpers.test_clock"]] = (
+        "test_helpers.test_clock"
+    )
 
     class AdvanceParams(RequestOptions):
         expand: NotRequired[List[str]]
@@ -364,7 +364,6 @@ class TestClock(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -385,7 +384,6 @@ class TestClock(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/test_helpers/issuing/_personalization_design_service.py
+++ b/stripe/test_helpers/issuing/_personalization_design_service.py
@@ -26,7 +26,9 @@ class PersonalizationDesignService(StripeService):
         """
         Specifies which fields in the response should be expanded.
         """
-        rejection_reasons: "PersonalizationDesignService.RejectParamsRejectionReasons"
+        rejection_reasons: (
+            "PersonalizationDesignService.RejectParamsRejectionReasons"
+        )
         """
         The reason(s) the personalization design was rejected.
         """

--- a/stripe/treasury/_credit_reversal.py
+++ b/stripe/treasury/_credit_reversal.py
@@ -21,9 +21,9 @@ class CreditReversal(
     You can reverse some [ReceivedCredits](https://stripe.com/docs/api#received_credits) depending on their network and source flow. Reversing a ReceivedCredit leads to the creation of a new object known as a CreditReversal.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["treasury.credit_reversal"]
-    ] = "treasury.credit_reversal"
+    OBJECT_NAME: ClassVar[Literal["treasury.credit_reversal"]] = (
+        "treasury.credit_reversal"
+    )
 
     class StatusTransitions(StripeObject):
         posted_at: Optional[int]
@@ -180,7 +180,6 @@ class CreditReversal(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -201,7 +200,6 @@ class CreditReversal(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/treasury/_debit_reversal.py
+++ b/stripe/treasury/_debit_reversal.py
@@ -21,9 +21,9 @@ class DebitReversal(
     You can reverse some [ReceivedDebits](https://stripe.com/docs/api#received_debits) depending on their network and source flow. Reversing a ReceivedDebit leads to the creation of a new object known as a DebitReversal.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["treasury.debit_reversal"]
-    ] = "treasury.debit_reversal"
+    OBJECT_NAME: ClassVar[Literal["treasury.debit_reversal"]] = (
+        "treasury.debit_reversal"
+    )
 
     class LinkedFlows(StripeObject):
         issuing_dispute: Optional[str]
@@ -194,7 +194,6 @@ class DebitReversal(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -215,7 +214,6 @@ class DebitReversal(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/treasury/_financial_account.py
+++ b/stripe/treasury/_financial_account.py
@@ -32,9 +32,9 @@ class FinancialAccount(
     FinancialAccounts serve as the source and destination of Treasury's money movement APIs.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["treasury.financial_account"]
-    ] = "treasury.financial_account"
+    OBJECT_NAME: ClassVar[Literal["treasury.financial_account"]] = (
+        "treasury.financial_account"
+    )
 
     class Balance(StripeObject):
         cash: Dict[str, int]
@@ -811,7 +811,6 @@ class FinancialAccount(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -832,7 +831,6 @@ class FinancialAccount(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -900,7 +898,7 @@ class FinancialAccount(
     def _cls_retrieve_features(
         cls,
         financial_account: str,
-        **params: Unpack["FinancialAccount.RetrieveFeaturesParams"]
+        **params: Unpack["FinancialAccount.RetrieveFeaturesParams"],
     ) -> "FinancialAccountFeatures":
         """
         Retrieves Features information associated with the FinancialAccount.
@@ -920,7 +918,7 @@ class FinancialAccount(
     @staticmethod
     def retrieve_features(
         financial_account: str,
-        **params: Unpack["FinancialAccount.RetrieveFeaturesParams"]
+        **params: Unpack["FinancialAccount.RetrieveFeaturesParams"],
     ) -> "FinancialAccountFeatures":
         """
         Retrieves Features information associated with the FinancialAccount.
@@ -958,7 +956,7 @@ class FinancialAccount(
     async def _cls_retrieve_features_async(
         cls,
         financial_account: str,
-        **params: Unpack["FinancialAccount.RetrieveFeaturesParams"]
+        **params: Unpack["FinancialAccount.RetrieveFeaturesParams"],
     ) -> "FinancialAccountFeatures":
         """
         Retrieves Features information associated with the FinancialAccount.
@@ -978,7 +976,7 @@ class FinancialAccount(
     @staticmethod
     async def retrieve_features_async(
         financial_account: str,
-        **params: Unpack["FinancialAccount.RetrieveFeaturesParams"]
+        **params: Unpack["FinancialAccount.RetrieveFeaturesParams"],
     ) -> "FinancialAccountFeatures":
         """
         Retrieves Features information associated with the FinancialAccount.
@@ -1016,7 +1014,7 @@ class FinancialAccount(
     def _cls_update_features(
         cls,
         financial_account: str,
-        **params: Unpack["FinancialAccount.UpdateFeaturesParams"]
+        **params: Unpack["FinancialAccount.UpdateFeaturesParams"],
     ) -> "FinancialAccountFeatures":
         """
         Updates the Features associated with a FinancialAccount.
@@ -1036,7 +1034,7 @@ class FinancialAccount(
     @staticmethod
     def update_features(
         financial_account: str,
-        **params: Unpack["FinancialAccount.UpdateFeaturesParams"]
+        **params: Unpack["FinancialAccount.UpdateFeaturesParams"],
     ) -> "FinancialAccountFeatures":
         """
         Updates the Features associated with a FinancialAccount.
@@ -1074,7 +1072,7 @@ class FinancialAccount(
     async def _cls_update_features_async(
         cls,
         financial_account: str,
-        **params: Unpack["FinancialAccount.UpdateFeaturesParams"]
+        **params: Unpack["FinancialAccount.UpdateFeaturesParams"],
     ) -> "FinancialAccountFeatures":
         """
         Updates the Features associated with a FinancialAccount.
@@ -1094,7 +1092,7 @@ class FinancialAccount(
     @staticmethod
     async def update_features_async(
         financial_account: str,
-        **params: Unpack["FinancialAccount.UpdateFeaturesParams"]
+        **params: Unpack["FinancialAccount.UpdateFeaturesParams"],
     ) -> "FinancialAccountFeatures":
         """
         Updates the Features associated with a FinancialAccount.

--- a/stripe/treasury/_financial_account_features.py
+++ b/stripe/treasury/_financial_account_features.py
@@ -11,9 +11,9 @@ class FinancialAccountFeatures(StripeObject):
     Stripe or the platform can control Features via the requested field.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["treasury.financial_account_features"]
-    ] = "treasury.financial_account_features"
+    OBJECT_NAME: ClassVar[Literal["treasury.financial_account_features"]] = (
+        "treasury.financial_account_features"
+    )
 
     class CardIssuing(StripeObject):
         class StatusDetail(StripeObject):

--- a/stripe/treasury/_inbound_transfer.py
+++ b/stripe/treasury/_inbound_transfer.py
@@ -31,9 +31,9 @@ class InboundTransfer(
     Use [InboundTransfers](https://stripe.com/docs/treasury/moving-money/financial-accounts/into/inbound-transfers) to add funds to your [FinancialAccount](https://stripe.com/docs/api#financial_accounts) via a PaymentMethod that is owned by you. The funds will be transferred via an ACH debit.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["treasury.inbound_transfer"]
-    ] = "treasury.inbound_transfer"
+    OBJECT_NAME: ClassVar[Literal["treasury.inbound_transfer"]] = (
+        "treasury.inbound_transfer"
+    )
 
     class FailureDetails(StripeObject):
         code: Literal[
@@ -358,7 +358,7 @@ class InboundTransfer(
     def _cls_cancel(
         cls,
         inbound_transfer: str,
-        **params: Unpack["InboundTransfer.CancelParams"]
+        **params: Unpack["InboundTransfer.CancelParams"],
     ) -> "InboundTransfer":
         """
         Cancels an InboundTransfer.
@@ -415,7 +415,7 @@ class InboundTransfer(
     async def _cls_cancel_async(
         cls,
         inbound_transfer: str,
-        **params: Unpack["InboundTransfer.CancelParams"]
+        **params: Unpack["InboundTransfer.CancelParams"],
     ) -> "InboundTransfer":
         """
         Cancels an InboundTransfer.
@@ -513,7 +513,6 @@ class InboundTransfer(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -534,7 +533,6 @@ class InboundTransfer(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -681,7 +679,7 @@ class InboundTransfer(
         def _cls_return_inbound_transfer(
             cls,
             id: str,
-            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"]
+            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"],
         ) -> "InboundTransfer":
             """
             Marks the test mode InboundTransfer object as returned and links the InboundTransfer to a ReceivedDebit. The InboundTransfer must already be in the succeeded state.
@@ -701,7 +699,7 @@ class InboundTransfer(
         @staticmethod
         def return_inbound_transfer(
             id: str,
-            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"]
+            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"],
         ) -> "InboundTransfer":
             """
             Marks the test mode InboundTransfer object as returned and links the InboundTransfer to a ReceivedDebit. The InboundTransfer must already be in the succeeded state.
@@ -711,7 +709,7 @@ class InboundTransfer(
         @overload
         def return_inbound_transfer(
             self,
-            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"]
+            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"],
         ) -> "InboundTransfer":
             """
             Marks the test mode InboundTransfer object as returned and links the InboundTransfer to a ReceivedDebit. The InboundTransfer must already be in the succeeded state.
@@ -721,7 +719,7 @@ class InboundTransfer(
         @class_method_variant("_cls_return_inbound_transfer")
         def return_inbound_transfer(  # pyright: ignore[reportGeneralTypeIssues]
             self,
-            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"]
+            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"],
         ) -> "InboundTransfer":
             """
             Marks the test mode InboundTransfer object as returned and links the InboundTransfer to a ReceivedDebit. The InboundTransfer must already be in the succeeded state.
@@ -741,7 +739,7 @@ class InboundTransfer(
         async def _cls_return_inbound_transfer_async(
             cls,
             id: str,
-            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"]
+            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"],
         ) -> "InboundTransfer":
             """
             Marks the test mode InboundTransfer object as returned and links the InboundTransfer to a ReceivedDebit. The InboundTransfer must already be in the succeeded state.
@@ -761,7 +759,7 @@ class InboundTransfer(
         @staticmethod
         async def return_inbound_transfer_async(
             id: str,
-            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"]
+            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"],
         ) -> "InboundTransfer":
             """
             Marks the test mode InboundTransfer object as returned and links the InboundTransfer to a ReceivedDebit. The InboundTransfer must already be in the succeeded state.
@@ -771,7 +769,7 @@ class InboundTransfer(
         @overload
         async def return_inbound_transfer_async(
             self,
-            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"]
+            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"],
         ) -> "InboundTransfer":
             """
             Marks the test mode InboundTransfer object as returned and links the InboundTransfer to a ReceivedDebit. The InboundTransfer must already be in the succeeded state.
@@ -781,7 +779,7 @@ class InboundTransfer(
         @class_method_variant("_cls_return_inbound_transfer_async")
         async def return_inbound_transfer_async(  # pyright: ignore[reportGeneralTypeIssues]
             self,
-            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"]
+            **params: Unpack["InboundTransfer.ReturnInboundTransferParams"],
         ) -> "InboundTransfer":
             """
             Marks the test mode InboundTransfer object as returned and links the InboundTransfer to a ReceivedDebit. The InboundTransfer must already be in the succeeded state.

--- a/stripe/treasury/_outbound_payment.py
+++ b/stripe/treasury/_outbound_payment.py
@@ -33,9 +33,9 @@ class OutboundPayment(
     Simulate OutboundPayment state changes with the `/v1/test_helpers/treasury/outbound_payments` endpoints. These methods can only be called on test mode objects.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["treasury.outbound_payment"]
-    ] = "treasury.outbound_payment"
+    OBJECT_NAME: ClassVar[Literal["treasury.outbound_payment"]] = (
+        "treasury.outbound_payment"
+    )
 
     class DestinationPaymentMethodDetails(StripeObject):
         class BillingDetails(StripeObject):
@@ -777,7 +777,6 @@ class OutboundPayment(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -798,7 +797,6 @@ class OutboundPayment(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -1055,7 +1053,7 @@ class OutboundPayment(
         def _cls_return_outbound_payment(
             cls,
             id: str,
-            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"]
+            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"],
         ) -> "OutboundPayment":
             """
             Transitions a test mode created OutboundPayment to the returned status. The OutboundPayment must already be in the processing state.
@@ -1075,7 +1073,7 @@ class OutboundPayment(
         @staticmethod
         def return_outbound_payment(
             id: str,
-            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"]
+            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"],
         ) -> "OutboundPayment":
             """
             Transitions a test mode created OutboundPayment to the returned status. The OutboundPayment must already be in the processing state.
@@ -1085,7 +1083,7 @@ class OutboundPayment(
         @overload
         def return_outbound_payment(
             self,
-            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"]
+            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"],
         ) -> "OutboundPayment":
             """
             Transitions a test mode created OutboundPayment to the returned status. The OutboundPayment must already be in the processing state.
@@ -1095,7 +1093,7 @@ class OutboundPayment(
         @class_method_variant("_cls_return_outbound_payment")
         def return_outbound_payment(  # pyright: ignore[reportGeneralTypeIssues]
             self,
-            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"]
+            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"],
         ) -> "OutboundPayment":
             """
             Transitions a test mode created OutboundPayment to the returned status. The OutboundPayment must already be in the processing state.
@@ -1115,7 +1113,7 @@ class OutboundPayment(
         async def _cls_return_outbound_payment_async(
             cls,
             id: str,
-            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"]
+            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"],
         ) -> "OutboundPayment":
             """
             Transitions a test mode created OutboundPayment to the returned status. The OutboundPayment must already be in the processing state.
@@ -1135,7 +1133,7 @@ class OutboundPayment(
         @staticmethod
         async def return_outbound_payment_async(
             id: str,
-            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"]
+            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"],
         ) -> "OutboundPayment":
             """
             Transitions a test mode created OutboundPayment to the returned status. The OutboundPayment must already be in the processing state.
@@ -1145,7 +1143,7 @@ class OutboundPayment(
         @overload
         async def return_outbound_payment_async(
             self,
-            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"]
+            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"],
         ) -> "OutboundPayment":
             """
             Transitions a test mode created OutboundPayment to the returned status. The OutboundPayment must already be in the processing state.
@@ -1155,7 +1153,7 @@ class OutboundPayment(
         @class_method_variant("_cls_return_outbound_payment_async")
         async def return_outbound_payment_async(  # pyright: ignore[reportGeneralTypeIssues]
             self,
-            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"]
+            **params: Unpack["OutboundPayment.ReturnOutboundPaymentParams"],
         ) -> "OutboundPayment":
             """
             Transitions a test mode created OutboundPayment to the returned status. The OutboundPayment must already be in the processing state.

--- a/stripe/treasury/_outbound_transfer.py
+++ b/stripe/treasury/_outbound_transfer.py
@@ -33,9 +33,9 @@ class OutboundTransfer(
     Simulate OutboundTransfer state changes with the `/v1/test_helpers/treasury/outbound_transfers` endpoints. These methods can only be called on test mode objects.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["treasury.outbound_transfer"]
-    ] = "treasury.outbound_transfer"
+    OBJECT_NAME: ClassVar[Literal["treasury.outbound_transfer"]] = (
+        "treasury.outbound_transfer"
+    )
 
     class DestinationPaymentMethodDetails(StripeObject):
         class BillingDetails(StripeObject):
@@ -443,7 +443,7 @@ class OutboundTransfer(
     def _cls_cancel(
         cls,
         outbound_transfer: str,
-        **params: Unpack["OutboundTransfer.CancelParams"]
+        **params: Unpack["OutboundTransfer.CancelParams"],
     ) -> "OutboundTransfer":
         """
         An OutboundTransfer can be canceled if the funds have not yet been paid out.
@@ -463,7 +463,7 @@ class OutboundTransfer(
     @staticmethod
     def cancel(
         outbound_transfer: str,
-        **params: Unpack["OutboundTransfer.CancelParams"]
+        **params: Unpack["OutboundTransfer.CancelParams"],
     ) -> "OutboundTransfer":
         """
         An OutboundTransfer can be canceled if the funds have not yet been paid out.
@@ -501,7 +501,7 @@ class OutboundTransfer(
     async def _cls_cancel_async(
         cls,
         outbound_transfer: str,
-        **params: Unpack["OutboundTransfer.CancelParams"]
+        **params: Unpack["OutboundTransfer.CancelParams"],
     ) -> "OutboundTransfer":
         """
         An OutboundTransfer can be canceled if the funds have not yet been paid out.
@@ -521,7 +521,7 @@ class OutboundTransfer(
     @staticmethod
     async def cancel_async(
         outbound_transfer: str,
-        **params: Unpack["OutboundTransfer.CancelParams"]
+        **params: Unpack["OutboundTransfer.CancelParams"],
     ) -> "OutboundTransfer":
         """
         An OutboundTransfer can be canceled if the funds have not yet been paid out.
@@ -600,7 +600,6 @@ class OutboundTransfer(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -621,7 +620,6 @@ class OutboundTransfer(
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -658,7 +656,7 @@ class OutboundTransfer(
         def _cls_fail(
             cls,
             outbound_transfer: str,
-            **params: Unpack["OutboundTransfer.FailParams"]
+            **params: Unpack["OutboundTransfer.FailParams"],
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the failed status. The OutboundTransfer must already be in the processing state.
@@ -678,7 +676,7 @@ class OutboundTransfer(
         @staticmethod
         def fail(
             outbound_transfer: str,
-            **params: Unpack["OutboundTransfer.FailParams"]
+            **params: Unpack["OutboundTransfer.FailParams"],
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the failed status. The OutboundTransfer must already be in the processing state.
@@ -716,7 +714,7 @@ class OutboundTransfer(
         async def _cls_fail_async(
             cls,
             outbound_transfer: str,
-            **params: Unpack["OutboundTransfer.FailParams"]
+            **params: Unpack["OutboundTransfer.FailParams"],
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the failed status. The OutboundTransfer must already be in the processing state.
@@ -736,7 +734,7 @@ class OutboundTransfer(
         @staticmethod
         async def fail_async(
             outbound_transfer: str,
-            **params: Unpack["OutboundTransfer.FailParams"]
+            **params: Unpack["OutboundTransfer.FailParams"],
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the failed status. The OutboundTransfer must already be in the processing state.
@@ -774,7 +772,7 @@ class OutboundTransfer(
         def _cls_post(
             cls,
             outbound_transfer: str,
-            **params: Unpack["OutboundTransfer.PostParams"]
+            **params: Unpack["OutboundTransfer.PostParams"],
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the posted status. The OutboundTransfer must already be in the processing state.
@@ -794,7 +792,7 @@ class OutboundTransfer(
         @staticmethod
         def post(
             outbound_transfer: str,
-            **params: Unpack["OutboundTransfer.PostParams"]
+            **params: Unpack["OutboundTransfer.PostParams"],
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the posted status. The OutboundTransfer must already be in the processing state.
@@ -832,7 +830,7 @@ class OutboundTransfer(
         async def _cls_post_async(
             cls,
             outbound_transfer: str,
-            **params: Unpack["OutboundTransfer.PostParams"]
+            **params: Unpack["OutboundTransfer.PostParams"],
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the posted status. The OutboundTransfer must already be in the processing state.
@@ -852,7 +850,7 @@ class OutboundTransfer(
         @staticmethod
         async def post_async(
             outbound_transfer: str,
-            **params: Unpack["OutboundTransfer.PostParams"]
+            **params: Unpack["OutboundTransfer.PostParams"],
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the posted status. The OutboundTransfer must already be in the processing state.
@@ -890,7 +888,7 @@ class OutboundTransfer(
         def _cls_return_outbound_transfer(
             cls,
             outbound_transfer: str,
-            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"]
+            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"],
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the returned status. The OutboundTransfer must already be in the processing state.
@@ -910,7 +908,7 @@ class OutboundTransfer(
         @staticmethod
         def return_outbound_transfer(
             outbound_transfer: str,
-            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"]
+            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"],
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the returned status. The OutboundTransfer must already be in the processing state.
@@ -920,7 +918,7 @@ class OutboundTransfer(
         @overload
         def return_outbound_transfer(
             self,
-            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"]
+            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"],
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the returned status. The OutboundTransfer must already be in the processing state.
@@ -930,7 +928,7 @@ class OutboundTransfer(
         @class_method_variant("_cls_return_outbound_transfer")
         def return_outbound_transfer(  # pyright: ignore[reportGeneralTypeIssues]
             self,
-            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"]
+            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"],
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the returned status. The OutboundTransfer must already be in the processing state.
@@ -950,7 +948,7 @@ class OutboundTransfer(
         async def _cls_return_outbound_transfer_async(
             cls,
             outbound_transfer: str,
-            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"]
+            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"],
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the returned status. The OutboundTransfer must already be in the processing state.
@@ -970,7 +968,7 @@ class OutboundTransfer(
         @staticmethod
         async def return_outbound_transfer_async(
             outbound_transfer: str,
-            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"]
+            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"],
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the returned status. The OutboundTransfer must already be in the processing state.
@@ -980,7 +978,7 @@ class OutboundTransfer(
         @overload
         async def return_outbound_transfer_async(
             self,
-            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"]
+            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"],
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the returned status. The OutboundTransfer must already be in the processing state.
@@ -990,7 +988,7 @@ class OutboundTransfer(
         @class_method_variant("_cls_return_outbound_transfer_async")
         async def return_outbound_transfer_async(  # pyright: ignore[reportGeneralTypeIssues]
             self,
-            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"]
+            **params: Unpack["OutboundTransfer.ReturnOutboundTransferParams"],
         ) -> "OutboundTransfer":
             """
             Transitions a test mode created OutboundTransfer to the returned status. The OutboundTransfer must already be in the processing state.
@@ -1010,7 +1008,7 @@ class OutboundTransfer(
         def _cls_update(
             cls,
             outbound_transfer: str,
-            **params: Unpack["OutboundTransfer.UpdateParams"]
+            **params: Unpack["OutboundTransfer.UpdateParams"],
         ) -> "OutboundTransfer":
             """
             Updates a test mode created OutboundTransfer with tracking details. The OutboundTransfer must not be cancelable, and cannot be in the canceled or failed states.
@@ -1030,7 +1028,7 @@ class OutboundTransfer(
         @staticmethod
         def update(
             outbound_transfer: str,
-            **params: Unpack["OutboundTransfer.UpdateParams"]
+            **params: Unpack["OutboundTransfer.UpdateParams"],
         ) -> "OutboundTransfer":
             """
             Updates a test mode created OutboundTransfer with tracking details. The OutboundTransfer must not be cancelable, and cannot be in the canceled or failed states.
@@ -1068,7 +1066,7 @@ class OutboundTransfer(
         async def _cls_update_async(
             cls,
             outbound_transfer: str,
-            **params: Unpack["OutboundTransfer.UpdateParams"]
+            **params: Unpack["OutboundTransfer.UpdateParams"],
         ) -> "OutboundTransfer":
             """
             Updates a test mode created OutboundTransfer with tracking details. The OutboundTransfer must not be cancelable, and cannot be in the canceled or failed states.
@@ -1088,7 +1086,7 @@ class OutboundTransfer(
         @staticmethod
         async def update_async(
             outbound_transfer: str,
-            **params: Unpack["OutboundTransfer.UpdateParams"]
+            **params: Unpack["OutboundTransfer.UpdateParams"],
         ) -> "OutboundTransfer":
             """
             Updates a test mode created OutboundTransfer with tracking details. The OutboundTransfer must not be cancelable, and cannot be in the canceled or failed states.

--- a/stripe/treasury/_received_credit.py
+++ b/stripe/treasury/_received_credit.py
@@ -28,9 +28,9 @@ class ReceivedCredit(ListableAPIResource["ReceivedCredit"]):
     ReceivedCredits represent funds sent to a [FinancialAccount](https://stripe.com/docs/api#financial_accounts) (for example, via ACH or wire). These money movements are not initiated from the FinancialAccount.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["treasury.received_credit"]
-    ] = "treasury.received_credit"
+    OBJECT_NAME: ClassVar[Literal["treasury.received_credit"]] = (
+        "treasury.received_credit"
+    )
 
     class InitiatingPaymentMethodDetails(StripeObject):
         class BillingDetails(StripeObject):
@@ -372,7 +372,6 @@ class ReceivedCredit(ListableAPIResource["ReceivedCredit"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -393,7 +392,6 @@ class ReceivedCredit(ListableAPIResource["ReceivedCredit"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/treasury/_received_debit.py
+++ b/stripe/treasury/_received_debit.py
@@ -25,9 +25,9 @@ class ReceivedDebit(ListableAPIResource["ReceivedDebit"]):
     ReceivedDebits represent funds pulled from a [FinancialAccount](https://stripe.com/docs/api#financial_accounts). These are not initiated from the FinancialAccount.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["treasury.received_debit"]
-    ] = "treasury.received_debit"
+    OBJECT_NAME: ClassVar[Literal["treasury.received_debit"]] = (
+        "treasury.received_debit"
+    )
 
     class InitiatingPaymentMethodDetails(StripeObject):
         class BillingDetails(StripeObject):
@@ -325,7 +325,6 @@ class ReceivedDebit(ListableAPIResource["ReceivedDebit"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -346,7 +345,6 @@ class ReceivedDebit(ListableAPIResource["ReceivedDebit"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/treasury/_transaction.py
+++ b/stripe/treasury/_transaction.py
@@ -30,9 +30,9 @@ class Transaction(ListableAPIResource["Transaction"]):
     Transactions represent changes to a [FinancialAccount's](https://stripe.com/docs/api#financial_accounts) balance.
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["treasury.transaction"]
-    ] = "treasury.transaction"
+    OBJECT_NAME: ClassVar[Literal["treasury.transaction"]] = (
+        "treasury.transaction"
+    )
 
     class BalanceImpact(StripeObject):
         cash: int
@@ -285,7 +285,6 @@ class Transaction(ListableAPIResource["Transaction"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -306,7 +305,6 @@ class Transaction(ListableAPIResource["Transaction"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/stripe/treasury/_transaction_entry.py
+++ b/stripe/treasury/_transaction_entry.py
@@ -31,9 +31,9 @@ class TransactionEntry(ListableAPIResource["TransactionEntry"]):
     TransactionEntries represent individual units of money movements within a single [Transaction](https://stripe.com/docs/api#transactions).
     """
 
-    OBJECT_NAME: ClassVar[
-        Literal["treasury.transaction_entry"]
-    ] = "treasury.transaction_entry"
+    OBJECT_NAME: ClassVar[Literal["treasury.transaction_entry"]] = (
+        "treasury.transaction_entry"
+    )
 
     class BalanceImpact(StripeObject):
         cash: int
@@ -279,7 +279,6 @@ class TransactionEntry(ListableAPIResource["TransactionEntry"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)
@@ -300,7 +299,6 @@ class TransactionEntry(ListableAPIResource["TransactionEntry"]):
             params=params,
         )
         if not isinstance(result, ListObject):
-
             raise TypeError(
                 "Expected list object from API, got %s"
                 % (type(result).__name__)

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -829,7 +829,7 @@ class TestAPIRequestor(object):
 
     def test_raw_request_with_file_param(self, requestor, http_client_mock):
         test_file = tempfile.NamedTemporaryFile()
-        test_file.write("\u263A".encode("utf-16"))
+        test_file.write("\u263a".encode("utf-16"))
         test_file.seek(0)
         meth = "post"
         path = "/v1/files"

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -23,20 +23,25 @@ def assert_output(code: str, expected: str) -> None:
 
 
 def test_can_import_stripe_object() -> None:
+    # fmt: off
     from stripe.stripe_object import StripeObject as StripeObjectFromStripeStripeObject  # type: ignore
+    # fmt: on
     from stripe import (
         StripeObject as StripeObjectFromStripe,
     )
 
-    assert (
-        stripe.stripe_object.StripeObject is StripeObjectFromStripeStripeObject  # type: ignore
-    )
+    # fmt: off
+    assert stripe.stripe_object.StripeObject is StripeObjectFromStripeStripeObject  # type: ignore
+    # fmt: on
     assert stripe.StripeObject is StripeObjectFromStripeStripeObject
     assert StripeObjectFromStripe is StripeObjectFromStripeStripeObject
 
 
 def test_can_import_request_options() -> None:
+    # fmt: off
     from stripe.request_options import RequestOptions as RequestOptionsStripeRequestOptions  # type: ignore
+    # fmt: on
+
     from stripe import (
         RequestOptions as RequestOptionsFromStripe,
     )
@@ -47,10 +52,13 @@ def test_can_import_request_options() -> None:
 
 def test_can_import_http_client() -> None:
     from stripe.http_client import HTTPClient as HTTPClientFromStripeHTTPClient  # type: ignore
+
+    # fmt: off
     from stripe.http_client import PycurlClient as PycurlClientFromStripeHTTPClient  # type: ignore
     from stripe.http_client import RequestsClient as RequestsClientFromStripeHTTPClient  # type: ignore
     from stripe.http_client import UrlFetchClient as UrlFetchClientFromStripeHTTPClient  # type: ignore
     from stripe.http_client import new_default_http_client as new_default_http_clientFromStripeHTTPClient  # type: ignore
+    # fmt: on
 
     from stripe import (
         HTTPClient as HTTPClientFromStripe,
@@ -81,7 +89,10 @@ def test_can_import_http_client() -> None:
 
 def test_can_import_webhook_members() -> None:
     from stripe.webhook import Webhook as WebhookFromStripeWebhook  # type: ignore
+
+    # fmt: off
     from stripe.webhook import WebhookSignature as WebhookSignatureFromStripeWebhook  # type: ignore
+    # fmt: on
 
     from stripe import (
         Webhook,
@@ -96,7 +107,6 @@ def test_can_import_webhook_members() -> None:
 
 
 def test_can_import_list_search_objects() -> None:
-
     # This import has to be single line, mypy and pyright are producing errors
     # on different lines of multiline import
     # fmt: off
@@ -128,8 +138,11 @@ def test_can_import_misc_resources() -> None:
         ErrorObject as ErrorObjectFromStripe,
         OAuthErrorObject as OAuthErrorObjectFromStripe,
     )
+
+    # fmt: off
     from stripe.api_resources.error_object import ErrorObject as ErrorObjectFromStripeApiResources  # type: ignore
     from stripe.api_resources.error_object import OAuthErrorObject as OAuthErrorObjectFromStripeApiResources  # type: ignore
+    # fmt: on
 
     # FileUpload is an old alias for File, time to hide it
     from stripe.api_resources import FileUpload as FileUploadFromApiResources  # type: ignore
@@ -245,9 +258,11 @@ def test_can_import_app_info() -> None:
 
 
 def test_can_import_stripe_response() -> None:
+    # fmt: off
     from stripe.stripe_response import StripeResponse as StripeResponseFromStripeResponse  # type: ignore
     from stripe.stripe_response import StripeResponseBase as StripeResponseBaseFromStripeResponse  # type: ignore
     from stripe.stripe_response import StripeStreamResponse as StripeStreamResponseFromStripeResponse  # type: ignore
+    # fmt: on
 
     from stripe import (
         StripeResponse as StripeResponseFromStripe,
@@ -288,7 +303,10 @@ def test_can_import_oauth_members() -> None:
 
 
 def test_can_import_util() -> None:
+    # fmt: off
     from stripe.util import convert_to_stripe_object as convert_to_stripe_objectFromStripeUtil  # type: ignore
+    # fmt: on
+
     from stripe import (
         convert_to_stripe_object as convert_to_stripe_objectFromStripe,
     )
@@ -383,7 +401,9 @@ def test_can_import_namespaced_resource() -> None:
 
     # This import has to be single line, mypy and pyright are producing errors
     # on different lines of multiline import
+    # fmt: off
     from stripe.api_resources.tax.calculation import Calculation as CalcFromModule  # type: ignore
+    # fmt: on
 
     assert stripe.tax is TaxPackage
     assert stripe.tax.Calculation is CalculationFromStripe

--- a/tests/test_generated_examples.py
+++ b/tests/test_generated_examples.py
@@ -26935,8 +26935,10 @@ class TestGeneratedExamples(object):
             http_client=http_client_mock.get_mock_http_client(),
         )
 
-        await client.test_helpers.issuing.personalization_designs.activate_async(
-            "pd_xyz"
+        await (
+            client.test_helpers.issuing.personalization_designs.activate_async(
+                "pd_xyz"
+            )
         )
         http_client_mock.assert_requested(
             "post",
@@ -26981,8 +26983,10 @@ class TestGeneratedExamples(object):
     async def test_test_helpers_issuing_personalization_designs_deactivate_post_async(
         self, http_client_mock: HTTPClientMock
     ) -> None:
-        await stripe.issuing.PersonalizationDesign.TestHelpers.deactivate_async(
-            "pd_xyz",
+        await (
+            stripe.issuing.PersonalizationDesign.TestHelpers.deactivate_async(
+                "pd_xyz",
+            )
         )
         http_client_mock.assert_requested(
             "post",
@@ -27225,54 +27229,56 @@ class TestGeneratedExamples(object):
     async def test_test_helpers_issuing_transactions_create_force_capture_post_async(
         self, http_client_mock: HTTPClientMock
     ) -> None:
-        await stripe.issuing.Transaction.TestHelpers.create_force_capture_async(
-            amount=100,
-            card="foo",
-            currency="usd",
-            merchant_data={
-                "category": "ac_refrigeration_repair",
-                "city": "foo",
-                "country": "US",
-                "name": "foo",
-                "network_id": "bar",
-                "postal_code": "10001",
-                "state": "NY",
-                "terminal_id": "foo",
-            },
-            purchase_details={
-                "flight": {
-                    "departure_at": 1633651200,
-                    "passenger_name": "John Doe",
-                    "refundable": True,
-                    "segments": [
+        await (
+            stripe.issuing.Transaction.TestHelpers.create_force_capture_async(
+                amount=100,
+                card="foo",
+                currency="usd",
+                merchant_data={
+                    "category": "ac_refrigeration_repair",
+                    "city": "foo",
+                    "country": "US",
+                    "name": "foo",
+                    "network_id": "bar",
+                    "postal_code": "10001",
+                    "state": "NY",
+                    "terminal_id": "foo",
+                },
+                purchase_details={
+                    "flight": {
+                        "departure_at": 1633651200,
+                        "passenger_name": "John Doe",
+                        "refundable": True,
+                        "segments": [
+                            {
+                                "arrival_airport_code": "SFO",
+                                "carrier": "Delta",
+                                "departure_airport_code": "LAX",
+                                "flight_number": "DL100",
+                                "service_class": "Economy",
+                                "stopover_allowed": True,
+                            },
+                        ],
+                        "travel_agency": "Orbitz",
+                    },
+                    "fuel": {
+                        "type": "diesel",
+                        "unit": "liter",
+                        "unit_cost_decimal": "3.5",
+                        "volume_decimal": "10",
+                    },
+                    "lodging": {"check_in_at": 1533651200, "nights": 2},
+                    "receipt": [
                         {
-                            "arrival_airport_code": "SFO",
-                            "carrier": "Delta",
-                            "departure_airport_code": "LAX",
-                            "flight_number": "DL100",
-                            "service_class": "Economy",
-                            "stopover_allowed": True,
+                            "description": "Room charge",
+                            "quantity": "1",
+                            "total": 200,
+                            "unit_cost": 200,
                         },
                     ],
-                    "travel_agency": "Orbitz",
+                    "reference": "foo",
                 },
-                "fuel": {
-                    "type": "diesel",
-                    "unit": "liter",
-                    "unit_cost_decimal": "3.5",
-                    "volume_decimal": "10",
-                },
-                "lodging": {"check_in_at": 1533651200, "nights": 2},
-                "receipt": [
-                    {
-                        "description": "Room charge",
-                        "quantity": "1",
-                        "total": 200,
-                        "unit_cost": 200,
-                    },
-                ],
-                "reference": "foo",
-            },
+            )
         )
         http_client_mock.assert_requested(
             "post",

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -467,9 +467,9 @@ class RequestsVerify(object):
 
 
 class TestRequestsClient(StripeClientTestCase, ClientTestBase):
-    REQUEST_CLIENT: Type[
+    REQUEST_CLIENT: Type[_http_client.RequestsClient] = (
         _http_client.RequestsClient
-    ] = _http_client.RequestsClient
+    )
 
     @pytest.fixture
     def session(self, mocker, request_mocks):
@@ -834,9 +834,9 @@ class TestUrlFetchClient(StripeClientTestCase, ClientTestBase):
 
 
 class TestUrllib2Client(StripeClientTestCase, ClientTestBase):
-    REQUEST_CLIENT: Type[
+    REQUEST_CLIENT: Type[_http_client.Urllib2Client] = (
         _http_client.Urllib2Client
-    ] = _http_client.Urllib2Client
+    )
 
     request_object: Any
 
@@ -1254,7 +1254,6 @@ class TestHTTPXClient(StripeClientTestCase, ClientTestBase):
     async def test_request_async(
         self, request_mock, mock_response, check_call_async
     ):
-
         mock_response(request_mock, '{"foo": "baz"}', 200)
 
         for method in VALID_API_METHODS:
@@ -1549,9 +1548,9 @@ class TestHTTPXClientRetryBehavior(TestHTTPXClient):
 
 
 class TestAIOHTTPClient(StripeClientTestCase, ClientTestBase):
-    REQUEST_CLIENT: Type[
+    REQUEST_CLIENT: Type[_http_client.AIOHTTPClient] = (
         _http_client.AIOHTTPClient
-    ] = _http_client.AIOHTTPClient
+    )
 
     @pytest.fixture
     def mock_response(self, mocker, request_mock):
@@ -1559,9 +1558,11 @@ class TestAIOHTTPClient(StripeClientTestCase, ClientTestBase):
             class Content:
                 def __aiter__(self):
                     async def chunk():
-                        yield bytes(body, "utf-8") if isinstance(
-                            body, str
-                        ) else body
+                        yield (
+                            bytes(body, "utf-8")
+                            if isinstance(body, str)
+                            else body
+                        )
 
                     return chunk()
 
@@ -1683,7 +1684,6 @@ class TestAIOHTTPClient(StripeClientTestCase, ClientTestBase):
     async def test_request_async(
         self, request_mock, mock_response, check_call_async
     ):
-
         mock_response(request_mock, '{"foo": "baz"}', 200)
 
         for method in VALID_API_METHODS:

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ skip_install = true
 commands =
   pyright: pyright {posargs}
   lint: python -m flake8  --show-source stripe tests setup.py
-  fmt: black . {posargs}
+  fmt: ruff format . {posargs}
   mypy: mypy {posargs}
 deps =
   -r requirements.txt


### PR DESCRIPTION
Per discussion, I've swapped from [black](https://black.readthedocs.io/en/stable/) to [ruff](https://docs.astral.sh/ruff/) for formatting. It's must faster when running `make codegen-format`:

Before:

```
558 files reformatted, 104 files left unchanged.
  fmt: OK (13.54=setup[0.05]+cmd[13.48] seconds)
  congratulations :) (13.61 seconds)
```

after:

```
474 files reformatted, 188 files left unchanged
  fmt: OK (0.40=setup[0.04]+cmd[0.35] seconds)
  congratulations :) (0.44 seconds)
```

I separated the PR into 3 main commits:

- tooling changes happened in 9b435797
- mass formatting happened in c46b4b95
- add a [rev ignore](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view) file in 15c3956a (so I don't get credit for a ton of git-blame lines)

So broadly, a reviewer will mostly want to look at the changes from the first commit. Past that, there are superficial formatting changes, but nothing serious.