### PR TITLE
remove test using soon-to-be-gone endpoint

### DIFF
--- a/tests/api_resources/test_invoice.py
+++ b/tests/api_resources/test_invoice.py
@@ -117,11 +117,6 @@ class TestInvoice(object):
         )
         assert isinstance(resource, stripe.Invoice)
 
-    def test_can_upcoming(self, http_client_mock):
-        resource = stripe.Invoice.upcoming(customer="cus_123")
-        http_client_mock.assert_requested("get", path="/v1/invoices/upcoming")
-        assert isinstance(resource, stripe.Invoice)
-
     def test_can_void_invoice(self, http_client_mock):
         resource = stripe.Invoice.retrieve(TEST_RESOURCE_ID)
         resource = resource.void_invoice()

--- a/tests/api_resources/test_list_object.py
+++ b/tests/api_resources/test_list_object.py
@@ -440,57 +440,58 @@ class TestAutoPaging:
         )
         assert lo.data[0].api_key == "sk_test_iter_forwards_options"
 
-    def test_iter_with_params(self, http_client_mock: HTTPClientMock):
-        http_client_mock.stub_request(
-            "get",
-            path="/v1/invoices/upcoming/lines",
-            query_string="customer=cus_123&expand[0]=data.price&limit=1",
-            rbody=json.dumps(
-                {
-                    "object": "list",
-                    "data": [
-                        {
-                            "id": "prod_001",
-                            "object": "product",
-                            "price": {"object": "price", "id": "price_123"},
-                        }
-                    ],
-                    "url": "/v1/invoices/upcoming/lines?customer=cus_123&expand%5B%5D=data.price",
-                    "has_more": True,
-                }
-            ),
-        )
-        # second page
-        http_client_mock.stub_request(
-            "get",
-            path="/v1/invoices/upcoming/lines",
-            query_string="customer=cus_123&expand[0]=data.price&limit=1&starting_after=prod_001",
-            rbody=json.dumps(
-                {
-                    "object": "list",
-                    "data": [
-                        {
-                            "id": "prod_002",
-                            "object": "product",
-                            "price": {"object": "price", "id": "price_123"},
-                        }
-                    ],
-                    "url": "/v1/invoices/upcoming/lines?customer=cus_123&expand%5B%5D=data.price",
-                    "has_more": False,
-                }
-            ),
-        )
+    # TODO(xavdid): re-add test with a new endpoint
+    # def test_iter_with_params(self, http_client_mock: HTTPClientMock):
+    #     http_client_mock.stub_request(
+    #         "get",
+    #         path="/v1/invoices/upcoming/lines",
+    #         query_string="customer=cus_123&expand[0]=data.price&limit=1",
+    #         rbody=json.dumps(
+    #             {
+    #                 "object": "list",
+    #                 "data": [
+    #                     {
+    #                         "id": "prod_001",
+    #                         "object": "product",
+    #                         "price": {"object": "price", "id": "price_123"},
+    #                     }
+    #                 ],
+    #                 "url": "/v1/invoices/upcoming/lines?customer=cus_123&expand%5B%5D=data.price",
+    #                 "has_more": True,
+    #             }
+    #         ),
+    #     )
+    #     # second page
+    #     http_client_mock.stub_request(
+    #         "get",
+    #         path="/v1/invoices/upcoming/lines",
+    #         query_string="customer=cus_123&expand[0]=data.price&limit=1&starting_after=prod_001",
+    #         rbody=json.dumps(
+    #             {
+    #                 "object": "list",
+    #                 "data": [
+    #                     {
+    #                         "id": "prod_002",
+    #                         "object": "product",
+    #                         "price": {"object": "price", "id": "price_123"},
+    #                     }
+    #                 ],
+    #                 "url": "/v1/invoices/upcoming/lines?customer=cus_123&expand%5B%5D=data.price",
+    #                 "has_more": False,
+    #             }
+    #         ),
+    #     )
 
-        lo = stripe.Invoice.upcoming_lines(
-            api_key="sk_test_invoice_lines",
-            customer="cus_123",
-            expand=["data.price"],
-            limit=1,
-        )
+    #     lo = stripe.Invoice.upcoming_lines(
+    #         api_key="sk_test_invoice_lines",
+    #         customer="cus_123",
+    #         expand=["data.price"],
+    #         limit=1,
+    #     )
 
-        seen = [item["id"] for item in lo.auto_paging_iter()]
+    #     seen = [item["id"] for item in lo.auto_paging_iter()]
 
-        assert seen == ["prod_001", "prod_002"]
+    #     assert seen == ["prod_001", "prod_002"]
 
 
 class TestAutoPagingAsync:

--- a/tests/api_resources/test_list_object.py
+++ b/tests/api_resources/test_list_object.py
@@ -3,7 +3,6 @@ import json
 import pytest
 
 import stripe
-from tests.http_client_mock import HTTPClientMock
 
 
 class TestListObject(object):


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

The `/v1/invoices/upcoming/lines` endpoint is being removed soon. As a result, this test is causing CI failures upstream. I'm removing it for now in the hopes that we can replace it with a endpoint that accomplishes the same thing, but still exists.

Another test was removed entirely.

We don't need to change anything auto-generated; that'll get picked up when the spec is updated. These changes are purely for manual files.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- comment out test
- remove endpoint-specific test

### See Also
<!-- Include any links or additional information that help explain this change. -->
