### PR TITLE
Chain exceptions when reraising them

### DIFF
--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -713,7 +713,7 @@ class RequestsClient(HTTPClient):
 
         return content, status_code, result.headers
 
-    def _handle_request_error(self, e) -> NoReturn:
+    def _handle_request_error(self, e: Exception) -> NoReturn:
         # Catch SSL error first as it belongs to ConnectionError,
         # but we don't want to retry
         if isinstance(e, self.requests.exceptions.SSLError):
@@ -764,7 +764,7 @@ class RequestsClient(HTTPClient):
             should_retry = False
 
         msg = textwrap.fill(msg) + "\n\n(Network error: %s)" % (err,)
-        raise APIConnectionError(msg, should_retry=should_retry)
+        raise APIConnectionError(msg, should_retry=should_retry) from e
 
     def close(self):
         if getattr(self._thread_local, "session", None) is not None:
@@ -869,7 +869,7 @@ class UrlFetchClient(HTTPClient):
 
         return content, result.status_code, result.headers
 
-    def _handle_request_error(self, e, url) -> NoReturn:
+    def _handle_request_error(self, e: Exception, url: str) -> NoReturn:
         if isinstance(e, self.urlfetch.InvalidURLError):
             msg = (
                 "The Stripe library attempted to fetch an "
@@ -892,7 +892,7 @@ class UrlFetchClient(HTTPClient):
             )
 
         msg = textwrap.fill(msg) + "\n\n(Network error: " + str(e) + ")"
-        raise APIConnectionError(msg)
+        raise APIConnectionError(msg) from e
 
     def close(self):
         pass
@@ -1046,7 +1046,7 @@ class PycurlClient(HTTPClient):
 
         return rcontent, rcode, headers
 
-    def _handle_request_error(self, e) -> NoReturn:
+    def _handle_request_error(self, e: Exception) -> NoReturn:
         if e.args[0] in [
             self.pycurl.E_COULDNT_CONNECT,
             self.pycurl.E_COULDNT_RESOLVE_HOST,
@@ -1079,7 +1079,7 @@ class PycurlClient(HTTPClient):
             should_retry = False
 
         msg = textwrap.fill(msg) + "\n\n(Network error: " + e.args[1] + ")"
-        raise APIConnectionError(msg, should_retry=should_retry)
+        raise APIConnectionError(msg, should_retry=should_retry) from e
 
     def _get_proxy(self, url) -> Optional[ParseResult]:
         if self._parsed_proxy:
@@ -1194,13 +1194,13 @@ class Urllib2Client(HTTPClient):
         lh = dict((k.lower(), v) for k, v in iter(dict(headers).items()))
         return rcontent, rcode, lh
 
-    def _handle_request_error(self, e) -> NoReturn:
+    def _handle_request_error(self, e: Exception) -> NoReturn:
         msg = (
             "Unexpected error communicating with Stripe. "
             "If this problem persists, let us know at support@stripe.com."
         )
         msg = textwrap.fill(msg) + "\n\n(Network error: " + str(e) + ")"
-        raise APIConnectionError(msg)
+        raise APIConnectionError(msg) from e
 
     def close(self):
         pass
@@ -1307,7 +1307,7 @@ class HTTPXClient(HTTPClient):
         response_headers = response.headers
         return content, status_code, response_headers
 
-    def _handle_request_error(self, e) -> NoReturn:
+    def _handle_request_error(self, e: Exception) -> NoReturn:
         msg = (
             "Unexpected error communicating with Stripe. If this "
             "problem persists, let us know at support@stripe.com."
@@ -1316,7 +1316,7 @@ class HTTPXClient(HTTPClient):
         should_retry = True
 
         msg = textwrap.fill(msg) + "\n\n(Network error: %s)" % (err,)
-        raise APIConnectionError(msg, should_retry=should_retry)
+        raise APIConnectionError(msg, should_retry=should_retry) from e
 
     def request_stream(
         self, method: str, url: str, headers: Mapping[str, str], post_data=None
@@ -1446,7 +1446,7 @@ class AIOHTTPClient(HTTPClient):
 
         return (await content.read()), status_code, response_headers
 
-    def _handle_request_error(self, e) -> NoReturn:
+    def _handle_request_error(self, e: Exception) -> NoReturn:
         msg = (
             "Unexpected error communicating with Stripe. If this "
             "problem persists, let us know at support@stripe.com."
@@ -1455,7 +1455,7 @@ class AIOHTTPClient(HTTPClient):
         should_retry = True
 
         msg = textwrap.fill(msg) + "\n\n(Network error: %s)" % (err,)
-        raise APIConnectionError(msg, should_retry=should_retry)
+        raise APIConnectionError(msg, should_retry=should_retry) from e
 
     def request_stream(self) -> Tuple[Iterable[bytes], int, Mapping[str, str]]:
         raise NotImplementedError(

--- a/stripe/_stripe_object.py
+++ b/stripe/_stripe_object.py
@@ -171,7 +171,7 @@ class StripeObject(Dict[str, Any]):
                     k = self._field_remappings[k]
                 return self[k]
             except KeyError as err:
-                raise AttributeError(*err.args)
+                raise AttributeError(*err.args) from err
 
         def __delattr__(self, k):
             if k[0] == "_" or k in self.__dict__:


### PR DESCRIPTION
This makes debugging easier, since the original exception's details and traceback aren't just flattened to a string.