### PR TITLE
Add strongly typed Thin Event push payloads

### DIFF
--- a/justfile
+++ b/justfile
@@ -14,6 +14,11 @@ test *args: install-test-deps
     # configured in pyproject.toml
     pytest {{ args }}
 
+# run a single test by name
+test-one test_name: install-test-deps
+    # don't use all cores, there's a spin up time to that and we're only using one test
+    pytest -k {{ test_name }} -n 0
+
 # ⭐ check for potential mistakes
 lint: install-dev-deps
     python -m flake8 --show-source stripe tests setup.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ include = [
   "tests/test_generated_examples.py",
   "tests/test_exports.py",
   "tests/test_http_client.py",
+  "tests/test_v2_event.py",
 ]
 exclude = ["build", "**/__pycache__"]
 reportMissingTypeArgument = true

--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -821,7 +821,7 @@ class _APIRequestor(object):
 
         return rcontent, rcode, rheaders
 
-    def _should_handle_code_as_error(self, rcode):
+    def _should_handle_code_as_error(self, rcode: int) -> bool:
         return not 200 <= rcode < 300
 
     def _interpret_response(

--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -551,10 +551,14 @@ class _APIRequestor(object):
                 "questions."
             )
 
-        abs_url = "%s%s" % (
-            self._options.base_addresses.get(base_address),
-            url,
-        )
+        # we're passed full urls from thin events, so we should just call those directly
+        if url.startswith("https://"):
+            abs_url = url
+        else:
+            abs_url = "%s%s" % (
+                self._options.base_addresses.get(base_address),
+                url,
+            )
 
         params = params or {}
         if params and (method == "get" or method == "delete"):

--- a/stripe/_stripe_client.py
+++ b/stripe/_stripe_client.py
@@ -113,7 +113,7 @@ from stripe._v2_services import V2Services
 # services: The end of the section generated from our OpenAPI spec
 
 if TYPE_CHECKING:
-    from stripe.events._event_classes import All_PUSHED_THIN_EVENTS
+    from stripe.events._event_classes import ALL_PUSHED_THIN_EVENTS
 
 
 class StripeClient(object):
@@ -278,7 +278,7 @@ class StripeClient(object):
         sig_header: str,
         secret: str,
         tolerance: int = Webhook.DEFAULT_TOLERANCE,
