### PR TITLE
Handle external account

### DIFF
--- a/stripe/_external_account_service.py
+++ b/stripe/_external_account_service.py
@@ -20,7 +20,12 @@ class ExternalAccountService(StripeService):
         """
         Specifies which fields in the response should be expanded.
         """
-        external_account: str
+        external_account: Union[
+            str,
+            "ExternalAccountService.CreateParamsCard",
+            "ExternalAccountService.CreateParamsBankAccount",
+            "ExternalAccountService.CreateParamsCardToken",
+        ]
         """
         Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/js), or a dictionary containing a user's external account details (with the options shown below).
         """
@@ -28,6 +33,57 @@ class ExternalAccountService(StripeService):
         """
         Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
         """
+
+    class CreateParamsBankAccount(TypedDict):
+        object: Literal["bank_account"]
+        account_holder_name: NotRequired[str]
+        """
+        The name of the person or business that owns the bank account.This field is required when attaching the bank account to a `Customer` object.
+        """
+        account_holder_type: NotRequired[Literal["company", "individual"]]
+        """
+        The type of entity that holds the account. It can be `company` or `individual`. This field is required when attaching the bank account to a `Customer` object.
+        """
+        account_number: str
+        """
+        The account number for the bank account, in string form. Must be a checking account.
+        """
+        country: str
+        """
+        The country in which the bank account is located.
+        """
+        currency: NotRequired[str]
+        """
+        The currency the bank account is in. This must be a country/currency pairing that [Stripe supports.](docs/payouts)
+        """
+        routing_number: NotRequired[str]
+        """
+        The routing number, sort code, or other country-appropriateinstitution number for the bank account. For US bank accounts, this is required and should bethe ACH routing number, not the wire routing number. If you are providing an IBAN for`account_number`, this field is not required.
+        """
+
+    class CreateParamsCard(TypedDict):
+        object: Literal["card"]
+        address_city: NotRequired[str]
+        address_country: NotRequired[str]
+        address_line1: NotRequired[str]
+        address_line2: NotRequired[str]
+        address_state: NotRequired[str]
+        address_zip: NotRequired[str]
+        currency: NotRequired[str]
+        cvc: NotRequired[str]
+        exp_month: int
+        exp_year: int
+        name: NotRequired[str]
+        number: str
+        metadata: NotRequired[Dict[str, str]]
+        """
+        Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+        """
+
+    class CreateParamsCardToken(TypedDict):
+        object: Literal["card"]
+        currency: NotRequired[str]
+        token: str
 
     class DeleteParams(TypedDict):
         pass


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
The `external_account` should be a union type, not a `string`.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Changes `external_account` field in `external_account_service.create` from `string` to a union type.


## Changelog
- Changes `external_account` field in `external_account_service.create` from `string` to a union type.