### PR TITLE
Fix V2 ListObject.data type hint

### DIFF
--- a/stripe/v2/_list_object.py
+++ b/stripe/v2/_list_object.py
@@ -17,7 +17,7 @@ class ListObject(StripeObject, Generic[T]):
     """
 
     OBJECT_NAME = "list"
-    data: List[StripeObject]
+    data: List[T]
     next_page_url: Optional[str]
 
     def __getitem__(self, k):


### PR DESCRIPTION
### Why?
The V2 ListObject `data` member is defined with the type hint `List[StripeObject]` which does not take advantage of of the generic type parameter to give accurate type hints.  This PR corrects the type hint so that the `data` will be of type `List[T]`

### What?
- changed v2 ListObject data type from List[StripeObject] to List[T]
