### PR TITLE
Fix using `auto_paging_iter()` with `expand: [...]`

### DIFF
--- a/tests/api_resources/test_list_object.py
+++ b/tests/api_resources/test_list_object.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 import stripe
+from tests.http_client_mock import HTTPClientMock
 
 
 class TestListObject(object):
@@ -438,6 +439,58 @@ class TestAutoPaging:
             api_key="sk_test_iter_forwards_options",
         )
         assert lo.data[0].api_key == "sk_test_iter_forwards_options"
+
+    def test_iter_with_params(self, http_client_mock: HTTPClientMock):
+        http_client_mock.stub_request(
+            "get",
+            path="/v1/invoices/upcoming/lines",
+            query_string="customer=cus_123&expand[0]=data.price&limit=1",
+            rbody=json.dumps(
+                {
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": "prod_001",
+                            "object": "product",
+                            "price": {"object": "price", "id": "price_123"},
+                        }
+                    ],
+                    "url": "/v1/invoices/upcoming/lines?customer=cus_123&expand%5B%5D=data.price",
+                    "has_more": True,
+                }
+            ),
+        )
+        # second page
+        http_client_mock.stub_request(
+            "get",
+            path="/v1/invoices/upcoming/lines",
+            query_string="customer=cus_123&expand[0]=data.price&limit=1&starting_after=prod_001",
+            rbody=json.dumps(
+                {
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": "prod_002",
+                            "object": "product",
+                            "price": {"object": "price", "id": "price_123"},
+                        }
+                    ],
+                    "url": "/v1/invoices/upcoming/lines?customer=cus_123&expand%5B%5D=data.price",
+                    "has_more": False,
+                }
+            ),
+        )
+
+        lo = stripe.Invoice.upcoming_lines(
+            api_key="sk_test_invoice_lines",
+            customer="cus_123",
+            expand=["data.price"],
+            limit=1,
+        )
+
+        seen = [item["id"] for item in lo.auto_paging_iter()]
+
+        assert seen == ["prod_001", "prod_002"]
 
 
 class TestAutoPagingAsync:

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -245,16 +245,17 @@ class TestAPIRequestor(object):
 
     def test_url_construction(self, requestor, http_client_mock):
         CASES = (
-            ("%s?foo=bar" % stripe.api_base, "", {"foo": "bar"}),
-            ("%s?foo=bar" % stripe.api_base, "?", {"foo": "bar"}),
+            (f"{stripe.api_base}?foo=bar", "", {"foo": "bar"}),
+            (f"{stripe.api_base}?foo=bar", "?", {"foo": "bar"}),
             (stripe.api_base, "", {}),
             (
-                "%s/%%20spaced?foo=bar%%24&baz=5" % stripe.api_base,
+                f"{stripe.api_base}/%20spaced?baz=5&foo=bar%24",
                 "/%20spaced?foo=bar%24",
                 {"baz": "5"},
             ),
+            # duplicate query params keys should be deduped
             (
-                "%s?foo=bar&foo=bar" % stripe.api_base,
+                f"{stripe.api_base}?foo=bar",
                 "?foo=bar",
                 {"foo": "bar"},
             ),


### PR DESCRIPTION
### Why

When you called `auto_paging_iter()` on a list that you fetched with `expand`, the server would give a 400 error. Ultimately, this was caused by the SDK making a malformed request with similar-but-different `expand` values.

When you turn a response into a `StripeObject`, we store the request url that created that response. That url includes any query params. So, given this code:

```py
lines = stripe.Invoice.upcoming_lines(
    limit=3, 
    customer='cus_ROQYYBI1BraV53',
    expand=['data.price.product']
)
```

hits the url: `/v1/invoices/upcoming/lines?customer=cus_ROQYYBI1BraV53&expand%5B%5D=data.price.product`

In addition to the URL, Python's `StripeObject` _also_ stores the `params` used to create the object. On subsequent requests with the same object (e.g. when paging through a list) the SDK adds the original params to paging related ones (such as `starting_after`) to the original url to make the request. 

Because the server returned the params and Python still has the params, we end up with duplicates in the url:

`https://api.stripe.com/v1/invoices/upcoming/lines?customer=cus_ROQYYBI1BraV53&expand%5B%5D=data.price.product&limit=3&customer=cus_ROQYYBI1BraV53&expand[0]=data.price.product&starting_after=il_tmp_1QVdh7JoUivz182DmwLpUU1y`

Not only is `customer` duplicated, there's both `expand[]` and `expand[0]` keys. The latter is what's causing the issue. Clients can send `expand[0]=a&expand[1]=b` or `expand[]=a&expand[]=b`, but can't mix. 

The server sends `extend[]` in its `url` response and python adds indexes, so the clobbering was the root of the issue.

To fix, I parsed out the existing query params from a url and merged them with `params`, which avoids duplicates. I also merged `expand` values just in case someone is expanding something new on the `next_page()` call that wasn't expanded originally. 

This approach is a little kludgy, but _does_ work and fix the bug. I'm open to other suggestions though!

### What

- when making a `GET` or `DELETE` request with additional params, deduplicate params.
- add test

### Testing

```py
import stripe
stripe.api_key = "sk_test_..."
# set up customer with more than one page of invoice items
customer = stripe.Customer.create()
for i in range(5):
    stripe.InvoiceItem.create(
        customer=customer.id,
        price="price_1PVu24JoUivz182D067aXjgy"
    )
    print(f"Created invoice item {i}")
print(f"Done creating invoice items for {customer.id}, now listing them")
# try to iterate over all invoice items
lines = stripe.Invoice.upcoming_lines(
    limit=3, 
    customer=customer.id,
    expand=['data.price.product']
)
for line in lines.auto_paging_iter(): # errors after 3
   print(f"{line.id}")
```

---

fixes [RUN_DEVSDK-1427](https://jira.corp.stripe.com/browse/RUN_DEVSDK-1427)