### PR TITLE
remove gpg step from publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,30 +125,19 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Configure GPG Key
-        run: |
-          set -ex
-          echo $GPG_SIGNING_PRIVKEY | base64 --decode | gpg --import --batch --yes --pinentry-mode loopback --passphrase "$GPG_SIGNING_PASSPHRASE"
-        env:
-          GPG_SIGNING_PRIVKEY: ${{ secrets.GPG_SIGNING_PRIVKEY }}
-          GPG_SIGNING_PASSPHRASE: ${{ secrets.GPG_SIGNING_PASSPHRASE }}
       - name: Install tools
         run: just install-build-deps
+
       - name: Publish packages to PyPI
         # could probably move this into a just recipe too?
         run: |
           set -ex
           source .venv/bin/activate
-          export VERSION=$(cat VERSION)
-          gpg --detach-sign --local-user $GPG_SIGNING_KEYID  --pinentry-mode loopback --passphrase $GPG_SIGNING_PASSPHRASE -a dist/stripe-$VERSION.tar.gz
-          gpg --detach-sign --local-user $GPG_SIGNING_KEYID  --pinentry-mode loopback --passphrase $GPG_SIGNING_PASSPHRASE -a dist/stripe-$VERSION-py3-none-any.whl
 
-          python -m twine upload --verbose dist/stripe-$VERSION.tar.gz  dist/stripe-$VERSION-py3-none-any.whl dist/stripe-$VERSION.tar.gz.asc dist/stripe-$VERSION-py3-none-any.whl.asc
+          python -m twine upload --verbose dist/*
         env:
-          GPG_SIGNING_KEYID: ${{ secrets.GPG_SIGNING_KEYID }}
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          GPG_SIGNING_PASSPHRASE: ${{ secrets.GPG_SIGNING_PASSPHRASE }}
       - uses: stripe/openapi/actions/notify-release@master
         if: always()
         with:


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

PyPI hasn't supported the checking or verifying of PGP signatures since 2023. In the interest of simplifying our publish process, we can go ahead and remove it and all of its secrets from our CI

more context: https://blog.pypi.org/posts/2023-05-23-removing-pgp/

`twine upload dist/*` is the recommended way to use the package ([source](https://twine.readthedocs.io/en/stable/#using-twine)). And, `just build` does `rm -rf` first, so we'll only be uploading things we just built.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- remove GPG steps from CI
- simplify twine upload command

### See Also
<!-- Include any links or additional information that help explain this change. -->
