### PR TITLE
add httpx to optional deps and only ship tests in sdist

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ The default HTTP client uses `requests` for making synchronous requests but
 you to explicitly initialize your own http client and pass it to StripeClient
 or set it as the global default.
 
+If you don't already have a dependency on an async-compatible HTTP library, `pip install stripe[async]` will install one for you (new in `v13.0.1`).
+
 ```python
 # By default, an explicitly initialized HTTPXClient will raise an exception if you
 # attempt to call a sync method. If you intend to only use async, this is useful to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,18 +7,6 @@ authors = [{ name = "Stripe", email = "support@stripe.com" }]
 license-files = ["LICENSE"]
 keywords = ["stripe", "api", "payments"]
 requires-python = ">=3.7"
-dependencies = [
-  "typing_extensions <= 4.2.0, > 3.7.2; python_version < '3.7'",
-  # The best typing support comes from 4.5.0+ but we can support down to
-  # 3.7.2 without throwing exceptions.
-  "typing_extensions >= 4.5.0; python_version >= '3.7'",
-  "requests >= 2.20; python_version >= '3.0'",
-]
-
-[project.optional-dependencies]
-# `pip install stripe[async]` gets you everything + `httpx`, so our async stuff works out of the box
-async = ["httpx"]
-
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
@@ -37,6 +25,18 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
+
+dependencies = [
+  "typing_extensions <= 4.2.0, > 3.7.2; python_version < '3.7'",
+  # The best typing support comes from 4.5.0+ but we can support down to
+  # 3.7.2 without throwing exceptions.
+  "typing_extensions >= 4.5.0; python_version >= '3.7'",
+  "requests >= 2.20; python_version >= '3.0'",
+]
+
+[project.optional-dependencies]
+# `pip install stripe[async]` gets you everything + `httpx`, so our async stuff works out of the box
+async = ["httpx"]
 
 [project.urls]
 homepage = "https://stripe.com/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,11 @@ dependencies = [
   "typing_extensions >= 4.5.0; python_version >= '3.7'",
   "requests >= 2.20; python_version >= '3.0'",
 ]
+
+[project.optional-dependencies]
+# `pip install stripe[async]` gets you everything + `httpx`, so our async stuff works out of the box
+async = ["httpx"]
+
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
@@ -45,7 +50,8 @@ requires = ["flit_core >=3.11, <4"]
 build-backend = "flit_core.buildapi"
 
 [tool.flit.sdist]
-include = ["tests/", "justfile", "examples/", "CHANGELOG.md", "deps/"]
+# see: https://github.com/stripe/stripe-python/issues/1616
+include = ["tests/"]
 
 [tool.ruff]
 # same as our black config


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

This is two small changes in 1 PR:

- walk back some changes from https://github.com/stripe/stripe-python/pull/1627 that haven't shipped yet to ship only what people need
- a fix for https://github.com/stripe/stripe-python/issues/1558. Users will be able to `pip install stripe[async]` and they'll get everything they need for async requests.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- added optional dependency group to `pyproject.toml`
- remove everything but `tests` from our sdist

### See Also
<!-- Include any links or additional information that help explain this change. -->

## Changelog

- Add new `async` optional dependency. Now, `pip install stripe[async]` gets you everything you need to make async HTTP calls out of the box.