### PR TITLE
Rename beta SDKs to public preview SDKs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ be aware that the data you see at runtime may not match the types.
 
 ### Public Preview SDKs
 
-Stripe has features in the [public preview phase](https://docs.stripe.com/release-phases) that can be accessed via the beta version of this package.
+Stripe has features in the [public preview phase](https://docs.stripe.com/release-phases) that can be accessed via versions of this package that have the `-beta.X` suffix like `12.2.0-beta.2`.
 We would love for you to try these as we incrementally release new features and improve them based on your feedback.
 
 The public preview SDKs are different versions of the same package as the stable SDKs. They are appended with `b.X` such as `10.1.0b1`. To install, choose the version that includes support for the preview feature you are interested in by reviewing the [releases page](https://github.com/stripe/stripe-dotnet/releases/) and then use it in the `pip install` command:
@@ -260,7 +260,7 @@ pip install stripe==<replace-with-the-version-of-your-choice>
 > **Note**
 > There can be breaking changes between two versions of the public preview SDKs without a bump in the major version. Therefore we recommend pinning the package version to a specific version in your [requirements file](https://pip.pypa.io/en/stable/user_guide/#requirements-files) or `setup.py`. This way you can install the same version each time without breaking changes unless you are intentionally looking for the latest public preview SDK.
 
-If your beta feature requires a `Stripe-Version` header to be sent, set the `stripe.api_version` field using the `stripe.add_beta_version` function (available only in the public preview SDKs):
+Some preview features require a name and version to be set in the `Stripe-Version` header like `feature_beta=v3`. If your preview feature has this requirement, use the `stripe.add_beta_version` function (available only in the public preview SDKs):
 
 ```python
 stripe.add_beta_version("feature_beta", "v3")

--- a/README.md
+++ b/README.md
@@ -246,22 +246,21 @@ sends by default. If you are overriding `stripe.api_version` / `stripe_version` 
 [webhook endpoint](https://stripe.com/docs/webhooks#api-versions) tied to an older version,
 be aware that the data you see at runtime may not match the types.
 
-## Beta SDKs
+### Public Preview SDKs
 
-Stripe has features in the beta phase that can be accessed via the beta version of this package.
-We would love for you to try these and share feedback with us before these features reach the stable phase.
-To install a beta version use `pip install` with the exact version you'd like to use:
+Stripe has features in the [public preview phase](https://docs.stripe.com/release-phases) that can be accessed via the beta version of this package.
+We would love for you to try these as we incrementally release new features and improve them based on your feedback.
+
+The public preview SDKs are just a different version of the same package and are appended with `-beta.X` such as `45.0.0-beta.1`. To install, choose the version that includes support for the preview feature you are interested in by reviewing the [releases page](https://github.com/stripe/stripe-dotnet/releases/) and then use it in the `pip install` command:
 
 ```
-pip install --pre stripe
+pip install stripe==<replace-with-the-version-of-your-choice>
 ```
 
 > **Note**
-> There can be breaking changes between beta versions. Therefore we recommend pinning the package version to a specific beta version in your [requirements file](https://pip.pypa.io/en/stable/user_guide/#requirements-files) or `setup.py`. This way you can install the same version each time without breaking changes unless you are intentionally looking for the latest beta version.
+> There can be breaking changes between two versions of the public preview SDKs without a bump in the major version. Therefore we recommend pinning the package version to a specific version in your [requirements file](https://pip.pypa.io/en/stable/user_guide/#requirements-files) or `setup.py`. This way you can install the same version each time without breaking changes unless you are intentionally looking for the latest public preview SDK.
 
-We highly recommend keeping an eye on when the beta feature you are interested in goes from beta to stable so that you can move from using a beta version of the SDK to the stable version.
-
-If your beta feature requires a `Stripe-Version` header to be sent, set the `stripe.api_version` field using the `stripe.add_beta_version` function:
+If your beta feature requires a `Stripe-Version` header to be sent, set the `stripe.api_version` field using the `stripe.add_beta_version` function (available only in the public preview SDKs):
 
 ```python
 stripe.add_beta_version("feature_beta", "v3")

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ be aware that the data you see at runtime may not match the types.
 Stripe has features in the [public preview phase](https://docs.stripe.com/release-phases) that can be accessed via the beta version of this package.
 We would love for you to try these as we incrementally release new features and improve them based on your feedback.
 
-The public preview SDKs are just a different version of the same package and are appended with `-beta.X` such as `45.0.0-beta.1`. To install, choose the version that includes support for the preview feature you are interested in by reviewing the [releases page](https://github.com/stripe/stripe-dotnet/releases/) and then use it in the `pip install` command:
+The public preview SDKs are different versions of the same package as the stable SDKs. They are appended with `b.X` such as `10.1.0b1`. To install, choose the version that includes support for the preview feature you are interested in by reviewing the [releases page](https://github.com/stripe/stripe-dotnet/releases/) and then use it in the `pip install` command:
 
 ```
 pip install stripe==<replace-with-the-version-of-your-choice>


### PR DESCRIPTION
### Why?
Beta SDKs are being re-branded as public preview SDKs

### What?
- Reword the beta SDKs section to use the term "public preview" unless talking about the actual version string
- Link to https://docs.stripe.com/release-phases and re-use verbiage from ther
- Add info as to how to find the beta versions
- Update installation command to use specific version

