### PR TITLE
Updated upload artifact ci action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           just build
 
       - name: "Upload Artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
### Why?
`upload-artifact@v3` is being deprecated https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/