### PR TITLE
Use the right API version 2025-08-27.preview

### DIFF
--- a/stripe/_api_version.py
+++ b/stripe/_api_version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 # File generated from our OpenAPI spec
 class _ApiVersion:
-    CURRENT = "2025-08-04.private"
+    CURRENT = "2025-08-27.preview"


### PR DESCRIPTION
### Why?
The Open API spec used to generate the SDK was using an older API version. The spec with the fix for this cannot be used as it also contains changes meant for the next release. Therefore, manually making the API version change here

### What?
Update API version 2025-08-04.private to 2025-08-27.preview 


