### PR TITLE
Fix incorrect property name on `ThinEvent.related_object.type`

### DIFF
--- a/stripe/v2/_event.py
+++ b/stripe/v2/_event.py
@@ -89,11 +89,11 @@ class RelatedObject:
 
     def __init__(self, d) -> None:
         self.id = d["id"]
-        self.type_ = d["type"]
+        self.type = d["type"]
         self.url = d["url"]
 
     def __repr__(self) -> str:
-        return f"<RelatedObject id={self.id} type={self.type_} url={self.url}>"
+        return f"<RelatedObject id={self.id} type={self.type} url={self.url}>"
 
 
 class ThinEvent:


### PR DESCRIPTION
I noticed what was probably a typo in the properties of `ThinEvent.related_object`. While `type` is a global function (and typical reserved word) it's a perfectly valid property name.

In general, we want the property names on types to match the values you get from the API responses (so users can more easily navigate unfamiliar SDK usage), so it's probably worth updating. 

That said, this is technically a breaking change so we might want to hold off on merging it?

## Changelog

- Rename `ThinEvent.related_object.type_` to `ThinEvent.related_object.type`
    - This was an unintentional typo before. The property name now correctly matches the value you get back from the API