### PR TITLE
Added instruction to update CA certificates in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,12 @@ just format
 # or: venv/bin/ruff format . --quiet
 ```
 
+Update bundled CA certificates from the [Mozilla cURL release][curl]:
+
+```sh
+just update-certs
+```
+
 [api-keys]: https://dashboard.stripe.com/account/apikeys
 [ruff]: https://github.com/astral-sh/ruff
 [connect]: https://stripe.com/connect


### PR DESCRIPTION
### Why?
We have the instruction to quickly update ca-certs in our PHP and Ruby SDK. Adding this to the python readme to bring it to parity with the other SDKs. 

### What?
* Added instruction to update CA certificates in the development section of the README. 

### See Also
<!-- Include any links or additional information that help explain this change. -->
