### PR TITLE
Add explicit permissions to GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,14 @@ on:
       - sdk-release/**
       - feature/**
 
+permissions: {}
+
 jobs:
   lint:
     name: Static Checks
     runs-on: "ubuntu-24.04"
+    permissions:
+      contents: read
     steps:
       - uses: extractions/setup-just@v2
       - uses: actions/checkout@v3
@@ -49,6 +53,8 @@ jobs:
   build:
     name: Build
     runs-on: "ubuntu-24.04"
+    permissions:
+      contents: read
     steps:
       - uses: extractions/setup-just@v2
       - uses: actions/checkout@v3
@@ -73,6 +79,8 @@ jobs:
     # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877 for list of supported versions
     # move to ubuntu-latest when we drop 3.7
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -113,6 +121,8 @@ jobs:
       endsWith(github.actor, '-stripe')
     needs: [build, test, lint]
     runs-on: "ubuntu-24.04"
+    permissions:
+      contents: read
     steps:
       - uses: extractions/setup-just@v2
       - uses: actions/checkout@v3

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -7,6 +7,8 @@ on:
     types:
       - auto_merge_enabled
 
+permissions: {}
+
 jobs:
   require_merge_commit_on_merge_script_pr:
     name: Merge script PRs must create merge commits


### PR DESCRIPTION
### Why?
Fix code scanning alerts about unlimited permissions in GitHub workflows. By default, workflows have read/write access to all scopes, which is a security concern. This change applies the principle of least privilege.

### What?
- Added `permissions: {}` at workflow level to restrict default permissions
- Added `contents: read` permission to each job that needs repository access
- The `rules` workflow gets empty permissions as it only runs shell scripts

### See Also
- [GitHub docs on workflow permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)