### PR TITLE
Prioritize requests as preferred HTTP library

### DIFF
--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -116,10 +116,10 @@ def _now_ms():
 
 
 def new_default_http_client(*args: Any, **kwargs: Any) -> "HTTPClient":
-    if urlfetch:
-        impl = UrlFetchClient
-    elif requests:
+    if requests:
         impl = RequestsClient
+    elif urlfetch:
+        impl = UrlFetchClient
     elif pycurl:
         impl = PycurlClient
     else:


### PR DESCRIPTION
Prioritize the `requests` library over Google app engine's `urlfetch` as http provider.

`_http_client.py` [declares](https://github.com/stripe/stripe-python/blob/master/stripe/_http_client.py#L42-L45) that "Requests is the preferred HTTP library"; however, `urlfetch` is chosen before `requests` when creating a default http client.

Additionally, the current ordering throws the error `No api proxy found for service "urlfetch"` when `appengine-python-standard` is installed. It appears that the recommended [solution](https://github.com/stripe/stripe-python/issues/43) is to uninstall the `appengine-python-standard` package.