### PR TITLE
Added lint ignore instruction for deprecated import

### DIFF
--- a/stripe/_stripe_client.py
+++ b/stripe/_stripe_client.py
@@ -24,7 +24,7 @@ from stripe._http_client import (
 from stripe._api_version import _ApiVersion
 from stripe._stripe_object import StripeObject
 from stripe._stripe_response import StripeResponse
-from stripe._util import _convert_to_stripe_object, get_api_mode, deprecated
+from stripe._util import _convert_to_stripe_object, get_api_mode, deprecated  # noqa: F401
 from stripe._webhook import Webhook, WebhookSignature
 from stripe._event import Event
 from stripe.v2._event import ThinEvent


### PR DESCRIPTION
### Why?
Currently deprecated import is not being used by the code in _stripe_client.py. This is needed to make the CI 🟢 

### What?
Added a rule to ignore the line which imports `utils.deprecated` method. 

### See Also
