### PR TITLE
Update CI to use ubuntu 22.04 and not run Python 3.6 just for today

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,12 +71,15 @@ jobs:
     # Specific ubuntu version to support python 3.6 testing
     # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877 for details
     # move to ubuntu-latest when we drop 3.6
-    runs-on: ubuntu-20.04
+
+    #### TODO (helenye): **REVERT THIS BACK WHEN THE 20.04 BROWNOUT IS OVER**
+    #### https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         python_version:
-          - "3.6"
+          # - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

There is a CI brownout today as part of https://github.com/actions/runner-images/issues/11101 until 5pm ET. This updates the box temporarily to get the CI to run today so I can merge this branch. I'll have a follow-up for master.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

### See Also
<!-- Include any links or additional information that help explain this change. -->
