### PR TITLE
Clean up examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,9 +3,14 @@
 From the examples folder, run:
 `PYTHONPATH=../ python your_example.py`
 
+e.g.
+
+`PYTHONPATH=../ python thinevent_webhook_handler.py`
+
 ## Adding a new example
 
-1. Clone new_example.py
+1. Clone example_template.py
 2. Implement your example
-3. Run it (as per above)
-4. 👍
+3. Fill out the file comment. Include a description and key steps that are being demonstrated.
+4. Run it (as per above)
+5. 👍

--- a/examples/example_template.py
+++ b/examples/example_template.py
@@ -1,0 +1,22 @@
+"""
+example_template.py - This is a template for defining new examples.  It is not intended to be used directly.
+
+<describe what this example does>
+
+In this example, we:
+  - <key step 1>
+  - <key step 2
+  - ...
+
+<describe assumptions about the user's stripe account, environment, or configuration;
+or things to watch out for when running>
+"""
+
+import stripe
+
+# Set your API key here
+api_key = "{{API_KEY}}"
+
+print("Hello world")
+# client = stripe.StripeClient(api_key)
+# client.v2....

--- a/examples/meter_event_stream.py
+++ b/examples/meter_event_stream.py
@@ -1,3 +1,15 @@
+"""
+meter_event_stream.py - use the high-throughput meter event stream to report create billing meter events.
+
+In this example, we:
+  - create a meter event session and store the session's authentication token
+  - define an event with a payload
+  - use the meter_event_stream service accessor in StripeClient to create an event stream that reports this event
+
+This example expects a billing meter with an event_name of 'alpaca_ai_tokens'.  If you have
+a different meter event name, you can change it before running this example.
+"""
+
 from datetime import datetime, timezone
 import stripe
 

--- a/examples/new_example.py
+++ b/examples/new_example.py
@@ -1,8 +1,0 @@
-import stripe
-
-# Set your API key here
-api_key = "{{API_KEY}}"
-
-print("Hello world")
-# client = stripe.StripeClient(api_key)
-# client.v2....

--- a/examples/thinevent_webhook_handler.py
+++ b/examples/thinevent_webhook_handler.py
@@ -1,3 +1,14 @@
+"""
+thinevent_webhook_handler.py - receive and process thin events like the
+v1.billing.meter.error_report_triggered event.
+
+In this example, we:
+   - use parseThinEvent to parse the received thin event webhook body
+   - call StripeClient.v2.core.events.retrieve to retrieve the full event object
+  - if it is a V1BillingMeterErrorReportTriggeredEvent event type, call fetchRelatedObject
+    to retrieve the Billing Meter object associated with the event.
+"""
+
 import os
 from stripe import StripeClient
 from stripe.events import V1BillingMeterErrorReportTriggeredEvent

--- a/examples/thinevent_webhook_handler.py
+++ b/examples/thinevent_webhook_handler.py
@@ -3,10 +3,12 @@ thinevent_webhook_handler.py - receive and process thin events like the
 v1.billing.meter.error_report_triggered event.
 
 In this example, we:
-   - use parseThinEvent to parse the received thin event webhook body
-   - call StripeClient.v2.core.events.retrieve to retrieve the full event object
-  - if it is a V1BillingMeterErrorReportTriggeredEvent event type, call fetchRelatedObject
-    to retrieve the Billing Meter object associated with the event.
+    - create a StripeClient called client
+    - use client.parse_thin_event to parse the received thin event webhook body
+    - call client.v2.core.events.retrieve to retrieve the full event object
+    - if it is a V1BillingMeterErrorReportTriggeredEvent event type, call
+      event.fetchRelatedObject to retrieve the Billing Meter object associated
+      with the event.
 """
 
 import os


### PR DESCRIPTION
### Why?
In our recent SDK release we added a couple new examples along with a template to make it easy for us to create new examples.  The names of the examples and the template were confusing and hard to understand and our documentation around examples was lacking.  This PR fixes/clarifies the names and added comments to explain each new example.

### What?
- renamed new_example.py to example_template.py and added file comment template
- renamed stripe_webhook_handler.py to thinevent_webhook_handler.py and added file comment describing the example
- added comment to meter_event_stream.py describing the example
