### PR TITLE
Re-add `tests` to our `sdist`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ documentation = "https://stripe.com/docs/api/?lang=python"
 requires = ["flit_core >=3.11, <4"]
 build-backend = "flit_core.buildapi"
 
+[tool.flit.sdist]
+include = ["tests/", "justfile", "examples/", "CHANGELOG.md"]
+
 [tool.ruff]
 # same as our black config
 line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ requires = ["flit_core >=3.11, <4"]
 build-backend = "flit_core.buildapi"
 
 [tool.flit.sdist]
-include = ["tests/", "justfile", "examples/", "CHANGELOG.md"]
+include = ["tests/", "justfile", "examples/", "CHANGELOG.md", "deps/"]
 
 [tool.ruff]
 # same as our black config


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

In https://github.com/stripe/stripe-python/pull/1572, I slimmed down what we include in our `sdist` (aka Standard Distribution). In https://github.com/stripe/stripe-python/issues/1616, a user flagged that we should continue including tests & other supporting files. This PR re-adds them. 

I've confirmed locally that we're now shipping all the folders we included in the 12.5.1 release.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- add tests to the stddist section in `pyproject.toml`

### See Also
<!-- Include any links or additional information that help explain this change. -->
