### PR TITLE
Fix v2 event object name

### DIFF
--- a/examples/stripe_webhook_handler.py
+++ b/examples/stripe_webhook_handler.py
@@ -24,7 +24,6 @@ def webhook():
         # Fetch the event data to understand the failure
         event = client.v2.core.events.retrieve(thin_event.id)
         if isinstance(event, V1BillingMeterErrorReportTriggeredEvent):
-            # CHECK: fetch_object is present and callable, returning a strongly-typed object (without casting)
             meter = event.fetch_related_object()
             meter_id = meter.id
             print("Success! " + str(meter_id))

--- a/examples/stripe_webhook_handler.py
+++ b/examples/stripe_webhook_handler.py
@@ -27,6 +27,7 @@ def webhook():
             # CHECK: fetch_object is present and callable, returning a strongly-typed object (without casting)
             meter = event.fetch_related_object()
             meter_id = meter.id
+            print("Success! " + str(meter_id))
 
             # Record the failures and alert your team
             # Add your logic here

--- a/stripe/_util.py
+++ b/stripe/_util.py
@@ -321,7 +321,7 @@ def _convert_to_stripe_object(
         resp = resp.copy()
         klass_name = resp.get("object")
         if isinstance(klass_name, str):
-            if api_mode == "V2" and klass_name == "event":
+            if api_mode == "V2" and klass_name == "v2.core.event":
                 event_name = resp.get("type", "")
                 klass = get_thin_event_classes().get(
                     event_name, stripe.StripeObject

--- a/tests/test_stripe_client.py
+++ b/tests/test_stripe_client.py
@@ -38,7 +38,7 @@ class TestStripeClient(object):
         http_client_mock.stub_request(
             method,
             path=path,
-            rbody='{"id": "evt_123","object": "event", "type": "v1.billing.meter.error_report_triggered"}',
+            rbody='{"id": "evt_123","object": "v2.core.event", "type": "v1.billing.meter.error_report_triggered"}',
             rcode=200,
             rheaders={},
         )

--- a/tests/test_v2_event.py
+++ b/tests/test_v2_event.py
@@ -16,7 +16,7 @@ class TestV2Event(object):
         return json.dumps(
             {
                 "id": "evt_234",
-                "object": "event",
+                "object": "v2.core.event",
                 "type": "financial_account.balance.opened",
                 "created": "2022-02-15T00:27:45.330Z",
                 "related_object": {
@@ -37,7 +37,7 @@ class TestV2Event(object):
         return json.dumps(
             {
                 "id": "evt_234",
-                "object": "event",
+                "object": "v2.core.event",
                 "type": "financial_account.balance.opened",
                 "created": "2022-02-15T00:27:45.330Z",
                 "related_object": {


### PR DESCRIPTION
### Why?
The SDK uses object strings in the API response to decide what class to parse a resource returned from the Stripe API into.  Recently, the object string for the V2 event base class changed from "event" to "v2.core.event".  We have to update the SDK to match.

### What?
- Changed "event" to "v2.core.event" in _util._convert_to_stripe_object

Verified using the `stripe_webhook_handler.py` example with events triggered from and forwarded by the Stripe CLI

### See Also
http://go/j/DEVSDK-2202