### PR TITLE
update object tags for meter-related classes

### DIFF
--- a/stripe/v2/billing/_meter_event.py
+++ b/stripe/v2/billing/_meter_event.py
@@ -10,8 +10,8 @@ class MeterEvent(StripeObject):
     Fix me empty_doc_string.
     """
 
-    OBJECT_NAME: ClassVar[Literal["billing.meter_event"]] = (
-        "billing.meter_event"
+    OBJECT_NAME: ClassVar[Literal["v2.billing.meter_event"]] = (
+        "v2.billing.meter_event"
     )
     created: str
     """
@@ -29,7 +29,7 @@ class MeterEvent(StripeObject):
     """
     Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
     """
-    object: Literal["billing.meter_event"]
+    object: Literal["v2.billing.meter_event"]
     """
     String representing the object's type. Objects of the same type share the same value of the object field.
     """

--- a/stripe/v2/billing/_meter_event_adjustment.py
+++ b/stripe/v2/billing/_meter_event_adjustment.py
@@ -6,8 +6,8 @@ from typing_extensions import Literal
 
 
 class MeterEventAdjustment(StripeObject):
-    OBJECT_NAME: ClassVar[Literal["billing.meter_event_adjustment"]] = (
-        "billing.meter_event_adjustment"
+    OBJECT_NAME: ClassVar[Literal["v2.billing.meter_event_adjustment"]] = (
+        "v2.billing.meter_event_adjustment"
     )
 
     class Cancel(StripeObject):
@@ -36,7 +36,7 @@ class MeterEventAdjustment(StripeObject):
     """
     Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
     """
-    object: Literal["billing.meter_event_adjustment"]
+    object: Literal["v2.billing.meter_event_adjustment"]
     """
     String representing the object's type. Objects of the same type share the same value of the object field.
     """

--- a/stripe/v2/billing/_meter_event_session.py
+++ b/stripe/v2/billing/_meter_event_session.py
@@ -6,8 +6,8 @@ from typing_extensions import Literal
 
 
 class MeterEventSession(StripeObject):
-    OBJECT_NAME: ClassVar[Literal["billing.meter_event_session"]] = (
-        "billing.meter_event_session"
+    OBJECT_NAME: ClassVar[Literal["v2.billing.meter_event_session"]] = (
+        "v2.billing.meter_event_session"
     )
     authentication_token: str
     """
@@ -30,7 +30,7 @@ class MeterEventSession(StripeObject):
     """
     Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
     """
-    object: Literal["billing.meter_event_session"]
+    object: Literal["v2.billing.meter_event_session"]
     """
     String representing the object's type. Objects of the same type share the same value of the object field.
     """

--- a/tests/test_raw_request.py
+++ b/tests/test_raw_request.py
@@ -72,7 +72,7 @@ class TestRawRequest(object):
         http_client_mock.stub_request(
             "post",
             path=self.POST_REL_URL_V2,
-            rbody='{"id": "bmes_123", "object": "billing.meter_event_session"}',
+            rbody='{"id": "bmes_123", "object": "v2.billing.meter_event_session"}',
             rcode=200,
             rheaders={},
         )


### PR DESCRIPTION
## Changelog

- fixes a bug where the `object` property of the `MeterEvent`, `MeterEventAdjustment`, and `MeterEventSession` didn't match the server.