### PR TITLE
Update param in deprecation docs link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       matrix:
         python_version:
           # The last ~5 versions, once we're on schedule
-          # https://docs.stripe.com/sdks/versioning?server=python#stripe-sdk-language-version-support-policy
+          # https://docs.stripe.com/sdks/versioning?lang=python#stripe-sdk-language-version-support-policy
           - "3.7"
           - "3.8"
           - "3.9"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This release changes the pinned API version to `2025-09-30.clover` and contains 
 * [#1569](https://github.com/stripe/stripe-python/pull/1569) Renamed Urllib2Client to UrllibClient
   - ⚠️ Rename `http_client.Urllib2Client` to `http_client.UrllibClient` as Python `urllib2` was renamed to `urllib` in Python 3.
 * [#1606](https://github.com/stripe/stripe-python/pull/1606) ⚠️ drop support for Python 3.6 & clarify version policy
-  - Read our new [language version support policy](https://docs.stripe.com/sdks/versioning?server=python#stripe-sdk-language-version-support-policy)
+  - Read our new [language version support policy](https://docs.stripe.com/sdks/versioning?lang=python#stripe-sdk-language-version-support-policy)
       - ⚠️ In this release, we drop support for Python 3.6
       - Support for Python 3.7 is deprecated and will be removed in the next scheduled major release (March 2026)
 * [#1596](https://github.com/stripe/stripe-python/pull/1596) ⚠️ Unify resource and service method parameters into one class

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ python -m pip install .
 
 ### Requirements
 
-Per our [Language Version Support Policy](https://docs.stripe.com/sdks/versioning?server=python#stripe-sdk-language-version-support-policy), we currently support **Python 3.7+**.
+Per our [Language Version Support Policy](https://docs.stripe.com/sdks/versioning?lang=python#stripe-sdk-language-version-support-policy), we currently support **Python 3.7+**.
 
-Support for Python 3.7 and 3.8 is deprecated and will be removed in an upcoming major version. Read more and see the full schedule in the docs: https://docs.stripe.com/sdks/versioning?server=python#stripe-sdk-language-version-support-policy
+Support for Python 3.7 and 3.8 is deprecated and will be removed in an upcoming major version. Read more and see the full schedule in the docs: https://docs.stripe.com/sdks/versioning?lang=python#stripe-sdk-language-version-support-policy
 
 #### Extended Support
 


### PR DESCRIPTION
### Why?

We're using a different `pref` name in the docs for the version deprecation policy, so these links need to be updated.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- replace `?server=` with `?lang=` in links
