### PR TITLE
Add `StripeContext` object

### DIFF
--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -578,3 +578,5 @@ from stripe._webhook_endpoint_service import (
     WebhookEndpointService as WebhookEndpointService,
 )
 # The end of the section generated from our OpenAPI spec
+
+from stripe._stripe_context import StripeContext as StripeContext

--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -500,8 +500,8 @@ class _APIRequestor(object):
             headers["Stripe-Account"] = stripe_account
 
         stripe_context = options.get("stripe_context")
-        if stripe_context:
-            headers["Stripe-Context"] = stripe_context
+        if stripe_context and str(stripe_context):
+            headers["Stripe-Context"] = str(stripe_context)
 
         idempotency_key = options.get("idempotency_key")
         if idempotency_key:

--- a/stripe/_request_options.py
+++ b/stripe/_request_options.py
@@ -1,13 +1,16 @@
 from stripe._requestor_options import RequestorOptions
 from typing import Mapping, Optional, Dict, Tuple, Any
-from typing_extensions import NotRequired, TypedDict
+from typing_extensions import NotRequired, TypedDict, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stripe._stripe_context import StripeContext
 
 
 class RequestOptions(TypedDict):
     api_key: NotRequired["str|None"]
     stripe_version: NotRequired["str|None"]
     stripe_account: NotRequired["str|None"]
-    stripe_context: NotRequired["str|None"]
+    stripe_context: NotRequired["str|StripeContext|None"]
     max_network_retries: NotRequired["int|None"]
     idempotency_key: NotRequired["str|None"]
     content_type: NotRequired["str|None"]

--- a/stripe/_stripe_context.py
+++ b/stripe/_stripe_context.py
@@ -1,0 +1,76 @@
+from typing import List, Optional
+
+
+class StripeContext:
+    """
+    StripeContext represents a context path for Stripe API requests.
+
+    The context is used to access child accounts by adding segments,
+    or parent accounts by removing segments. This class provides an
+    immutable interface for manipulating context paths.
+    """
+
+    def __init__(self, segments: Optional[List[str]] = None) -> None:
+        """
+        Initialize a StripeContext with the given segments.
+
+        Args:
+            segments: List of context path segments. Defaults to empty list.
+        """
+        self._segments = segments[:] if segments else []
+
+    @classmethod
+    def parse(cls, context_string: str) -> "StripeContext":
+        """
+        Parse a context string into a StripeContext instance.
+
+        Args:
+            context_string: A string like "a/b/c" to be split on "/"
+
+        Returns:
+            A new StripeContext instance with the parsed segments
+        """
+        if not context_string:
+            return cls([])
+        return cls(context_string.split("/"))
+
+    def parent(self) -> "StripeContext":
+        """
+        Create a new StripeContext with the last segment removed.
+
+        Returns:
+            A new StripeContext instance with one fewer segment
+
+        Raises:
+            ValueError: If context has no segments to remove
+        """
+        if not self._segments:
+            raise ValueError("Cannot get parent of empty context")
+        return StripeContext(self._segments[:-1])
+
+    def child(self, segment: str) -> "StripeContext":
+        """
+        Create a new StripeContext with an additional segment appended.
+
+        Args:
+            segment: The segment to append to the context path
+
+        Returns:
+            A new StripeContext instance with the new segment added
+        """
+        return StripeContext(self._segments + [segment])
+
+    def __str__(self) -> str:
+        """
+        Convert the StripeContext to its string representation.
+
+        Returns:
+            A string with segments joined by "/"
+        """
+        return "/".join(self._segments)
+
+    def __repr__(self) -> str:
+        """
+        Return a string representation of the StripeContext for debugging.
+        """
+        return f"StripeContext({self._segments!r})"

--- a/stripe/v2/_event.py
+++ b/stripe/v2/_event.py
@@ -6,6 +6,7 @@ from typing import ClassVar, Optional
 from typing_extensions import Literal
 
 from stripe._stripe_object import StripeObject
+from stripe._stripe_context import StripeContext
 
 # This describes the common format for the pull payload of a V2 ThinEvent
 # more specific classes will add `data` and `fetch_related_objects()` as needed
@@ -121,7 +122,7 @@ class ThinEvent:
     """
     Time at which the object was created.
     """
-    context: Optional[str] = None
+    context: Optional[StripeContext] = None
     """
     [Optional] Authentication context needed to fetch the event or related object.
     """
@@ -141,7 +142,7 @@ class ThinEvent:
         self.type = parsed["type"]
         self.created = parsed["created"]
         self.livemode = parsed.get("livemode")
