### PR TITLE
Add section on private preview SDKs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,10 +248,10 @@ be aware that the data you see at runtime may not match the types.
 
 ### Public Preview SDKs
 
-Stripe has features in the [public preview phase](https://docs.stripe.com/release-phases) that can be accessed via versions of this package that have the `-bX` suffix like `12.2.0b2`.
+Stripe has features in the [public preview phase](https://docs.stripe.com/release-phases) that can be accessed via versions of this package that have the `bX` suffix like `12.2.0b2`.
 We would love for you to try these as we incrementally release new features and improve them based on your feedback.
 
-To install, choose the version that includes support for the preview feature you are interested in by reviewing the [releases page](https://github.com/stripe/stripe-python/releases/) and then use it in the `pip install` command:
+To install, pick the latest version with the `bX` suffix by reviewing the [releases page](https://github.com/stripe/stripe-python/releases/) and then use it in the `pip install` command:
 
 ```
 pip install stripe==<replace-with-the-version-of-your-choice>
@@ -265,6 +265,9 @@ Some preview features require a name and version to be set in the `Stripe-Versio
 ```python
 stripe.add_beta_version("feature_beta", "v3")
 ```
+### Private Preview SDKs
+
+Stripe has features in the [private preview phase](https://docs.stripe.com/release-phases) that can be accessed via versions of this package that have the `aX` suffix like `12.2.0a2`. These are invite-only features. Once invited, you can install the private preview SDKs by following the same instructions as for the [public preview SDKs](https://github.com/stripe/stripe-python?tab=readme-ov-file#public-preview-sdks) above and replacing the suffix `b` with `a` in package versions.
 
 ### Custom requests
 


### PR DESCRIPTION
### Why?
Need a section on how to install the private preview SDKs

### What?
- Added a section on private preview SDKs
- Updated the note on public preview SDKs to nudge users to use the latest beta versions - these are guaranteed to have all the active previews and users do not need to go and find which version maps the feature they are interested in



