### PR TITLE
add just to publish CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
     needs: [build, test, lint]
     runs-on: "ubuntu-24.04"
     steps:
+      - uses: extractions/setup-just@v2
       - uses: actions/checkout@v3
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v3


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Publish jobs were failing because of a missing `just`: https://github.com/stripe/stripe-python/actions/runs/12839070157/job/35805871582#step:6:12

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- adds just to the `publish` CI job

### See Also
<!-- Include any links or additional information that help explain this change. -->
