### PR TITLE
fix deprecation warning in httpx @ 0.28

### DIFF
--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -1244,7 +1244,9 @@ class HTTPXClient(HTTPClient):
 
         kwargs = {}
         if self._verify_ssl_certs:
-            kwargs["verify"] = stripe.ca_bundle_path
+            kwargs["verify"] = ssl.create_default_context(
+                capath=stripe.ca_bundle_path
+            )
         else:
             kwargs["verify"] = False
 


### PR DESCRIPTION
fixes https://github.com/stripe/stripe-python/issues/1428 per suggestion in the [httpx docs](https://github.com/encode/httpx/blob/0.28.0/docs/advanced/ssl.md#configuring-client-instances).