### PR TITLE
Emit warning when `stripe-notify` header is present in response

### DIFF
--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -73,7 +73,8 @@ _default_proxy: Optional[str] = None
 
 
 def _maybe_emit_stripe_notice(rheaders: Mapping[str, str]) -> None:
-    if notice := rheaders.get("Stripe-Notice"):
+    notice = rheaders.get("Stripe-Notice")
+    if notice:
         import warnings
 
         warnings.warn(notice)

--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -72,6 +72,13 @@ HttpVerb = Literal["get", "post", "delete"]
 _default_proxy: Optional[str] = None
 
 
+def _maybe_emit_stripe_notice(rheaders: Mapping[str, str]) -> None:
+    if notice := rheaders.get("Stripe-Notice"):
+        import warnings
+
+        warnings.warn(notice)
+
+
 def is_v2_delete_resp(method: str, api_mode: ApiMode) -> bool:
     return method == "delete" and api_mode == "V2"
 
@@ -209,6 +216,7 @@ class _APIRequestor(object):
             options=options,
             usage=usage,
         )
+        _maybe_emit_stripe_notice(rheaders)
         resp = requestor._interpret_response(rbody, rcode, rheaders, api_mode)
 
         obj = _convert_to_stripe_object(
@@ -243,6 +251,7 @@ class _APIRequestor(object):
             options=options,
             usage=usage,
         )
+        _maybe_emit_stripe_notice(rheaders)
         resp = requestor._interpret_response(rbody, rcode, rheaders, api_mode)
 
         obj = _convert_to_stripe_object(

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -1015,6 +1015,72 @@ class TestAPIRequestor(object):
                 "get", self.v1_path, {}, base_address="api"
             )
 
+    def test_stripe_notice_header_emits_warning(
+        self, requestor, http_client_mock
+    ):
+        http_client_mock.stub_request(
+            "get",
+            path=self.v1_path,
+            rbody="{}",
+            rcode=200,
+            rheaders={"Stripe-Notice": "test notice value"},
+        )
+
+        with pytest.warns(UserWarning, match="test notice value"):
+            requestor.request("get", self.v1_path, {}, base_address="api")
+
+    @pytest.mark.anyio
+    async def test_stripe_notice_header_emits_warning_async(
+        self, requestor, http_client_mock
+    ):
+        http_client_mock.stub_request(
+            "get",
+            path=self.v1_path,
+            rbody="{}",
+            rcode=200,
+            rheaders={"Stripe-Notice": "test notice value"},
+        )
+
+        with pytest.warns(UserWarning, match="test notice value"):
+            await requestor.request_async(
+                "get", self.v1_path, {}, base_address="api"
+            )
+
+    def test_no_stripe_notice_header_emits_no_warning(
+        self, requestor, http_client_mock
+    ):
+        import warnings
+
+        http_client_mock.stub_request(
+            "get",
+            path=self.v1_path,
+            rbody="{}",
+            rcode=200,
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            requestor.request("get", self.v1_path, {}, base_address="api")
+
+    @pytest.mark.anyio
+    async def test_no_stripe_notice_header_emits_no_warning_async(
+        self, requestor, http_client_mock
+    ):
+        import warnings
+
+        http_client_mock.stub_request(
+            "get",
+            path=self.v1_path,
+            rbody="{}",
+            rcode=200,
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            await requestor.request_async(
+                "get", self.v1_path, {}, base_address="api"
+            )
+
     def test_raw_request_with_file_param(self, requestor, http_client_mock):
         test_file = tempfile.NamedTemporaryFile()
         test_file.write("\u263a".encode("utf-16"))


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We've noticed a trend where users (and their agents) will sometimes reach for suboptimal API endpoints/methods because of outdated information. For example, using `/v1/accounts` when `/v2/core/accounts` is available and has a superset of the functionality from v1.

In an effort to help steer users towards best practices, we're introducing a new header to provide feedback during the development process. The SDK is responsible for surfacing this header, if present.

Once enabled internally, the header will be returned by the server for:

- all testmode calls
- livemode calls made by an agent

We may tweak that going forwards. But no matter the conditions, the SDKs will act as a thin pipe.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- Emit warning when we see the `Stripe-Notice` header in a response
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- https://go/agent-steering
- [DEVSDK-2430](https://go/j/browse/DEVSDK-2430)
