### PR TITLE
add support for v2 deleted objects (#1543)

### DIFF
--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -66,6 +66,10 @@ HttpVerb = Literal["get", "post", "delete"]
 _default_proxy: Optional[str] = None
 
 
+def is_v2_delete_resp(method: str, api_mode: ApiMode) -> bool:
+    return method == "delete" and api_mode == "V2"
+
+
 class _APIRequestor(object):
     _instance: ClassVar["_APIRequestor|None"] = None
 
@@ -201,6 +205,7 @@ class _APIRequestor(object):
             params=params,
             requestor=requestor,
             api_mode=api_mode,
+            is_v2_deleted_object=is_v2_delete_resp(method, api_mode),
         )
 
         return obj
@@ -234,6 +239,7 @@ class _APIRequestor(object):
             params=params,
             requestor=requestor,
             api_mode=api_mode,
+            is_v2_deleted_object=is_v2_delete_resp(method, api_mode),
         )
 
         return obj

--- a/stripe/v2/__init__.py
+++ b/stripe/v2/__init__.py
@@ -6,6 +6,7 @@ from stripe.v2._amount import Amount as Amount, AmountParam as AmountParam
 from stripe.v2 import billing as billing, core as core
 from stripe.v2._billing_service import BillingService as BillingService
 from stripe.v2._core_service import CoreService as CoreService
+from stripe.v2._deleted_object import DeletedObject as DeletedObject
 from stripe.v2._event import Event as Event
 from stripe.v2._event_destination import EventDestination as EventDestination
 # The end of the section generated from our OpenAPI spec

--- a/stripe/v2/_deleted_object.py
+++ b/stripe/v2/_deleted_object.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# File generated from our OpenAPI spec
+from stripe._stripe_object import StripeObject
+from typing import Optional
+
+
+class DeletedObject(StripeObject):
+    id: str
+    """
+    The ID of the object that's being deleted.
+    """
+    object: Optional[str]
+    """
+    String representing the object's type. Objects of the same type share the same value of the object field.
+    """

--- a/stripe/v2/core/_event_destination_service.py
+++ b/stripe/v2/core/_event_destination_service.py
@@ -3,10 +3,11 @@
 from stripe._request_options import RequestOptions
 from stripe._stripe_service import StripeService
 from stripe._util import sanitize_id
+from stripe.v2._deleted_object import DeletedObject
 from stripe.v2._event import Event
 from stripe.v2._event_destination import EventDestination
 from stripe.v2._list_object import ListObject
-from typing import Dict, List, Optional, cast
+from typing import Dict, List, cast
 from typing_extensions import Literal, NotRequired, TypedDict
 
 
@@ -124,7 +125,7 @@ class EventDestinationService(StripeService):
         """
         Additional fields to include in the response. Currently supports `webhook_endpoint.url`.
         """
-        metadata: NotRequired[Dict[str, Optional[str]]]
+        metadata: NotRequired[Dict[str, str]]
         """
         Metadata.
         """
@@ -226,12 +227,12 @@ class EventDestinationService(StripeService):
         id: str,
         params: "EventDestinationService.DeleteParams" = {},
         options: RequestOptions = {},
-    ) -> EventDestination:
+    ) -> DeletedObject:
         """
         Delete an event destination.
         """
         return cast(
-            EventDestination,
+            DeletedObject,
             self._request(
                 "delete",
                 "/v2/core/event_destinations/{id}".format(id=sanitize_id(id)),
@@ -246,12 +247,12 @@ class EventDestinationService(StripeService):
         id: str,
         params: "EventDestinationService.DeleteParams" = {},
         options: RequestOptions = {},
-    ) -> EventDestination:
+    ) -> DeletedObject:
         """
         Delete an event destination.
         """
         return cast(
-            EventDestination,
+            DeletedObject,
             await self._request_async(
                 "delete",
                 "/v2/core/event_destinations/{id}".format(id=sanitize_id(id)),


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

The typing of delete calls has always been a little confusing in V1: SDKs say they return an entire object (like a `Customer`) but with the `deleted` property set to `True`. That's true for some APIs but not for others. For consistency, we just always say you get a "real" object.

V2 APIs are more strict about the data they return: there's only ever `id` and `object`. To better represent this, we're now generating a `V2.DeletedObject` class that is returned from all v2 delete calls. This PR includes that generated class, but APIRequestor-related code to use it when appropreate.

> Note: this PR is generated using the V2 OpenAPI spec rather than the protos so that the `DeletedObject` class is generated. 

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- add param to `_convert_to_stripe_object`
- provide that param from the API requestor
- add tests

### See Also
<!-- Include any links or additional information that help explain this change. -->

[DEVSDK-2588](https://go/j/DEVSDK-2588)