### PR TITLE
fix: encode empty list/tuple as (key, '') to clear array fields

### DIFF
--- a/stripe/_encode.py
+++ b/stripe/_encode.py
@@ -158,6 +158,15 @@ def _api_encode(
         elif hasattr(value, "id"):
             yield (key, getattr(value, "id"))
         elif isinstance(value, list) or isinstance(value, tuple):
+            if not value:
+                # An empty list signals "clear this array field".  Stripe's
+                # form-encoded API interprets `key=` (empty string) as a
+                # request to remove all previously set values, matching the
+                # documented workaround of passing "" instead of [].
+                # Without this, an empty list is silently dropped and the
+                # field is left unchanged.
+                # See https://github.com/stripe/stripe-python/issues/802
+                yield (key, "")
             for i, sv in enumerate(value):
                 # Always use indexed format for arrays
                 encoded_key = "%s[%d]" % (key, i)

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -116,3 +116,27 @@ class TestApiEncode:
             ("items[1][0]", 3),
             ("items[1][1]", 4),
         ]
+
+    def test_encode_empty_list_yields_empty_string(self):
+        """An empty list must encode to (key, '') so the Stripe API clears the field.
+
+        Regression test for https://github.com/stripe/stripe-python/issues/802
+
+        Before this fix, _api_encode({"blocked_categories": []}) yielded
+        nothing — the field was silently omitted from the request and the Stripe
+        API left the previously-set values untouched.  The documented workaround
+        was to pass "" instead of [], which encodes to ("blocked_categories", "").
+        The fix makes an empty list behave identically to that workaround.
+        """
+        result = list(_api_encode({"blocked_categories": []}))
+        assert result == [("blocked_categories", "")], (
+            "Empty list should encode to (key, '') to clear the field; "
+            f"got {result!r} instead"
+        )
+
+    def test_encode_empty_tuple_yields_empty_string(self):
+        """An empty tuple must encode to (key, '') just like an empty list."""
+        result = list(_api_encode({"tags": ()}))
+        assert result == [("tags", "")], (
+            f"Empty tuple should encode to (key, ''); got {result!r}"
+        )


### PR DESCRIPTION
## Problem

Passing an empty `list` or `tuple` for an array field in a Stripe API update call silently does nothing — the field is omitted from the request body and the previously-set values remain unchanged.

**Reproduction:**
```python
stripe.issuing.Cardholder.modify(
    "ich_...",
    spending_controls={"blocked_categories": []},
)
# blocked_categories is NOT cleared — previous values remain.
```

The documented workaround is to pass `""` instead of `[]`:
```python
spending_controls={"blocked_categories": ""},  # works, but not obvious
```

This is because `_api_encode` iterates over the list with `enumerate`, and an empty list yields zero iterations — no key/value pair is emitted and the field disappears from the request.

Fixes #802.

## Fix

Before the indexed loop in `_api_encode`, detect an empty list/tuple and emit `(key, "")` — the same encoding produced by the `""` workaround — so the Stripe API receives an explicit signal to clear the field:

```python
elif isinstance(value, list) or isinstance(value, tuple):
    if not value:
        yield (key, "")   # <-- new: clear the array
    for i, sv in enumerate(value):
        ...
```

## Tests

Two new assertions in `tests/test_encode.py`:

| Test | Scenario |
|------|----------|
| `test_encode_empty_list_yields_empty_string` | `[]` → `[("blocked_categories", "")]` |
| `test_encode_empty_tuple_yields_empty_string` | `()` → `[("tags", "")]` |

Both pass; existing list-encoding tests are unchanged.