### PR TITLE
Fix V2 namespace singularization

### DIFF
--- a/stripe/_v2_services.py
+++ b/stripe/_v2_services.py
@@ -16,9 +16,9 @@ if TYPE_CHECKING:
     from stripe.v2._orchestrated_commerce_service import (
         OrchestratedCommerceService,
     )
-    from stripe.v2._payment_service import PaymentService
+    from stripe.v2._payments_service import PaymentsService
     from stripe.v2._reporting_service import ReportingService
-    from stripe.v2._signal_service import SignalService
+    from stripe.v2._signals_service import SignalsService
     from stripe.v2._tax_service import TaxService
     from stripe.v2._test_helper_service import TestHelperService
 
@@ -38,9 +38,9 @@ _subservices = {
         "stripe.v2._orchestrated_commerce_service",
         "OrchestratedCommerceService",
     ],
-    "payments": ["stripe.v2._payment_service", "PaymentService"],
+    "payments": ["stripe.v2._payments_service", "PaymentsService"],
     "reporting": ["stripe.v2._reporting_service", "ReportingService"],
-    "signals": ["stripe.v2._signal_service", "SignalService"],
+    "signals": ["stripe.v2._signals_service", "SignalsService"],
     "tax": ["stripe.v2._tax_service", "TaxService"],
     "test_helpers": ["stripe.v2._test_helper_service", "TestHelperService"],
 }
@@ -56,9 +56,9 @@ class V2Services(StripeService):
     money_management: "MoneyManagementService"
     network: "NetworkService"
     orchestrated_commerce: "OrchestratedCommerceService"
-    payments: "PaymentService"
+    payments: "PaymentsService"
     reporting: "ReportingService"
-    signals: "SignalService"
+    signals: "SignalsService"
     tax: "TaxService"
     test_helpers: "TestHelperService"
 

--- a/stripe/v2/__init__.py
+++ b/stripe/v2/__init__.py
@@ -43,11 +43,11 @@ if TYPE_CHECKING:
     from stripe.v2._orchestrated_commerce_service import (
         OrchestratedCommerceService as OrchestratedCommerceService,
     )
-    from stripe.v2._payment_service import PaymentService as PaymentService
+    from stripe.v2._payments_service import PaymentsService as PaymentsService
     from stripe.v2._reporting_service import (
         ReportingService as ReportingService,
     )
-    from stripe.v2._signal_service import SignalService as SignalService
+    from stripe.v2._signals_service import SignalsService as SignalsService
     from stripe.v2._tax_service import TaxService as TaxService
     from stripe.v2._test_helper_service import (
         TestHelperService as TestHelperService,
@@ -90,9 +90,9 @@ _import_map = {
         "stripe.v2._orchestrated_commerce_service",
         False,
     ),
-    "PaymentService": ("stripe.v2._payment_service", False),
+    "PaymentsService": ("stripe.v2._payments_service", False),
     "ReportingService": ("stripe.v2._reporting_service", False),
-    "SignalService": ("stripe.v2._signal_service", False),
+    "SignalsService": ("stripe.v2._signals_service", False),
     "TaxService": ("stripe.v2._tax_service", False),
     "TestHelperService": ("stripe.v2._test_helper_service", False),
 }

--- a/stripe/v2/_payments_service.py
+++ b/stripe/v2/_payments_service.py
@@ -24,7 +24,7 @@ _subservices = {
 }
 
 
-class PaymentService(StripeService):
+class PaymentsService(StripeService):
     off_session_payments: "OffSessionPaymentService"
     settlement_allocation_intents: "SettlementAllocationIntentService"
 

--- a/stripe/v2/_signals_service.py
+++ b/stripe/v2/_signals_service.py
@@ -15,7 +15,7 @@ _subservices = {
 }
 
 
-class SignalService(StripeService):
+class SignalsService(StripeService):
     account_signals: "AccountSignalService"
 
     def __init__(self, requestor):


### PR DESCRIPTION
### Why?

The codegen incorrectly singularized V2 namespace-promoted service names (`PaymentService` instead of `PaymentsService`). This was a latent bug that only manifested when new V2 namespaces were added.

### What?

- Renames `v2.PaymentService` to `v2.PaymentsService`

### See Also

## Changelog

- ⚠️ Renames `v2.PaymentService` to `v2.PaymentsService` to more closely match our API naming