### PR TITLE
don't auto-organize imports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,7 +19,10 @@
   // Formatting
   "editor.formatOnSave": true,
   "[python]": {
-    "editor.defaultFormatter": "charliermarsh.ruff"
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "never"
+    }
   },
 
   // Tests


### PR DESCRIPTION
Minor VSCode settings tweak to reduce noise in PRs.

I like auto-formatted imports, but our imports are not currently sorted (as far as VSCode is concerned). I was finding that auto-sorting added a lot of noise to PRs when I was working in unsorted files. Plus, this is a VS-code specific operation, so if team members use a different editor, imports would be unsorted until a VSCode user happened to work on the same file.

A better solution would ruff to handle the import sorting, which all editors (and tooling) will pick up and help us maintain. But that's slightly more involved, so short term I figured disabling the behavior was simpler.

If you want to sort imports manually, you can still run VSCode's Organize Imports command.