### PR TITLE
switch build systems

### DIFF
--- a/deps/build-requirements.txt
+++ b/deps/build-requirements.txt
@@ -1,4 +1,5 @@
 # packages needed to package & release
 
-twine
-setuptools
+# pinned to latest as of 2025-04-08; nothing special about these versions
+twine == 6.1.0
+build == 1.2.2


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We've been having CI failures (such as [this](https://github.com/stripe/stripe-python/actions/runs/14344596118/job/40211702000?pr=1493)) because we're using a deprecated approach to building python packages (calling `python setup.py`) and trying to target a deprecated format (eggs). Rather than figure out exactly what broke, I've swapped us to using [build](https://github.com/pypa/build), the current industry standard in favor of `setuptools`.

Separately, I added better logging to our dependency installation when running in CI, which will help us understand better why something might have broken.

Note: this has no user-facing impact. We're just building our package for distribution in a more modern way.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- swap `python setup.py` call to `python -m build`
- swap `setuptools` dependency for `build`
- add more logging to dependency installation when running in CI.

### See Also
<!-- Include any links or additional information that help explain this change. -->

- https://setuptools.pypa.io/en/latest/deprecated/commands.html
- https://github.com/stripe/stripe-python/actions/runs/14344596118/job/40211702000?pr=1493