### PR TITLE
upgrade ruff version

### DIFF
--- a/deps/dev-requirements.txt
+++ b/deps/dev-requirements.txt
@@ -2,6 +2,9 @@
 # version requirements: any modern python version (currently 3.10)
 
 # typechecking for all versions
+# can't use `>=1.1.339` since it flags override issues, e.g.:
+# > Method "_cls_delete" overrides class "DeletableAPIResource" in an incompatible manner Parameter "**params" has no corresponding parameter Pylance(reportIncompatibleMethodOverride)
+# can probably fix/ignore these issues and move forward, but we're stuck until then
 pyright == 1.1.336
 # general typechecking
 mypy == 1.7.0

--- a/deps/dev-requirements.txt
+++ b/deps/dev-requirements.txt
@@ -6,6 +6,7 @@ pyright == 1.1.336
 # general typechecking
 mypy == 1.7.0
 # formatting
-ruff == 0.4.4
+# pinned to last version before 2025 formatting
+ruff == 0.9.6
 # linting
 flake8

--- a/deps/dev-requirements.txt
+++ b/deps/dev-requirements.txt
@@ -6,7 +6,6 @@ pyright == 1.1.336
 # general typechecking
 mypy == 1.7.0
 # formatting
-# pinned to last version before 2025 formatting
 ruff == 0.9.6
 # linting
 flake8

--- a/stripe/_ephemeral_key.py
+++ b/stripe/_ephemeral_key.py
@@ -147,8 +147,7 @@ class EphemeralKey(
     def create(cls, **params):
         if params.get("stripe_version") is None:
             raise ValueError(
-                "stripe_version must be specified to create an ephemeral "
-                "key"
+                "stripe_version must be specified to create an ephemeral key"
             )
 
         url = cls.class_url()


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Bumps our formatter (`ruff`) version to latest to take advantage of the newer python LSP ([docs](https://docs.astral.sh/ruff/editors/migration/)). Also just good to bump these once in a while. After bumping, I ran `just format`, which formatting one file slightly differently than before ([expected](https://astral.sh/blog/ruff-v0.9.0))

Tried to bump others, but hit linting errors I didn't want to fix now.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- bumps `ruff` version
- re-formats everything using `just format` (1 file changed)
- adds comment to other tools versions

### See Also
<!-- Include any links or additional information that help explain this change. -->
