### PR TITLE
Fix timeout type hint in RequestsClient

### DIFF
--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -595,7 +595,7 @@ class RequestsClient(HTTPClient):
 
     def __init__(
         self,
-        timeout: int = 80,
+        timeout: Union[float, Tuple[float, float]] = 80,
         session: Optional["RequestsSession"] = None,
         verify_ssl_certs: bool = True,
         proxy: Optional[Union[str, HTTPClient._Proxy]] = None,


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
The `RequestsClient`'s `__init__` method incorrectly typed the `timeout` parameter as `int`. The underlying `requests` library accepts a float for a total timeout or a `(connect_timeout, read_timeout)` tuple.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
This commit updates the type hint to `Union[float, Tuple[float, float]]` to accurately reflect the timeout in the requests library.

### See Also
<!-- Include any links or additional information that help explain this change. -->
https://github.com/psf/requests/blob/91a3eabd3dcc4d7f36dd8249e4777a90ef9b4305/src/requests/sessions.py#L538