### PR TITLE
Add "source" field to user-agent header

### DIFF
--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -1,7 +1,10 @@
 from io import BytesIO, IOBase
+import functools
+import hashlib
 import json
 import os
 import platform
+import socket
 from typing import (
     Any,
     AsyncIterable,
@@ -70,6 +73,19 @@ HttpVerb = Literal["get", "post", "delete"]
 
 # Lazily initialized
 _default_proxy: Optional[str] = None
+
+
+@functools.lru_cache(maxsize=None)
+def _get_uname_hash() -> Optional[str]:
+    try:
+        parts: List[str] = list(platform.uname())
+        try:
+            parts.append(socket.gethostname())
+        except Exception:
+            pass
+        return hashlib.md5(" ".join(parts).encode()).hexdigest()
+    except Exception:
+        return None
 
 
 def _maybe_emit_stripe_notice(rheaders: Mapping[str, str]) -> None:
@@ -525,6 +541,9 @@ class _APIRequestor(object):
             "lang": "python",
             "httplib": self._get_http_client().name,
         }
+        uname_hash = _get_uname_hash()
+        if uname_hash is not None:
+            ua["source"] = uname_hash
         attr_funcs: List[Tuple[str, Callable[[], str]]] = [
             ("lang_version", platform.python_version),
         ]

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import re
 import tempfile
 import uuid
 from collections import OrderedDict
@@ -787,6 +788,36 @@ class TestAPIRequestor(object):
         assert "platform" not in json.loads(
             last_call.get_raw_header("X-Stripe-Client-User-Agent")
         )
+
+    def test_source_field_is_md5_hex(self, requestor, http_client_mock):
+        http_client_mock.stub_request(
+            "get", path=self.v1_path, rbody="{}", rcode=200
+        )
+        requestor.request("get", self.v1_path, {}, base_address="api")
+
+        last_call = http_client_mock.get_last_call()
+        client_ua = json.loads(
+            last_call.get_raw_header("X-Stripe-Client-User-Agent")
+        )
+        assert "source" in client_ua
+        assert re.fullmatch(r"[0-9a-f]{32}", client_ua["source"])
+
+    def test_source_field_absent_when_uname_fails(
+        self, requestor, mocker, http_client_mock
+    ):
+        http_client_mock.stub_request(
+            "get", path=self.v1_path, rbody="{}", rcode=200
+        )
+        mocker.patch(
+            "stripe._api_requestor._get_uname_hash", return_value=None
+        )
+        requestor.request("get", self.v1_path, {}, base_address="api")
+
+        last_call = http_client_mock.get_last_call()
+        client_ua = json.loads(
+            last_call.get_raw_header("X-Stripe-Client-User-Agent")
+        )
+        assert "source" not in client_ua
 
     def test_uses_given_idempotency_key(self, requestor, http_client_mock):
         method = "post"


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Earlier this year, we removed the output of `uname` from the user-agent header for privacy reasons. It over-collected data we usually didn't need.

Since then, our tech support team has reached out asking us to re-add some of the information to help with complex debugging tasks: sometimes they need to help users identify exactly which machine produced an API call.

Rather than just revert the previous change and reintroduce the same privacy issues that caused its removal in the first place, we're taking a more privacy-focused approach. Rather than send all the PII in plaintext, we hash it first. This way it can still be used to confirm the source of an API call if a user generates the hashes themselves, but isn't sensitive in and of itself.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add `source` key to user-agent hash. It's contents are an md5 hash of `uname -a`
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [DEVSDK-3131](https://go/j/DEVSDK-3131)
