### PR TITLE
Allow AIOHTTPClient to accept user-provided session or connector (#1736)

### DIFF
--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -1417,17 +1417,17 @@ class AIOHTTPClient(HTTPClient):
         self._timeout = timeout
         self._user_session = session
         self._user_connector = connector
-        self._owns_session = session is None
+        self._internally_managed_session = session is None
         self._cached_session = None
 
     @property
     def _session(self):
         if self._cached_session is None:
-            if self._user_session is not None:
+            if self._user_session:
                 self._cached_session = self._user_session
             else:
                 kwargs = {}
-                if self._user_connector is not None:
+                if self._user_connector:
                     kwargs["connector"] = self._user_connector
                 elif self._verify_ssl_certs:
                     ssl_context = ssl.create_default_context(
@@ -1524,7 +1524,7 @@ class AIOHTTPClient(HTTPClient):
         pass
 
     async def close_async(self):
-        if self._owns_session:
+        if self._internally_managed_session:
             await self._session.close()
 
 


### PR DESCRIPTION
### Why?

Currently, AIOHTTPClient always creates its own `aiohttp.ClientSession` and TCPConnector internally, with no way for users to customize them. This means users cannot:

  - Share a connection pool across multiple clients (e.g., Stripe + other services)
  - Tune connection pool settings like `limit`, `limit_per_host`, or `keepalive_timeout`
  - Provide a custom TCPConnector with their own SSL context or DNS caching configuration

The only workaround is setting the private _cached_session attribute after construction, which is an unstable interface.

`RequestsClient` already accepts an optional session parameter in its constructor (line 585), so there is existing precedent for this pattern. The need is stronger for `AIOHTTPClient` because async usage inherently involves concurrent requests, making connection pool sharing and tuning a common requirement for people using this client.

### What?

  - Added optional session and connector parameters to AIOHTTPClient.__init__
  - When session is provided, it is used directly as the underlying client session
  - When connector is provided, AIOHTTPClient creates a ClientSession using the user's connector (the SDK still controls the session itself)
  - When neither is provided, behavior is identical to before (creates its own connector with Stripe's CA bundle and a new session)
  - Added `_owns_session` tracking so that `close_async()` only closes the session if AIOHTTPClient created it. This avoids destroying a shared session that the user manages themselves (an improvement over `RequestsClient.close()`, which
  unconditionally closes even user-provided sessions)
  - This is a backward-compatible change: both new parameters default to None, preserving existing behavior for all current users

### See Also
 - #1736