### PR TITLE
Update add_beta_version logic

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,7 +6,9 @@
 # explicitly when using `ignore`.
 # E704 is disabled in the default configuration, but by specifying `ignore`, we wipe that out.
 # ruff formatting creates code that violates it, so we have to disable it manually
-ignore = E501, W503, E704
+# E203 checks that `:` is not preceded by whitespace, but in some cases,
+# formatting adds the whitespace. We let formatting be the source of truth in that case.
+ignore = E501, W503, E704, E203
 per-file-ignores =
     */__init__.py: IMP100, E402, F401
     # we test various import patterns

--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -140,7 +140,9 @@ def add_beta_version(
         start_index = stripe.api_version.index(beta_entry) + len(beta_entry)
         end_index = stripe.api_version.find(";", start_index)
         end_index = end_index if end_index != -1 else len(stripe.api_version)
-        existing_version = int(stripe.api_version[start_index + 1 : end_index])
+        existing_version = int(
+            stripe.api_version[(start_index + 1):end_index]
+        )
         new_version = int(beta_version[1:])
         if new_version <= existing_version:
             return  # Keep the higher version, no update needed

--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -141,7 +141,7 @@ def add_beta_version(
         end_index = stripe.api_version.find(";", start_index)
         end_index = end_index if end_index != -1 else len(stripe.api_version)
         existing_version = int(
-            stripe.api_version[(start_index + 1):end_index]
+            stripe.api_version[(start_index + 1) : end_index]
         )
         new_version = int(beta_version[1:])
         if new_version <= existing_version:


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
We decided to allow `add_beta_version` to overwrite an existing beta version

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Validates that `beta_version` is of the form "v" + a number
- Allows overwriting existing `beta_name`. The new behavior is that the higher `beta_version` is accepted instead of raising an `Exception`.

## Changelog
- `stripe.add_beta_version` will use the highest version number used for a beta feature instead of raising an `Exception` on a conflict as it had done previously.