### PR TITLE
Add a new deprecated v1 services section

### DIFF
--- a/stripe/_stripe_client.py
+++ b/stripe/_stripe_client.py
@@ -370,3 +370,6 @@ class StripeClient(object):
             requestor=self._requestor,
             api_mode=api_mode,
         )
+
+    # deprecated v1 services: The beginning of the section generated from our OpenAPI spec
+    # deprecated v1 services: The end of the section generated from our OpenAPI spec


### PR DESCRIPTION
### Why?
Adds a new section to autogenerate the property methods for deprecated v1 services in stripeclient. 

### See Also
