### PR TITLE
Changed V1File implementation to pass content_type in options

### DIFF
--- a/stripe/_api_mode.py
+++ b/stripe/_api_mode.py
@@ -1,4 +1,4 @@
 from typing_extensions import Literal
 
 
-ApiMode = Literal["V1", "V1FILES"]
+ApiMode = Literal["V1"]

--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -509,7 +509,10 @@ class _APIRequestor(object):
                 abs_url = urlunsplit((scheme, netloc, path, query, fragment))
             post_data = None
         elif method == "post":
-            if api_mode == "V1FILES":
+            if (
+                options is not None
+                and options.get("content_type") == "multipart/form-data"
+            ):
                 generator = MultipartDataGenerator()
                 generator.add_params(params or {})
                 post_data = generator.get_post_data()

--- a/stripe/_file.py
+++ b/stripe/_file.py
@@ -209,6 +209,8 @@ class File(CreateableAPIResource["File"], ListableAPIResource["File"]):
 
         All of Stripe's officially supported Client libraries support sending multipart/form-data.
         """
+        params["content_type"] = "multipart/form-data"
+
         return cast(
             "File",
             cls._static_request(
@@ -216,7 +218,7 @@ class File(CreateableAPIResource["File"], ListableAPIResource["File"]):
                 cls.class_url(),
                 params=params,
                 base_address="files",
-                api_mode="V1FILES",
+                api_mode="V1",
             ),
         )
 
@@ -229,6 +231,8 @@ class File(CreateableAPIResource["File"], ListableAPIResource["File"]):
 
         All of Stripe's officially supported Client libraries support sending multipart/form-data.
         """
+        params["content_type"] = "multipart/form-data"
+
         return cast(
             "File",
             await cls._static_request_async(
@@ -236,7 +240,7 @@ class File(CreateableAPIResource["File"], ListableAPIResource["File"]):
                 cls.class_url(),
                 params=params,
                 base_address="files",
-                api_mode="V1FILES",
+                api_mode="V1",
             ),
         )
 

--- a/stripe/_file_service.py
+++ b/stripe/_file_service.py
@@ -169,12 +169,13 @@ class FileService(StripeService):
 
         All of Stripe's officially supported Client libraries support sending multipart/form-data.
         """
+        options["content_type"] = "multipart/form-data"
         return cast(
             File,
             self._request(
                 "post",
                 "/v1/files",
-                api_mode="V1FILES",
+                api_mode="V1",
                 base_address="files",
                 params=params,
                 options=options,
@@ -189,12 +190,13 @@ class FileService(StripeService):
 
         All of Stripe's officially supported Client libraries support sending multipart/form-data.
         """
+        options["content_type"] = "multipart/form-data"
         return cast(
             File,
             await self._request_async(
                 "post",
                 "/v1/files",
-                api_mode="V1FILES",
+                api_mode="V1",
                 base_address="files",
                 params=params,
                 options=options,

--- a/stripe/_request_options.py
+++ b/stripe/_request_options.py
@@ -9,6 +9,7 @@ class RequestOptions(TypedDict):
     stripe_account: NotRequired["str|None"]
     max_network_retries: NotRequired["int|None"]
     idempotency_key: NotRequired["str|None"]
+    content_type: NotRequired["str|None"]
     headers: NotRequired["Mapping[str, str]|None"]
 
 
@@ -27,6 +28,7 @@ def merge_options(
             "stripe_version": requestor.stripe_version,
             "max_network_retries": requestor.max_network_retries,
             "idempotency_key": None,
+            "content_type": None,
             "headers": None,
         }
 
@@ -40,6 +42,7 @@ def merge_options(
         if request.get("max_network_retries") is not None
         else requestor.max_network_retries,
         "idempotency_key": request.get("idempotency_key"),
+        "content_type": request.get("content_type"),
         "headers": request.get("headers"),
     }
 
@@ -61,6 +64,7 @@ def extract_options_from_dict(
         "stripe_account",
         "max_network_retries",
         "idempotency_key",
+        "content_type",
         "headers",
     ]:
         if key in d_copy:


### PR DESCRIPTION
`V1Files` is no longer treated as a separate API mode. We now pass it as part of request options from resources and service methods.