### PR TITLE
Update to 22.04 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,15 +68,14 @@ jobs:
           path: dist/
 
   test:
-    # Specific ubuntu version to support python 3.6 testing
-    # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877 for details
-    # move to ubuntu-latest when we drop 3.6
-    runs-on: ubuntu-20.04
+    # Specific ubuntu version to support python 3.7 testing
+    # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877 for list of supported versions
+    # move to ubuntu-latest when we drop 3.7
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         python_version:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Github is removing out-of-the-box `ubuntu-20.04` support for CI, so remove these so our CI can run.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

These were already done in beta to get ready for the major release, repeating in master.

### See Also
<!-- Include any links or additional information that help explain this change. -->
https://jira.corp.stripe.com/browse/RUN_DEVSDK-1573