### PR TITLE
pin `pyflakes` dev dependency

### DIFF
--- a/deps/dev-requirements.txt
+++ b/deps/dev-requirements.txt
@@ -11,4 +11,5 @@ mypy == 1.7.0
 # formatting
 ruff == 0.9.6
 # linting
-flake8
+# flake8 7.2.0 bumped to pyflakes 3.3.0, which adds a new lint error around global usage which will need to be manually fixed
+flake8==7.1.2


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Our linter introduced new lint rules that we don't (yet) pass. To clear the build, I pinned flake8 to the last working version. This is good practice anyway, so we don't get surprise breakages like this.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- pin pyflakes to a specific version

### See Also
<!-- Include any links or additional information that help explain this change. -->
