### PR TITLE
fix: paginate backwards if `starting_after == None`

### DIFF
--- a/stripe/_list_object.py
+++ b/stripe/_list_object.py
@@ -132,8 +132,8 @@ class ListObject(StripeObject, Generic[T]):
 
         while True:
             if (
-                "ending_before" in self._retrieve_params
-                and "starting_after" not in self._retrieve_params
+                self._retrieve_params.get("ending_before") is not None
+                and self._retrieve_params.get("starting_after") is None
             ):
                 for item in reversed(page):
                     yield item
@@ -151,8 +151,8 @@ class ListObject(StripeObject, Generic[T]):
 
         while True:
             if (
-                "ending_before" in self._retrieve_params
-                and "starting_after" not in self._retrieve_params
+                self._retrieve_params.get("ending_before") is not None
+                and self._retrieve_params.get("starting_after") is None
             ):
                 for item in reversed(page):
                     yield item

--- a/tests/api_resources/test_list_object.py
+++ b/tests/api_resources/test_list_object.py
@@ -331,7 +331,9 @@ class TestAutoPaging:
             self.pageable_model_response(["pm_125", "pm_126"], True), "mykey"
         )
         lo._retrieve_params = {
-            "foo": "bar", "ending_before": "pm_127", "starting_after": None
+            "foo": "bar",
+            "ending_before": "pm_127",
+            "starting_after": None,
         }
 
         http_client_mock.stub_request(
@@ -606,7 +608,9 @@ class TestAutoPagingAsync:
             self.pageable_model_response(["pm_125", "pm_126"], True), "mykey"
         )
         lo._retrieve_params = {
-            "foo": "bar", "ending_before": "pm_127", "starting_after": None
+            "foo": "bar",
+            "ending_before": "pm_127",
+            "starting_after": None,
         }
 
         http_client_mock.stub_request(

--- a/tests/api_resources/test_list_object.py
+++ b/tests/api_resources/test_list_object.py
@@ -323,6 +323,36 @@ class TestAutoPaging:
 
         assert seen == ["pm_126", "pm_125", "pm_124", "pm_123"]
 
+    def test_iter_reverse_none_starting_after(self, http_client_mock):
+        """Test that if `starting_after` is present in the retrieve params, but is
+        `None`, that reverse pagination still occurs as expected.
+        """
+        lo = stripe.ListObject.construct_from(
+            self.pageable_model_response(["pm_125", "pm_126"], True), "mykey"
+        )
+        lo._retrieve_params = {
+            "foo": "bar", "ending_before": "pm_127", "starting_after": None
+        }
+
+        http_client_mock.stub_request(
+            "get",
+            path="/v1/pageablemodels",
+            query_string="ending_before=pm_125&foo=bar",
+            rbody=json.dumps(
+                self.pageable_model_response(["pm_123", "pm_124"], False)
+            ),
+        )
+
+        seen = [item["id"] for item in lo.auto_paging_iter()]
+
+        http_client_mock.assert_requested(
+            "get",
+            path="/v1/pageablemodels",
+            query_string="ending_before=pm_125&foo=bar",
+        )
+
+        assert seen == ["pm_126", "pm_125", "pm_124", "pm_123"]
+
     def test_class_method_two_pages(self, http_client_mock):
         http_client_mock.stub_request(
             "get",
@@ -547,6 +577,37 @@ class TestAutoPagingAsync:
             self.pageable_model_response(["pm_125", "pm_126"], True), "mykey"
         )
         lo._retrieve_params = {"foo": "bar", "ending_before": "pm_127"}
+
+        http_client_mock.stub_request(
+            "get",
+            path="/v1/pageablemodels",
+            query_string="ending_before=pm_125&foo=bar",
+            rbody=json.dumps(
+                self.pageable_model_response(["pm_123", "pm_124"], False)
+            ),
+        )
+
+        seen = [item["id"] async for item in lo.auto_paging_iter()]
+
+        http_client_mock.assert_requested(
+            "get",
+            path="/v1/pageablemodels",
+            query_string="ending_before=pm_125&foo=bar",
+        )
+
+        assert seen == ["pm_126", "pm_125", "pm_124", "pm_123"]
+
+    @pytest.mark.anyio
+    async def test_iter_reverse_none_starting_after(self, http_client_mock):
+        """Test that if `starting_after` is present in the retrieve params, but is
+        `None`, that reverse pagination still occurs as expected.
+        """
+        lo = stripe.ListObject.construct_from(
+            self.pageable_model_response(["pm_125", "pm_126"], True), "mykey"
+        )
+        lo._retrieve_params = {
+            "foo": "bar", "ending_before": "pm_127", "starting_after": None
+        }
 
         http_client_mock.stub_request(
             "get",


### PR DESCRIPTION
### Why?
This fixes the case where `starting_after` is present in `_retrieve_params` but is `None` so that the `auto_paging_iter` correctly paginates backwards.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- This fixes the case where `starting_after` is present in `_retrieve_params` but is `None` so that the `auto_paging_iter` correctly paginates backwards.
- adds tests to confirm this behavior

### See Also
closes #1562