-        self.context = parsed.get("context")
+        self.context = StripeContext.parse(parsed["context"]) if "context" in parsed else None
         if parsed.get("related_object"):
             self.related_object = RelatedObject(parsed["related_object"])
         if parsed.get("reason"):

--- a/tests/test_stripe_context.py
+++ b/tests/test_stripe_context.py
@@ -1,0 +1,112 @@
+import pytest
+from stripe._api_requestor import _APIRequestor
+from stripe._stripe_context import StripeContext
+from stripe.v2._event import ThinEvent
+
+
+class TestStripeContext:
+    def test_init_empty(self):
+        context = StripeContext()
+        assert str(context) == ""
+
+    def test_init_with_segments(self):
+        context = StripeContext(["a", "b", "c"])
+        assert str(context) == "a/b/c"
+
+    def test_parse_empty_string(self):
+        context = StripeContext.parse("")
+        assert str(context) == ""
+
+    def test_parse_single_segment(self):
+        context = StripeContext.parse("a")
+        assert str(context) == "a"
+
+    def test_parse_multiple_segments(self):
+        context = StripeContext.parse("a/b/c")
+        assert str(context) == "a/b/c"
+
+    def test_child_returns_new_instance(self):
+        context = StripeContext.parse("a/b")
+        child_context = context.child("c")
+
+        assert str(context) == "a/b"  # Original unchanged
+        assert str(child_context) == "a/b/c"  # New instance with added segment
+
+    def test_parent_returns_new_instance(self):
+        context = StripeContext.parse("a/b/c")
+        parent_context = context.parent()
+
+        assert str(context) == "a/b/c"  # Original unchanged
+        assert (
+            str(parent_context) == "a/b"
+        )  # New instance with removed segment
+
+    def test_parent_of_empty_context_raises_error(self):
+        context = StripeContext()
+        with pytest.raises(
+            ValueError, match="Cannot get parent of empty context"
+        ):
+            context.parent()
+
+    def test_parent_of_single_segment_context(self):
+        context = StripeContext.parse("a")
+        parent_context = context.parent()
+        assert str(parent_context) == ""
+
+    def test_repr(self):
+        context = StripeContext(["a", "b"])
+        assert repr(context) == "StripeContext(['a', 'b'])"
+
+    def test_chaining_operations(self):
+        context = StripeContext.parse("a")
+        result = context.child("b").child("c").parent()
+        assert str(result) == "a/b"
+
+
+class TestStripeContextThinEvent:
+    def test_thin_event_with_no_context(self):
+        payload = '{"id": "evt_123", "type": "payment.created", "created": "2023-01-01", "livemode": false}'
+        event = ThinEvent(payload)
+
+        assert event.context is None
+
+    def test_thin_event_with_context_string(self):
+        payload = '{"id": "evt_123", "type": "payment.created", "created": "2023-01-01", "livemode": false, "context": "a/b/c"}'
+        event = ThinEvent(payload)
+
+        assert isinstance(event.context, StripeContext)
+        assert str(event.context) == "a/b/c"
+
+    def test_thin_event_with_empty_context_string(self):
+        payload = '{"id": "evt_123", "type": "payment.created", "created": "2023-01-01", "livemode": false, "context": ""}'
+        event = ThinEvent(payload)
+
+        assert isinstance(event.context, StripeContext)
+        assert str(event.context) == ""
+
+
+class TestHeaderConversion:
+    def test_strings_get_sent(self):
+        r = _APIRequestor()
+        result = r.request_headers(
+            "get", "V1", {"stripe_context": "ctx_123/acct_1234"}
+        )
+        assert result["Stripe-Context"] == "ctx_123/acct_1234"
+
+    def test_objects_are_converted(self):
+        r = _APIRequestor()
+        result = r.request_headers(
+            "get",
+            "V1",
+            {"stripe_context": StripeContext(["ctx_123", "acct_1234"])},
+        )
+        assert result["Stripe-Context"] == "ctx_123/acct_1234"
+
+    def test_empty_values_arent_sent(self):
+        r = _APIRequestor()
+        result = r.request_headers(
+            "get",
+            "V1",
+            {"stripe_context": StripeContext()},
+        )
+        assert "Stripe-Context" not in result


### PR DESCRIPTION
### Why?

As the `stripe-context` header is evolving, we want to give better tools for creating and managing contexts. This PR adds a new class, `StripeContext`. It can be used anywhere the context option is supplied and gets serialized to a string when making requests. It's also found on the `EventNotification.context` property.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- add `StripeContext` class
- allow it to be supplied for RequestOptions.context; serialize it into strings
- add tests

## Changelog

- Add the `StripeContext` class
- ⚠️ Change `EventNotification` (formerly known as `ThinEvent`)'s `context` property from `string` to `StripeContext`
