### PR TITLE
Do not share single RequestorOptions between APIRequestor instances

### DIFF
--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -72,9 +72,11 @@ class _APIRequestor(object):
 
     def __init__(
         self,
-        options: RequestorOptions = RequestorOptions(),
+        options: Optional[RequestorOptions] = None,
         client: Optional[HTTPClient] = None,
     ):
+        if options is None:
+            options = RequestorOptions()
         self._options = options
         self._client = client
 


### PR DESCRIPTION
Given `RequestorOptions` is internally mutable, it's probably not the intent that a single `RequestorOptions` is shared between all `APIRequestor`s that aren't explicitly passed one.