### PR TITLE
Pull in OffSessionPayment changes for the May release

### DIFF
--- a/stripe/v2/payments/_off_session_payment.py
+++ b/stripe/v2/payments/_off_session_payment.py
@@ -26,7 +26,7 @@ class OffSessionPayment(StripeObject):
         """
 
     class TransferData(StripeObject):
-        amount: int
+        amount: Optional[int]
         """
         Amount in minor units that you want to transfer.
         """
@@ -38,10 +38,6 @@ class OffSessionPayment(StripeObject):
     amount_requested: Amount
     """
     The amount you requested to be collected on the OSP upon creation.
-    """
-    attempts: int
-    """
-    Number of authorization attempts.
     """
     cadence: Literal["recurring", "unscheduled"]
     """

--- a/stripe/v2/payments/_off_session_payment_service.py
+++ b/stripe/v2/payments/_off_session_payment_service.py
@@ -71,7 +71,7 @@ class OffSessionPaymentService(StripeService):
         """
 
     class CreateParamsTransferData(TypedDict):
-        amount: int
+        amount: NotRequired[int]
         """
         Amount in minor units that you want to transfer.
         """


### PR DESCRIPTION
### Why?
Changes were done to OffSessionPayment API in the May release which did not make it to the SDKs. Pulling those changes in now and making another SDK release for the `2025-05-28.preview` API version

### What?
- Pull protos in codegen for `2025-05-28.preview`
- Generate the SDK 
