### PR TITLE
Ignore E203 in master .flake8 as well

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,6 +4,9 @@ extend-ignore =
     # code formatting. Ruff makes a best effort to keep lines under the max
     # length, but can go over in some cases.
     E501,
+    # E203 checks that `:` is not preceded by whitespace, but in some cases,
+    # formatting adds the whitespace. We let formatting be the source of truth in that case.
+    E203,
     # flake8 runs all installed rules, but we only want a single B (see below) so we disable the rest
     B
 extend-select =


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We ignore E203 in all variants except master atm. Unify the change.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

### See Also
<!-- Include any links or additional information that help explain this change. -->
