### PR TITLE
Fix StripeError http_body

### DIFF
--- a/stripe/_error.py
+++ b/stripe/_error.py
@@ -40,7 +40,6 @@ class StripeError(Exception):
                     )
             elif isinstance(http_body, str):
                 body = http_body
-                pass
 
         self._message = message
         self.http_body = body

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
+import json
 from stripe import error
 
 
@@ -27,6 +28,22 @@ class TestStripeError(object):
             repr(err) == "StripeError(message='öre', http_status=None, "
             "request_id='123')"
         )
+
+    def test_error_string_body(self):
+        http_body = '{"error": {"code": "some_error"}}'
+        err = error.StripeError(
+            "message", http_body=http_body, json_body=json.loads(http_body)
+        )
+        assert err.http_body is not None
+        assert err.http_body == json.dumps(err.json_body)
+
+    def test_error_bytes_body(self):
+        http_body = '{"error": {"code": "some_error"}}'.encode("utf-8")
+        err = error.StripeError(
+            "message", http_body=http_body, json_body=json.loads(http_body)
+        )
+        assert err.http_body is not None
+        assert err.http_body == json.dumps(err.json_body)
 
     def test_error_object(self):
         err = error.StripeError(


### PR DESCRIPTION
### Why?
See https://github.com/stripe/stripe-python/issues/1432.  There was a bug introduced in v7.1 of the SDK where the unprocessed http body passed into a Stripe error was not correctly set into the `http_body` property. 

### What?
- changed StripeError constructor to properly set http_body when a string http body is passed in.

## Changelog
- Fixes an issue where `http_body` may be null in a Stripe error even when `json_body` is a valid dictionary.