### PR TITLE
Removed parseSnapshotEvent

### DIFF
--- a/stripe/_stripe_client.py
+++ b/stripe/_stripe_client.py
@@ -283,7 +283,7 @@ class StripeClient(object):
 
         return ThinEvent(payload)
 
-    def parse_snapshot_event(
+    def construct_event(
         self,
         payload: Union[bytes, str],
         sig_header: str,

--- a/stripe/v2/_event.py
+++ b/stripe/v2/_event.py
@@ -102,11 +102,29 @@ class ThinEvent:
     """
 
     id: str
+    """
+    Unique identifier for the event.
+    """
     type: str
+    """
+    The type of the event.
+    """
     created: str
+    """
+    Time at which the object was created.
+    """
     context: Optional[str] = None
+    """
+    [Optional] Authentication context needed to fetch the event or related object.
+    """
     related_object: Optional[RelatedObject] = None
+    """
+    [Optional] Object containing the reference to API resource relevant to the event.
+    """
     reason: Optional[Reason] = None
+    """
+    [Optional] Reason for the event.
+    """
 
     def __init__(self, payload: str) -> None:
         parsed = json.loads(payload)

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -135,7 +135,7 @@ class TestWebhookSignature(object):
 class TestStripeClientConstructEvent(object):
     def test_construct_event(self, stripe_mock_stripe_client):
         header = generate_header()
-        event = stripe_mock_stripe_client.parse_snapshot_event(
+        event = stripe_mock_stripe_client.construct_event(
             DUMMY_WEBHOOK_PAYLOAD, header, DUMMY_WEBHOOK_SECRET
         )
         assert isinstance(event, stripe.Event)
@@ -144,21 +144,21 @@ class TestStripeClientConstructEvent(object):
         payload = "this is not valid JSON"
         header = generate_header(payload=payload)
         with pytest.raises(ValueError):
-            stripe_mock_stripe_client.parse_snapshot_event(
+            stripe_mock_stripe_client.construct_event(
                 payload, header, DUMMY_WEBHOOK_SECRET
             )
 
     def test_raise_on_invalid_header(self, stripe_mock_stripe_client):
         header = "bad_header"
         with pytest.raises(stripe.error.SignatureVerificationError):
-            stripe_mock_stripe_client.parse_snapshot_event(
+            stripe_mock_stripe_client.construct_event(
                 DUMMY_WEBHOOK_PAYLOAD, header, DUMMY_WEBHOOK_SECRET
             )
 
     def test_construct_event_from_bytearray(self, stripe_mock_stripe_client):
         header = generate_header()
         payload = bytearray(DUMMY_WEBHOOK_PAYLOAD, "utf-8")
-        event = stripe_mock_stripe_client.parse_snapshot_event(
+        event = stripe_mock_stripe_client.construct_event(
             payload, header, DUMMY_WEBHOOK_SECRET
         )
         assert isinstance(event, stripe.Event)
@@ -166,7 +166,7 @@ class TestStripeClientConstructEvent(object):
     def test_construct_event_from_bytes(self, stripe_mock_stripe_client):
         header = generate_header()
         payload = bytes(DUMMY_WEBHOOK_PAYLOAD, "utf-8")
-        event = stripe_mock_stripe_client.parse_snapshot_event(
+        event = stripe_mock_stripe_client.construct_event(
             payload, header, DUMMY_WEBHOOK_SECRET
         )
         assert isinstance(event, stripe.Event)
@@ -181,7 +181,7 @@ class TestStripeClientConstructEvent(object):
             http_client=http_client_mock.get_mock_http_client(),
         )
         header = generate_header()
-        event = client.parse_snapshot_event(
+        event = client.construct_event(
             DUMMY_WEBHOOK_PAYLOAD, header, DUMMY_WEBHOOK_SECRET
         )
         assert event._requestor == client._requestor


### PR DESCRIPTION
- Removed parseSnapshotEvent since we already have webhook.construct_event.
- Added better description for class properties on ThinEvent.