### PR TITLE
hardcode `RateLimitError`

### DIFF
--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -227,6 +227,7 @@ from stripe._error import PermissionError as PermissionError
 from stripe._error import (
     SignatureVerificationError as SignatureVerificationError,
 )
+from stripe._error import RateLimitError as RateLimitError
 
 # HttpClient
 from stripe._http_client import (
@@ -455,7 +456,6 @@ from stripe._error import (
     NonZeroBalanceError as NonZeroBalanceError,
     NotCancelableError as NotCancelableError,
     QuotaExceededError as QuotaExceededError,
-    RateLimitError as RateLimitError,
     RecipientNotNotifiableError as RecipientNotNotifiableError,
     TemporarySessionExpiredError as TemporarySessionExpiredError,
 )

--- a/stripe/_error.py
+++ b/stripe/_error.py
@@ -183,6 +183,10 @@ class SignatureVerificationError(StripeError):
         self.sig_header = sig_header
 
 
+class RateLimitError(StripeError):
+    pass
+
+
 # classDefinitions: The beginning of the section generated from our OpenAPI spec
 class AlreadyCanceledError(StripeError):
     pass
@@ -247,10 +251,6 @@ class NotCancelableError(StripeError):
 
 
 class QuotaExceededError(StripeError):
-    pass
-
-
-class RateLimitError(StripeError):
     pass
 
 


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

In https://github.com/stripe/stripe-python-next/pull/755 we removed the hardcoded `RateLimitError` because it was being supplied by the v2 spec now. That works fine as long as it's always present (since it's used for v1 endpoints too). But, we've since hidden the API that supplies that RateLimit error (`/v2/reporting/reporting_runs`) from the SDK, so tests are erroring because they can't import that error.

To fix, we'll stick with the hardocded error class and prevent it from being generated (when relevant).

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- move `RateLimitError` out of the codegen block (normally you shouldn't edit the codegen section, but it needs to be present and linting complains if it's redefined. It'll stop being generated when the v2 openapi pr lands).

### See Also
<!-- Include any links or additional information that help explain this change. -->
