### PR TITLE
Deprecate and move V1 services living directly under StripeClient

### DIFF
--- a/stripe/v2/billing/_meter_event_stream_service.py
+++ b/stripe/v2/billing/_meter_event_stream_service.py
@@ -10,7 +10,7 @@ class MeterEventStreamService(StripeService):
     class CreateParams(TypedDict):
         events: List["MeterEventStreamService.CreateParamsEvent"]
         """
-        List of meter events to include in the request.
+        List of meter events to include in the request. Supports up to 100 events per request.
         """
 
     class CreateParamsEvent(TypedDict):


### PR DESCRIPTION
### What?
We introduced V1 namespace to improve code organization in Stripe SDKs in our [last release.](https://github.com/stripe/stripe-python/releases/tag/v12.5.0) 

## Changelog
- ⚠️ Deprecated the V1 service accessors living directly under StripeClient(e.g. customers, products) as they were copied under the new V1 service in our [last release](https://github.com/stripe/stripe-python/releases/tag/v12.5.0). Service accessors living directly under StripeClient(e.g. customers, products) will be removed from StripeClient in a future release. E.g.
```diff
client = StripeClient("sk_test...")

# Accessing V1 Stripe services on a StripeClient should be through the V1 namespace
- client.customers.list() 
+ client.v1.customers.list()
```
Refer to the [migration guide](https://github.com/stripe/stripe-python/wiki/v1-namespace-in-StripeClient) for help upgrading. 