-    ) -> "All_PUSHED_THIN_EVENTS":
+    ) -> "ALL_PUSHED_THIN_EVENTS":
         payload = (
             cast(Union[bytes, bytearray], raw).decode("utf-8")
             if hasattr(raw, "decode")

--- a/stripe/_util.py
+++ b/stripe/_util.py
@@ -9,7 +9,7 @@ import warnings
 
 from stripe._api_mode import ApiMode
 
-from urllib.parse import parse_qsl, quote_plus  # noqa: F401
+from urllib.parse import parse_qsl, quote_plus, urlparse  # noqa: F401
 
 from typing_extensions import Type, TYPE_CHECKING
 from typing import (
@@ -417,9 +417,15 @@ def sanitize_id(id):
     return quotedId
 
 
-def get_api_mode(url):
+def get_api_mode(url: str) -> ApiMode:
+    # support absolute urls
+    if url.startswith("http"):
+        url = urlparse(url).path
+
     if url.startswith("/v2"):
         return "V2"
+
+    # if urls aren't explicitly marked as v1, they're assumed to be v1
     else:
         return "V1"
 

--- a/stripe/events/_event_classes.py
+++ b/stripe/events/_event_classes.py
@@ -27,7 +27,7 @@ PUSHED_THIN_EVENT_CLASSES = {
     PushedV2CoreEventDestinationPingEvent.LOOKUP_TYPE: PushedV2CoreEventDestinationPingEvent,
 }
 
-All_PUSHED_THIN_EVENTS = Union[
+ALL_PUSHED_THIN_EVENTS = Union[
     PushedV1BillingMeterErrorReportTriggeredEvent,
     PushedV1BillingMeterNoMeterFoundEvent,
     PushedV2CoreEventDestinationPingEvent,

--- a/stripe/events/_event_classes.py
+++ b/stripe/events/_event_classes.py
@@ -1,13 +1,17 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+from typing import Union
 from stripe.events._v1_billing_meter_error_report_triggered_event import (
     V1BillingMeterErrorReportTriggeredEvent,
+    PushedV1BillingMeterErrorReportTriggeredEvent,
 )
 from stripe.events._v1_billing_meter_no_meter_found_event import (
     V1BillingMeterNoMeterFoundEvent,
+    PushedV1BillingMeterNoMeterFoundEvent,
 )
 from stripe.events._v2_core_event_destination_ping_event import (
     V2CoreEventDestinationPingEvent,
+    PushedV2CoreEventDestinationPingEvent,
 )
 
 
@@ -16,3 +20,15 @@ THIN_EVENT_CLASSES = {
     V1BillingMeterNoMeterFoundEvent.LOOKUP_TYPE: V1BillingMeterNoMeterFoundEvent,
     V2CoreEventDestinationPingEvent.LOOKUP_TYPE: V2CoreEventDestinationPingEvent,
 }
+
+PUSHED_THIN_EVENT_CLASSES = {
+    PushedV1BillingMeterErrorReportTriggeredEvent.LOOKUP_TYPE: PushedV1BillingMeterErrorReportTriggeredEvent,
+    PushedV1BillingMeterNoMeterFoundEvent.LOOKUP_TYPE: PushedV1BillingMeterNoMeterFoundEvent,
+    PushedV2CoreEventDestinationPingEvent.LOOKUP_TYPE: PushedV2CoreEventDestinationPingEvent,
+}
+
+All_PUSHED_THIN_EVENTS = Union[
+    PushedV1BillingMeterErrorReportTriggeredEvent,
+    PushedV1BillingMeterNoMeterFoundEvent,
+    PushedV2CoreEventDestinationPingEvent,
+]

--- a/stripe/events/_v1_billing_meter_error_report_triggered_event.py
+++ b/stripe/events/_v1_billing_meter_error_report_triggered_event.py
@@ -5,6 +5,7 @@ from stripe._api_requestor import _APIRequestor
 from stripe._stripe_client import StripeClient
 from stripe._stripe_object import StripeObject
 from stripe._stripe_response import StripeResponse
+from stripe._util import get_api_mode
 from stripe.billing._meter import Meter
 from stripe.v2._event import Event, RelatedObject, ThinEvent
 from typing import Any, Dict, List, Optional, cast
@@ -32,13 +33,17 @@ class PushedV1BillingMeterErrorReportTriggeredEvent(ThinEvent):
         )
 
     def fetch_related_object(self) -> "Meter":
+        response = self.client.raw_request(
+            "get",
+            self.related_object.url,
+            stripe_context=self.context,
+            usage=["fetch_related_object"],
+        )
         return cast(
             "Meter",
-            self.client.raw_request(
-                "get",
-                self.related_object.url,
-                stripe_context=self.context,
-                usage=["fetch_related_object"],
+            self.client.deserialize(
+                response,
+                api_mode=get_api_mode(self.related_object.url),
             ),
         )
 
@@ -49,13 +54,17 @@ class PushedV1BillingMeterErrorReportTriggeredEvent(ThinEvent):
         )
 
     async def fetch_related_object_async(self) -> "Meter":
+        response = await self.client.raw_request_async(
+            "get",
+            self.related_object.url,
+            stripe_context=self.context,
+            usage=["fetch_related_object"],
+        )
         return cast(
             "Meter",
-            await self.client.raw_request_async(
-                "get",
-                self.related_object.url,
-                stripe_context=self.context,
-                usage=["fetch_related_object"],
+            self.client.deserialize(
+                response,
+                api_mode=get_api_mode(self.related_object.url),
             ),
         )
 

--- a/stripe/events/_v1_billing_meter_error_report_triggered_event.py
+++ b/stripe/events/_v1_billing_meter_error_report_triggered_event.py
@@ -33,7 +33,15 @@ class PushedV1BillingMeterErrorReportTriggeredEvent(ThinEvent):
         )
 
     def fetch_related_object(self) -> "Meter":
-        raise NotImplementedError()  # TODO
+        return cast(
+            "Meter",
+            self.client.raw_request(
+                "get",
+                self.related_object.url,
+                stripe_context=self.context,
+                usage=["fetch_related_object"],
+            ),
+        )
 
     async def pull_async(self) -> "V1BillingMeterErrorReportTriggeredEvent":
         return cast(
@@ -41,8 +49,16 @@ class PushedV1BillingMeterErrorReportTriggeredEvent(ThinEvent):
             await super().pull_async(),
         )
 
-    def fetch_related_object_async(self) -> "Meter":
-        raise NotImplementedError()  # TODO
+    async def fetch_related_object_async(self) -> "Meter":
+        return cast(
+            "Meter",
+            await self.client.raw_request_async(
+                "get",
+                self.related_object.url,
+                stripe_context=self.context,
+                usage=["fetch_related_object"],
+            ),
+        )
 
 
 class V1BillingMeterErrorReportTriggeredEvent(Event):

--- a/stripe/events/_v1_billing_meter_error_report_triggered_event.py
+++ b/stripe/events/_v1_billing_meter_error_report_triggered_event.py
@@ -5,9 +5,23 @@ from stripe._api_requestor import _APIRequestor
 from stripe._stripe_object import StripeObject
 from stripe._stripe_response import StripeResponse
 from stripe.billing._meter import Meter
-from stripe.v2._event import Event
+from stripe.v2._event import Event, ThinEvent
 from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
+
+
+class PushedV1BillingMeterErrorReportTriggeredEvent(ThinEvent):
+    LOOKUP_TYPE = "v1.billing.meter.error_report_triggered"
+    type: Literal["v1.billing.meter.error_report_triggered"]
+
+    def pull(self) -> V1BillingMeterErrorReportTriggeredEvent:
+        return super()
+
+    def fetch_related_object(self) -> Meter:
+        return super()
+
+    async def fetch_related_object_async(self) -> Meter:
+        pass
 
 
 class V1BillingMeterErrorReportTriggeredEvent(Event):

--- a/stripe/events/_v1_billing_meter_error_report_triggered_event.py
+++ b/stripe/events/_v1_billing_meter_error_report_triggered_event.py
@@ -17,14 +17,14 @@ class PushedV1BillingMeterErrorReportTriggeredEvent(ThinEvent):
     type: Literal["v1.billing.meter.error_report_triggered"]
     related_object: RelatedObject
 
-    def __init__(self, payload: str, client: StripeClient) -> None:
+    def __init__(
+        self, parsed_body: Dict[str, Any], client: StripeClient
+    ) -> None:
         super().__init__(
-            payload,
+            parsed_body,
             client,
         )
-        # don't love the double json parse here, but it's fine
-        parsed = json.loads(payload)
-        self.related_object = RelatedObject(parsed["related_object"])
+        self.related_object = RelatedObject(parsed_body["related_object"])
 
     def pull(self) -> "V1BillingMeterErrorReportTriggeredEvent":
         return cast(

--- a/stripe/events/_v1_billing_meter_error_report_triggered_event.py
+++ b/stripe/events/_v1_billing_meter_error_report_triggered_event.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+import json
 from stripe._api_mode import ApiMode
 from stripe._api_requestor import _APIRequestor
+from stripe._stripe_client import StripeClient
 from stripe._stripe_object import StripeObject
 from stripe._stripe_response import StripeResponse
 from stripe.billing._meter import Meter
-from stripe.v2._event import Event, ThinEvent
+from stripe.v2._event import Event, RelatedObject, ThinEvent
 from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
 
@@ -13,15 +15,34 @@ from typing_extensions import Literal
 class PushedV1BillingMeterErrorReportTriggeredEvent(ThinEvent):
     LOOKUP_TYPE = "v1.billing.meter.error_report_triggered"
     type: Literal["v1.billing.meter.error_report_triggered"]
+    related_object: RelatedObject
 
-    def pull(self) -> V1BillingMeterErrorReportTriggeredEvent:
-        return super()
+    def __init__(self, payload: str, client: StripeClient) -> None:
+        super().__init__(
+            payload,
+            client,
+        )
+        # don't love the double json parse here, but it's fine
+        parsed = json.loads(payload)
+        self.related_object = RelatedObject(parsed["related_object"])
 
-    def fetch_related_object(self) -> Meter:
-        return super()
+    def pull(self) -> "V1BillingMeterErrorReportTriggeredEvent":
+        return cast(
+            "V1BillingMeterErrorReportTriggeredEvent",
+            super().pull(),
+        )
 
-    async def fetch_related_object_async(self) -> Meter:
-        pass
+    def fetch_related_object(self) -> "Meter":
+        raise NotImplementedError()  # TODO
+
+    async def pull_async(self) -> "V1BillingMeterErrorReportTriggeredEvent":
+        return cast(
+            "V1BillingMeterErrorReportTriggeredEvent",
+            await super().pull_async(),
+        )
+
+    def fetch_related_object_async(self) -> "Meter":
+        raise NotImplementedError()  # TODO
 
 
 class V1BillingMeterErrorReportTriggeredEvent(Event):

--- a/stripe/events/_v1_billing_meter_error_report_triggered_event.py
+++ b/stripe/events/_v1_billing_meter_error_report_triggered_event.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-import json
 from stripe._api_mode import ApiMode
 from stripe._api_requestor import _APIRequestor
 from stripe._stripe_client import StripeClient

--- a/stripe/events/_v1_billing_meter_no_meter_found_event.py
+++ b/stripe/events/_v1_billing_meter_no_meter_found_event.py
@@ -4,9 +4,17 @@ from stripe._api_mode import ApiMode
 from stripe._api_requestor import _APIRequestor
 from stripe._stripe_object import StripeObject
 from stripe._stripe_response import StripeResponse
-from stripe.v2._event import Event
+from stripe.v2._event import Event, ThinEvent
 from typing import Any, Dict, List, Optional
 from typing_extensions import Literal
+
+
+class PushedV1BillingMeterNoMeterFoundEvent(ThinEvent):
+    LOOKUP_TYPE = "v1.billing.meter.no_meter_found"
+    type: Literal["v1.billing.meter.no_meter_found"]
+
+    def pull(self) -> V1BillingMeterNoMeterFoundEvent:
+        return super()
 
 
 class V1BillingMeterNoMeterFoundEvent(Event):

--- a/stripe/events/_v1_billing_meter_no_meter_found_event.py
+++ b/stripe/events/_v1_billing_meter_no_meter_found_event.py
@@ -5,7 +5,7 @@ from stripe._api_requestor import _APIRequestor
 from stripe._stripe_object import StripeObject
 from stripe._stripe_response import StripeResponse
 from stripe.v2._event import Event, ThinEvent
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 from typing_extensions import Literal
 
 
@@ -13,8 +13,17 @@ class PushedV1BillingMeterNoMeterFoundEvent(ThinEvent):
     LOOKUP_TYPE = "v1.billing.meter.no_meter_found"
     type: Literal["v1.billing.meter.no_meter_found"]
 
-    def pull(self) -> V1BillingMeterNoMeterFoundEvent:
-        return super()
+    def pull(self) -> "V1BillingMeterNoMeterFoundEvent":
+        return cast(
+            "V1BillingMeterNoMeterFoundEvent",
+            super().pull(),
+        )
+
+    async def pull_async(self) -> "V1BillingMeterNoMeterFoundEvent":
+        return cast(
+            "V1BillingMeterNoMeterFoundEvent",
+            await super().pull_async(),
+        )
 
 
 class V1BillingMeterNoMeterFoundEvent(Event):

--- a/stripe/events/_v2_core_event_destination_ping_event.py
+++ b/stripe/events/_v2_core_event_destination_ping_event.py
@@ -1,10 +1,24 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 from stripe._stripe_object import StripeObject
-from stripe.v2._event import Event
+from stripe.v2._event import Event, ThinEvent
 from stripe.v2._event_destination import EventDestination
 from typing import cast
 from typing_extensions import Literal
+
+
+class PushedV2CoreEventDestinationPingEvent(ThinEvent):
+    LOOKUP_TYPE = "v2.core.event_destination.ping"
+    type: Literal["v2.core.event_destination.ping"]
+
+    def pull(self) -> V2CoreEventDestinationPingEvent:
+        return super()
+
+    def fetch_related_object(self) -> "EventDestination":
+        return super()
+
+    async def fetch_related_object_async(self) -> EventDestination:
+        pass
 
 
 class V2CoreEventDestinationPingEvent(Event):

--- a/stripe/events/_v2_core_event_destination_ping_event.py
+++ b/stripe/events/_v2_core_event_destination_ping_event.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
-import json
 from stripe._stripe_client import StripeClient
 from stripe._stripe_object import StripeObject
 from stripe.v2._event import Event, RelatedObject, ThinEvent

--- a/stripe/events/_v2_core_event_destination_ping_event.py
+++ b/stripe/events/_v2_core_event_destination_ping_event.py
@@ -5,6 +5,7 @@ from stripe._stripe_client import StripeClient
 from stripe._stripe_object import StripeObject
 from stripe.v2._event import Event, RelatedObject, ThinEvent
 from stripe.v2._event_destination import EventDestination
+from typing import cast
 from typing_extensions import Literal
 
 
@@ -29,7 +30,15 @@ class PushedV2CoreEventDestinationPingEvent(ThinEvent):
         )
 
     def fetch_related_object(self) -> "EventDestination":
-        raise NotImplementedError()  # TODO
+        return cast(
+            "EventDestination",
+            self.client.raw_request(
+                "get",
+                self.related_object.url,
+                stripe_context=self.context,
+                usage=["fetch_related_object"],
+            ),
+        )
 
     async def pull_async(self) -> "V2CoreEventDestinationPingEvent":
         return cast(
@@ -37,8 +46,16 @@ class PushedV2CoreEventDestinationPingEvent(ThinEvent):
             await super().pull_async(),
         )
 
-    def fetch_related_object_async(self) -> "EventDestination":
-        raise NotImplementedError()  # TODO
+    async def fetch_related_object_async(self) -> "EventDestination":
+        return cast(
+            "EventDestination",
+            await self.client.raw_request_async(
+                "get",
+                self.related_object.url,
+                stripe_context=self.context,
+                usage=["fetch_related_object"],
+            ),
+        )
 
 
 class V2CoreEventDestinationPingEvent(Event):

--- a/stripe/events/_v2_core_event_destination_ping_event.py
+++ b/stripe/events/_v2_core_event_destination_ping_event.py
@@ -5,7 +5,7 @@ from stripe._stripe_client import StripeClient
 from stripe._stripe_object import StripeObject
 from stripe.v2._event import Event, RelatedObject, ThinEvent
 from stripe.v2._event_destination import EventDestination
-from typing import cast
+from typing import Any, Dict, cast
 from typing_extensions import Literal
 
 
@@ -14,14 +14,14 @@ class PushedV2CoreEventDestinationPingEvent(ThinEvent):
     type: Literal["v2.core.event_destination.ping"]
     related_object: RelatedObject
 
-    def __init__(self, payload: str, client: StripeClient) -> None:
+    def __init__(
+        self, parsed_body: Dict[str, Any], client: StripeClient
+    ) -> None:
         super().__init__(
-            payload,
+            parsed_body,
             client,
         )
-        # don't love the double json parse here, but it's fine
-        parsed = json.loads(payload)
-        self.related_object = RelatedObject(parsed["related_object"])
+        self.related_object = RelatedObject(parsed_body["related_object"])
 
     def pull(self) -> "V2CoreEventDestinationPingEvent":
         return cast(

--- a/stripe/events/_v2_core_event_destination_ping_event.py
+++ b/stripe/events/_v2_core_event_destination_ping_event.py
@@ -1,24 +1,44 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
+import json
+from stripe._stripe_client import StripeClient
 from stripe._stripe_object import StripeObject
-from stripe.v2._event import Event, ThinEvent
+from stripe.v2._event import Event, RelatedObject, ThinEvent
 from stripe.v2._event_destination import EventDestination
-from typing import cast
 from typing_extensions import Literal
 
 
 class PushedV2CoreEventDestinationPingEvent(ThinEvent):
     LOOKUP_TYPE = "v2.core.event_destination.ping"
     type: Literal["v2.core.event_destination.ping"]
+    related_object: RelatedObject
 
-    def pull(self) -> V2CoreEventDestinationPingEvent:
-        return super()
+    def __init__(self, payload: str, client: StripeClient) -> None:
+        super().__init__(
+            payload,
+            client,
+        )
+        # don't love the double json parse here, but it's fine
+        parsed = json.loads(payload)
+        self.related_object = RelatedObject(parsed["related_object"])
+
+    def pull(self) -> "V2CoreEventDestinationPingEvent":
+        return cast(
+            "V2CoreEventDestinationPingEvent",
+            super().pull(),
+        )
 
     def fetch_related_object(self) -> "EventDestination":
-        return super()
+        raise NotImplementedError()  # TODO
 
-    async def fetch_related_object_async(self) -> EventDestination:
-        pass
+    async def pull_async(self) -> "V2CoreEventDestinationPingEvent":
+        return cast(
+            "V2CoreEventDestinationPingEvent",
+            await super().pull_async(),
+        )
+
+    def fetch_related_object_async(self) -> "EventDestination":
+        raise NotImplementedError()  # TODO
 
 
 class V2CoreEventDestinationPingEvent(Event):

--- a/stripe/events/_v2_core_event_destination_ping_event.py
+++ b/stripe/events/_v2_core_event_destination_ping_event.py
@@ -2,6 +2,7 @@
 # File generated from our OpenAPI spec
 from stripe._stripe_client import StripeClient
 from stripe._stripe_object import StripeObject
+from stripe._util import get_api_mode
 from stripe.v2._event import Event, RelatedObject, ThinEvent
 from stripe.v2._event_destination import EventDestination
 from typing import Any, Dict, cast
@@ -29,13 +30,17 @@ class PushedV2CoreEventDestinationPingEvent(ThinEvent):
         )
 
     def fetch_related_object(self) -> "EventDestination":
+        response = self.client.raw_request(
+            "get",
+            self.related_object.url,
+            stripe_context=self.context,
+            usage=["fetch_related_object"],
+        )
         return cast(
             "EventDestination",
-            self.client.raw_request(
-                "get",
-                self.related_object.url,
-                stripe_context=self.context,
-                usage=["fetch_related_object"],
+            self.client.deserialize(
+                response,
+                api_mode=get_api_mode(self.related_object.url),
             ),
         )
 
@@ -46,13 +51,17 @@ class PushedV2CoreEventDestinationPingEvent(ThinEvent):
         )
 
     async def fetch_related_object_async(self) -> "EventDestination":
+        response = await self.client.raw_request_async(
+            "get",
+            self.related_object.url,
+            stripe_context=self.context,
+            usage=["fetch_related_object"],
+        )
         return cast(
             "EventDestination",
-            await self.client.raw_request_async(
-                "get",
-                self.related_object.url,
-                stripe_context=self.context,
-                usage=["fetch_related_object"],
+            self.client.deserialize(
+                response,
+                api_mode=get_api_mode(self.related_object.url),
             ),
         )
 

--- a/stripe/v2/_event.py
+++ b/stripe/v2/_event.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import json
-from typing import ClassVar, Optional
+from typing import ClassVar, Optional, cast
 
 from typing_extensions import Literal
 
@@ -153,11 +153,20 @@ class ThinEvent:
     def __repr__(self) -> str:
         return f"<ThinEvent id={self.id} type={self.type} created={self.created} context={self.context} reason={self.reason}>"
 
-    def pull(self):  # TODO: general return type?
+    def pull(self) -> Event:
         response = self.client.raw_request(
             "get",
             f"/v2/core/events/{self.id}",
             stripe_context=self.context,
             usage=["pushed_event_pull"],
         )
-        return self.client.deserialize(response, api_mode="V2")
+        return cast(Event, self.client.deserialize(response, api_mode="V2"))
+
+    async def pull_async(self) -> Event:
+        response = await self.client.raw_request_async(
+            "get",
+            f"/v2/core/events/{self.id}",
+            stripe_context=self.context,
+            usage=["pushed_event_pull", "pushed_event_pull_async"],
+        )
+        return cast(Event, self.client.deserialize(response, api_mode="V2"))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,8 +1,12 @@
 import sys
 from collections import namedtuple
 
+import pytest
+
 import stripe
 from stripe import util
+from stripe._api_mode import ApiMode
+from stripe._util import get_api_mode
 
 LogTestCase = namedtuple("LogTestCase", "env flag should_output")
 FmtTestCase = namedtuple("FmtTestCase", "props expected")
@@ -152,3 +156,16 @@ class TestUtil(object):
         if isinstance(sanitized_id, bytes):
             sanitized_id = sanitized_id.decode("utf-8", "strict")
         assert sanitized_id == "cu++%25x+123"
+
+    @pytest.mark.parametrize(
+        ["url", "expected"],
+        [
+            ("/v2/core/events", "V2"),
+            ("/v1/events", "V1"),
+            ("https://api.stripe.com/v1/events", "V1"),
+            ("https://api.stripe.com/v2/core/events", "V2"),
+            ("something/v2/core/events", "V1"),
+        ],
+    )
+    def test_get_api_mode(self, url: str, expected: ApiMode):
+        assert get_api_mode(url) == expected

--- a/tests/test_v2_event.py
+++ b/tests/test_v2_event.py
@@ -1,18 +1,24 @@
 import json
+import sys
 from typing import Callable
 
 import pytest
+from stripe.billing._meter import Meter
+from tests.http_client_mock import HTTPClientMock
 
-import stripe
-from stripe import ThinEvent
+
+from stripe import DEFAULT_API_BASE
+from stripe._error import SignatureVerificationError
+from stripe._stripe_client import StripeClient
 from stripe.events._v1_billing_meter_error_report_triggered_event import (
     PushedV1BillingMeterErrorReportTriggeredEvent,
     V1BillingMeterErrorReportTriggeredEvent,
 )
 from stripe.v2._event import UnknownThinEvent
+from stripe.events._event_classes import ALL_PUSHED_THIN_EVENTS
 from tests.test_webhook import DUMMY_WEBHOOK_SECRET, generate_header
 
-EventParser = Callable[[str], ThinEvent]
+EventParser = Callable[[str], ALL_PUSHED_THIN_EVENTS]
 
 
 class TestV2Event(object):
@@ -24,12 +30,12 @@ class TestV2Event(object):
                 "object": "v2.core.event",
                 "type": "v1.billing.meter.error_report_triggered",
                 "livemode": True,
+                "context": "acct_123",
                 "created": "2022-02-15T00:27:45.330Z",
                 "related_object": {
                     "id": "mtr_123",
                     "type": "billing.meter",
                     "url": "/v1/billing/meters/mtr_123",
-                    "stripe_context": "acct_123",
                 },
                 "reason": {
                     "id": "foo",
@@ -63,16 +69,13 @@ class TestV2Event(object):
 
     @pytest.fixture(scope="function")
     def stripe_client(self, http_client_mock):
-        return stripe.StripeClient(
-            api_key="keyinfo_test_123",
-            stripe_context="wksp_123",
+        return StripeClient(
+            api_key="sk_test_1234",
             http_client=http_client_mock.get_mock_http_client(),
         )
 
     @pytest.fixture(scope="function")
-    def parse_thin_event(
-        self, stripe_client: stripe.StripeClient
-    ) -> EventParser:
+    def parse_thin_event(self, stripe_client: StripeClient) -> EventParser:
         """
         helper to simplify parsing and validating events given a payload
         returns a function that has the client pre-bound
@@ -118,11 +121,11 @@ class TestV2Event(object):
                     "type": "uknown.event.type",
                     "livemode": True,
                     "created": "2022-02-15T00:27:45.330Z",
+                    "context": "acct_456",
                     "related_object": {
                         "id": "mtr_123",
                         "type": "billing.meter",
                         "url": "/v1/billing/meters/mtr_123",
-                        "stripe_context": "acct_123",
                     },
                     "reason": {
                         "id": "foo",
@@ -136,9 +139,9 @@ class TestV2Event(object):
         assert event.related_object
 
     def test_validates_signature(
-        self, stripe_client: stripe.StripeClient, v2_payload_no_data
+        self, stripe_client: StripeClient, v2_payload_no_data
     ):
-        with pytest.raises(stripe.error.SignatureVerificationError):
+        with pytest.raises(SignatureVerificationError):
             stripe_client.parse_thin_event(
                 v2_payload_no_data, "bad header", DUMMY_WEBHOOK_SECRET
             )
@@ -153,17 +156,19 @@ class TestV2Event(object):
             rcode=200,
             rheaders={},
         )
-        client = stripe.StripeClient(
-            api_key="keyinfo_test_123",
+        client = StripeClient(
+            api_key="sk_test_1234",
+            stripe_context="org_456",
             http_client=http_client_mock.get_mock_http_client(),
         )
         event = client.v2.core.events.retrieve("evt_123")
 
         http_client_mock.assert_requested(
             method,
-            api_base=stripe.DEFAULT_API_BASE,
+            api_base=DEFAULT_API_BASE,
             path=path,
-            api_key="keyinfo_test_123",
+            api_key="sk_test_1234",
+            stripe_context="org_456",
         )
         assert event.id is not None
         assert isinstance(event, V1BillingMeterErrorReportTriggeredEvent)
@@ -173,3 +178,81 @@ class TestV2Event(object):
             V1BillingMeterErrorReportTriggeredEvent.V1BillingMeterErrorReportTriggeredEventData,
         )
         assert event.data.reason.error_count == 1
+
+    # an "integration" shaped test with all the bells and whistles
+    def test_v2_events_integration(
+        self,
+        http_client_mock: HTTPClientMock,
+        v2_payload_no_data,
+        v2_payload_with_data,
+        parse_thin_event: EventParser,
+    ):
+        method = "get"
+        path = "/v2/core/events/evt_234"
+        meter_path = "/v1/billing/meters/mtr_123"
+
+        http_client_mock.stub_request(
+            method,
+            path=path,
+            rbody=v2_payload_with_data,
+            rcode=200,
+            rheaders={},
+        )
+        http_client_mock.stub_request(
+            method,
+            path=meter_path,
+            rbody=json.dumps(
+                {
+                    "id": "mtr_123",
+                    "object": "billing.meter",
+                    "event_name": "cool event",
+                }
+            ),
+            rcode=200,
+            rheaders={},
+        )
+
+        thin_event = parse_thin_event(v2_payload_no_data)
+        assert thin_event.type == "v1.billing.meter.error_report_triggered"
+
+        event = thin_event.pull()
+        meter = thin_event.fetch_related_object()
+
+        if sys.version_info >= (3, 7):
+            from typing_extensions import assert_type  # noqa: SPY103 - this is only available on 3.6 pythons because of typing_extensions version restrictions
+
+            # these are purely type-level checks to ensure our narrowing works for users
+            assert_type(
+                thin_event, PushedV1BillingMeterErrorReportTriggeredEvent
+            )
+
+            assert_type(event, V1BillingMeterErrorReportTriggeredEvent)
+            assert_type(meter, Meter)
+
+        assert isinstance(event, V1BillingMeterErrorReportTriggeredEvent)
+
+        http_client_mock.assert_requested(
+            method,
+            api_base=DEFAULT_API_BASE,
+            path=path,
+            api_key="sk_test_1234",
+            # context read from event
+            stripe_context="acct_123",
+        )
+        http_client_mock.assert_requested(
+            method,
+            api_base=DEFAULT_API_BASE,
+            path=meter_path,
+            api_key="sk_test_1234",
+            # context read from event
+            stripe_context="acct_123",
+        )
+
+        assert isinstance(
+            event.data,
+            V1BillingMeterErrorReportTriggeredEvent.V1BillingMeterErrorReportTriggeredEventData,
+        )
+        assert event.data.reason.error_count == 1
+
+        assert isinstance(meter, Meter)
+        assert meter.event_name == "cool event"


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

As part of the Next Gen Event Handling project, we're adding fully typed push payloads to thin events. These describe the full union of thin events a user could receive. 

### What?
<!--
List out the key changes made in this PR, e.g.

### TODO

- [ ] add `UknownThinEvent` and make sure type narrowing works nicely

### See Also
<!-- Include any links or additional information that help explain this change. -->

- [DEVSDK-2662](https://go/j/browse/DEVSDK-2662)