### PR TITLE
Deserialize into correct v2 EventData types

### DIFF
--- a/stripe/events/_v1_billing_meter_error_report_triggered_event.py
+++ b/stripe/events/_v1_billing_meter_error_report_triggered_event.py
@@ -100,9 +100,7 @@ class V1BillingMeterErrorReportTriggeredEvent(Event):
         requestor: "_APIRequestor",
         api_mode: ApiMode,
     ) -> "V1BillingMeterErrorReportTriggeredEvent":
-        evt = super(
-            V1BillingMeterErrorReportTriggeredEvent, cls
-        )._construct_from(
+        evt = super()._construct_from(
             values=values,
             last_response=last_response,
             requestor=requestor,

--- a/stripe/events/_v1_billing_meter_error_report_triggered_event.py
+++ b/stripe/events/_v1_billing_meter_error_report_triggered_event.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe._api_mode import ApiMode
+from stripe._api_requestor import _APIRequestor
 from stripe._stripe_object import StripeObject
+from stripe._stripe_response import StripeResponse
 from stripe.billing._meter import Meter
 from stripe.v2._event import Event
-from typing import List, cast
+from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
 
 
@@ -87,6 +90,32 @@ class V1BillingMeterErrorReportTriggeredEvent(Event):
     """
     Data for the v1.billing.meter.error_report_triggered event
     """
+
+    @classmethod
+    def _construct_from(
+        cls,
+        *,
+        values: Dict[str, Any],
+        last_response: Optional[StripeResponse] = None,
+        requestor: "_APIRequestor",
+        api_mode: ApiMode,
+    ) -> "V1BillingMeterErrorReportTriggeredEvent":
+        evt = super(
+            V1BillingMeterErrorReportTriggeredEvent, cls
+        )._construct_from(
+            values=values,
+            last_response=last_response,
+            requestor=requestor,
+            api_mode=api_mode,
+        )
+        if evt.data:
+            evt.data = V1BillingMeterErrorReportTriggeredEvent.V1BillingMeterErrorReportTriggeredEventData._construct_from(
+                values=evt.data,
+                last_response=last_response,
+                requestor=requestor,
+                api_mode=api_mode,
+            )
+        return evt
 
     class RelatedObject(StripeObject):
         id: str

--- a/stripe/events/_v1_billing_meter_error_report_triggered_event.py
+++ b/stripe/events/_v1_billing_meter_error_report_triggered_event.py
@@ -108,7 +108,7 @@ class V1BillingMeterErrorReportTriggeredEvent(Event):
             requestor=requestor,
             api_mode=api_mode,
         )
-        if evt.data:
+        if hasattr(evt, "data"):
             evt.data = V1BillingMeterErrorReportTriggeredEvent.V1BillingMeterErrorReportTriggeredEventData._construct_from(
                 values=evt.data,
                 last_response=last_response,

--- a/stripe/events/_v1_billing_meter_no_meter_found_event.py
+++ b/stripe/events/_v1_billing_meter_no_meter_found_event.py
@@ -99,7 +99,7 @@ class V1BillingMeterNoMeterFoundEvent(Event):
         requestor: "_APIRequestor",
         api_mode: ApiMode,
     ) -> "V1BillingMeterNoMeterFoundEvent":
-        evt = super(V1BillingMeterNoMeterFoundEvent, cls)._construct_from(
+        evt = super()._construct_from(
             values=values,
             last_response=last_response,
             requestor=requestor,

--- a/stripe/events/_v1_billing_meter_no_meter_found_event.py
+++ b/stripe/events/_v1_billing_meter_no_meter_found_event.py
@@ -105,7 +105,7 @@ class V1BillingMeterNoMeterFoundEvent(Event):
             requestor=requestor,
             api_mode=api_mode,
         )
-        if evt.data:
+        if hasattr(evt, "data"):
             evt.data = V1BillingMeterNoMeterFoundEvent.V1BillingMeterNoMeterFoundEventData._construct_from(
                 values=evt.data,
                 last_response=last_response,

--- a/stripe/events/_v1_billing_meter_no_meter_found_event.py
+++ b/stripe/events/_v1_billing_meter_no_meter_found_event.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from stripe._api_mode import ApiMode
+from stripe._api_requestor import _APIRequestor
 from stripe._stripe_object import StripeObject
+from stripe._stripe_response import StripeResponse
 from stripe.v2._event import Event
-from typing import List
+from typing import Any, Dict, List, Optional
 from typing_extensions import Literal
 
 
@@ -86,3 +89,27 @@ class V1BillingMeterNoMeterFoundEvent(Event):
     """
     Data for the v1.billing.meter.no_meter_found event
     """
+
+    @classmethod
+    def _construct_from(
+        cls,
+        *,
+        values: Dict[str, Any],
+        last_response: Optional[StripeResponse] = None,
+        requestor: "_APIRequestor",
+        api_mode: ApiMode,
+    ) -> "V1BillingMeterNoMeterFoundEvent":
+        evt = super(V1BillingMeterNoMeterFoundEvent, cls)._construct_from(
+            values=values,
+            last_response=last_response,
+            requestor=requestor,
+            api_mode=api_mode,
+        )
+        if evt.data:
+            evt.data = V1BillingMeterNoMeterFoundEvent.V1BillingMeterNoMeterFoundEventData._construct_from(
+                values=evt.data,
+                last_response=last_response,
+                requestor=requestor,
+                api_mode=api_mode,
+            )
+        return evt


### PR DESCRIPTION
Currently we return generic StripeObjects for the EventData in our v2 events. This correctly calls construct_from when making v2 events (retrieve) to make sure they are typed appropriately.

## Changelog
* Fixes a bug where v2 EventData was not being deserialized into the appropriate type for `V1BillingMeterErrorReportTriggeredEvent` and `V1BillingMeterNoMeterFoundEvent`