### PR TITLE
fix SSL context with local path

### DIFF
--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -1245,7 +1245,7 @@ class HTTPXClient(HTTPClient):
         kwargs = {}
         if self._verify_ssl_certs:
             kwargs["verify"] = ssl.create_default_context(
-                capath=stripe.ca_bundle_path
+                cafile=stripe.ca_bundle_path
             )
         else:
             kwargs["verify"] = False

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,3 +1,4 @@
+import base64
 from typing import Any, List
 from typing_extensions import Type
 from unittest.mock import call
@@ -1971,3 +1972,33 @@ class TestAIOHTTPClientRetryBehavior(TestAIOHTTPClient):
 
     def test_timeout_async(self):
         pass
+
+
+class TestLiveHTTPClients:
+    """
+    Tests that actually make HTTP requests in order to test functionality (like https)
+    end to end.
+    """
+
+    @pytest.mark.anyio
+    async def test_httpx_request_async_https(self):
+        """
+        Test to ensure that httpx https calls succeed by making a live test call
+        to the public stripe API.
+        """
+        method = "get"
+        abs_url = "https://api.stripe.com/v1/balance"
+        data = {}
+
+        client = _http_client.HTTPXClient(verify_ssl_certs=True)
+        # the public test secret key, as found on https://docs.stripe.com/keys#obtain-api-keys
+        test_api_key = "sk_test_4eC39HqLyjWDarjtT1zdp7dc"
+        basic_auth = base64.b64encode(
+            (test_api_key + ":").encode("utf-8")
+        ).decode("utf-8")
+        headers = {"Authorization": "Basic " + basic_auth}
+
+        _, code, _ = await client.request_with_retries_async(
+            method, abs_url, headers, data
+        )
+        assert code >= 200 and code < 400


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

https://github.com/stripe/stripe-python/pull/1431 fixed a deprecation warning, but introduced a bug because we weren't creating the SSL context correctly. We have a path to a file, so we should use `cafile`. I mistakenly thought that kwarg was the actual contents of a file. This now lines up with [how `httpx` treated the string we were passing before](https://github.com/encode/httpx/blob/26d48e0634e6ee9cdc0533996db289ce4b430177/httpx/_config.py#L45-L54). 

Reported in https://github.com/stripe/stripe-python/issues/1437.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- use `cafile` kwarg instead of `capath` for `ssl.create_default_context`.

### Testing

This script fails without the fix and passes with it:

```py
import stripe

def main():
    stripe.default_http_client = stripe.HTTPXClient(allow_sync_methods=True)
    stripe.api_key = "sk_test_1234"
    print(stripe.Customer.list())
    
main()
```

### See Also
<!-- Include any links or additional information that help explain this change. -->

- https://github.com/stripe/stripe-python/issues/1437
- https://github.com/stripe/stripe-python/pull/1431