### PR TITLE
Do not apply a mark to async_http_client fixture

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -335,7 +335,6 @@ class TestIntegration(object):
         usage = telemetry["last_request_metrics"]["usage"]
         assert usage == ["stripe_client", "async"]
 
-    @pytest.mark.anyio
     @pytest.fixture(params=["aiohttp", "httpx"])
     async def async_http_client(self, request, anyio_backend):
         if request.param == "httpx":


### PR DESCRIPTION
### Why?

Applying marks to a pytest fixture has never actually worked, it has just been a no-op. Starting with pytest 9, it now raises an error to fix code that does so. Remove the mark.

### What?

Removing a mark that had no effect.

### See Also

https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
