### PR TITLE
remove unnecessary cast

### DIFF
--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -678,9 +678,7 @@ class RequestsClient(HTTPClient):
                 ).request(
                     method,
                     url,
-                    headers=cast(
-                        "MutableMapping[str, str | bytes] | None", headers
-                    ),  # https://jira.corp.stripe.com/browse/RUN_DEVSDK-2417
+                    headers=headers,
                     data=post_data,
                     timeout=self._timeout,
                     **kwargs,


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

In https://github.com/stripe/stripe-python/pull/1807/changes/93e508802fd38fdd4b4d45e657ad34435911be5c, we added a cast to work around an upstream type issue in `requests == 2.34.1` that was failing our CI. This has since been fixed, so we can remove the cast.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- remove typecast on `headers` in _http_client

### See Also
<!-- Include any links or additional information that help explain this change. -->

[RUN_DEVSDK-2417](https://go/j/RUN_DEVSDK-2417)