### PR TITLE
Add more codex keys to agent detection

### DIFF
--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -471,13 +471,18 @@ class _APIRequestor(object):
         return None
 
     AI_AGENTS = [
+        # aiAgents: The beginning of the section generated from our OpenAPI spec
         ("ANTIGRAVITY_CLI_ALIAS", "antigravity"),
         ("CLAUDECODE", "claude_code"),
         ("CLINE_ACTIVE", "cline"),
         ("CODEX_SANDBOX", "codex_cli"),
+        ("CODEX_THREAD_ID", "codex_cli"),
+        ("CODEX_SANDBOX_NETWORK_DISABLED", "codex_cli"),
+        ("CODEX_CI", "codex_cli"),
         ("CURSOR_AGENT", "cursor"),
         ("GEMINI_CLI", "gemini_cli"),
         ("OPENCODE", "open_code"),
+        # aiAgents: The end of the section generated from our OpenAPI spec
     ]
 
     @staticmethod


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Small follow up to my PR from earlier this week that added agent information to the `User-Agent` header. It adds a couple of more vars to check.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- makes the user-agent list generated instead of hardcoded
- adds some new codex-specific env vars to check

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2249](https://go/j/RUN_DEVSDK-2249)
