### PR TITLE
throw more specific error when accessing `Invoice.payment_intent`

### DIFF
--- a/stripe/_stripe_object.py
+++ b/stripe/_stripe_object.py
@@ -216,6 +216,15 @@ class StripeObject(Dict[str, Any]):
                     % (k, k, ", ".join(list(self.keys())))
                 )
             else:
+                from stripe._invoice import Invoice
+
+                # super specific one-off case to help users debug this property disappearing
+                # see also: https://go/j/DEVSDK-2835
+                if isinstance(self, Invoice) and k == "payment_intent":
+                    raise KeyError(
+                        "The 'payment_intent' attribute is no longer available on Invoice objects. See the docs for more details: https://docs.stripe.com/changelog/basil/2025-03-31/add-support-for-multiple-partial-payments-on-invoices#why-is-this-a-breaking-change"
+                    )
+
                 raise err
 
     def __delitem__(self, k: str) -> None:


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

After upgrading to API version [2025-03-31.basil](https://docs.stripe.com/changelog/basil#2025-03-31.basil), users have had a lot of trouble with `Invoice.payment_intent` disappearing. To make matters worse, the changelog isn't super descriptive, so it's hard to know how to find more information about this change.

To help, we're adding a one-off error message to point them at the docs to help ease their migration.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- add more specific error when accessing a specific property
- add tests

### See Also
<!-- Include any links or additional information that help explain this change. -->

[DEVSDK-2835](https://go/j/DEVSDK-2835)

## Changelog
* Throw a specific error when accessing `payment_intent` property on `Invoice` object to ease debugging. 