### PR TITLE
drop support for python 3.6 and clarify version policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         python_version:
+          # https://endoflife.date/python
           - "3.7"
           - "3.8"
           - "3.9"
@@ -87,6 +88,7 @@ jobs:
           - "pypy-3.8"
           - "pypy-3.9"
           - "pypy-3.10"
+          - "pypy-3.11"
     name: Test (${{ matrix.python_version }})
     steps:
       - uses: extractions/setup-just@v2

--- a/README.md
+++ b/README.md
@@ -9,20 +9,19 @@ classes for API resources that initialize themselves dynamically from API
 responses which makes it compatible with a wide range of versions of the Stripe
 API.
 
-## Documentation
+## API Documentation
 
 See the [Python API docs](https://stripe.com/docs/api?lang=python).
 
 ## Installation
 
-You don't need this source code unless you want to modify the package. If you just
-want to use the package, just run:
+This package is available on PyPI:
 
 ```sh
 pip install --upgrade stripe
 ```
 
-Install from source with:
+Alternatively, install from source with:
 
 ```sh
 python -m pip install .
@@ -30,7 +29,21 @@ python -m pip install .
 
 ### Requirements
 
--   Python 3.6+ (PyPy supported)
+Per our [Language Version Support Policy](TKTK), we currently support **Python 3.7+**.
+
+We drop support for end-of-life Python versions once they've been out of support for a year. We'll only drop support for Python versions in scheduled major releases (March & September, as outlined in the [Stripe API Versioning and Support Policy](https://docs.stripe.com/sdks/versioning)).
+
+#### Upcoming Deprecations
+
+| Python Version | [End of Life Date](https://endoflife.date/python) | Release when stripe-python drops support | Last stripe-python version to support this Python verison | Notes                                                                          |
+| -------------- | ------------------------------------------------- | ---------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| 3.7            | June 2023                                         | March 2026                               | TBD                                                       | This is a longer-than-normal window while we transition into this new schedule |
+| 3.8            | October 2024                                      | March 2026                               | TBD                                                       |                                                                                |
+| 3.9            | October 2025                                      | March 2027                               | TBD                                                       |                                                                                |
+
+And so forth.
+
+#### Extended Support
 
 #### Python 2.7 deprecation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ description = "Python bindings for the Stripe API"
 authors = [{ name = "Stripe", email = "support@stripe.com" }]
 license-files = ["LICENSE"]
 keywords = ["stripe", "api", "payments"]
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 dependencies = [
   "typing_extensions <= 4.2.0, > 3.7.2; python_version < '3.7'",
   # The best typing support comes from 4.5.0+ but we can support down to
@@ -22,7 +22,6 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.6",
   "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We've got a new Python version support policy! add docs to that, plus 

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- update CI
- update docs to link to our version support policy & clarify supported versions
- bump `requires-python`

### See Also
<!-- Include any links or additional information that help explain this change. -->

- [DEVSDK-2772](https://go/j/DEVSDK-2772)

## Changelog

- ⚠️ Drop support for Python 3.6. Please upgrade to Python 3.7+ to use the latest version.
