### PR TITLE
Added import for the new deprecated services in stripe_client

### DIFF
--- a/stripe/_stripe_client.py
+++ b/stripe/_stripe_client.py
@@ -24,7 +24,7 @@ from stripe._http_client import (
 from stripe._api_version import _ApiVersion
 from stripe._stripe_object import StripeObject
 from stripe._stripe_response import StripeResponse
-from stripe._util import _convert_to_stripe_object, get_api_mode
+from stripe._util import _convert_to_stripe_object, get_api_mode, deprecated
 from stripe._webhook import Webhook, WebhookSignature
 from stripe._event import Event
 from stripe.v2._event import ThinEvent


### PR DESCRIPTION
### Why?
Need to add import deprecated decorator manually.


### See Also
<!-- Include any links or additional information that help explain this change. -->
