### PR TITLE
Tweak telemetry collection

### DIFF
--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -5,6 +5,7 @@ import platform
 from typing import (
     Any,
     AsyncIterable,
+    Callable,
     Dict,
     List,
     Mapping,
@@ -509,14 +510,14 @@ class _APIRequestor(object):
         ua: Dict[str, Union[str, "AppInfo"]] = {
             "bindings_version": VERSION,
             "lang": "python",
-            "publisher": "stripe",
             "httplib": self._get_http_client().name,
         }
-        for attr, func in [
-            ["lang_version", platform.python_version],
-            ["platform", platform.platform],
-            ["uname", lambda: " ".join(platform.uname())],
-        ]:
+        attr_funcs: List[Tuple[str, Callable[[], str]]] = [
+            ("lang_version", platform.python_version),
+        ]
+        if stripe.enable_telemetry:
+            attr_funcs.append(("platform", platform.platform))
+        for attr, func in attr_funcs:
             try:
                 val = func()
             except Exception:

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -756,6 +756,7 @@ class TestAPIRequestor(object):
 
         mocker.patch("platform.platform", side_effect=fail)
 
+        stripe.enable_telemetry = True
         requestor.request("get", self.v1_path, {}, {}, base_address="api")
 
         last_call = http_client_mock.get_last_call()
@@ -765,6 +766,26 @@ class TestAPIRequestor(object):
                 "platform"
             ]
             == "(disabled)"
+        )
+
+    def test_platform_only_used_with_telemetry(
+        self, requestor, mocker, http_client_mock
+    ):
+        http_client_mock.stub_request(
+            "get", path=self.v1_path, rbody="{}", rcode=200
+        )
+
+        def fail():
+            raise RuntimeError
+
+        mocker.patch("platform.platform", side_effect=fail)
+
+        requestor.request("get", self.v1_path, {}, {}, base_address="api")
+
+        last_call = http_client_mock.get_last_call()
+        last_call.assert_method("get")
+        assert "platform" not in json.loads(
+            last_call.get_raw_header("X-Stripe-Client-User-Agent")
         )
 
     def test_uses_given_idempotency_key(self, requestor, http_client_mock):


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We've long collected detailed platform information about calls made using the SDK. But a user brought to our attention that we're probably collecting more than we need. To fix, we're no longer sending the full `uname` output and only collecting data we actually care about. Additionally, users can opt out of sending platform information using the existing telemetry opt-out methods.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- remove unused `publisher` User-Agent key
- condense important data from `uname` into the `platform` key
- tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [stripe/stripe-php#2015](https://github.com/stripe/stripe-php/issues/2015)
- [doc](https://docs.google.com/document/d/13fq-DtC_6WTfMyyI8b-Gq6jensyECa5K0X3WPL9fZJU/edit?tab=t.0)
- [RUN_DEVSDK-2244](https://go/j/RUN_DEVSDK-2244)
