### PR TITLE
Upgrade CI runner from ubuntu-22.04 to ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,7 @@ jobs:
           path: dist/
 
   test:
-    # Specific ubuntu version to support python 3.7 testing
-    # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877 for list of supported versions
-    # move to ubuntu-latest when we drop 3.7
-    runs-on: ubuntu-22.04
+    runs-on: "ubuntu-24.04"
     permissions:
       contents: read
     strategy:


### PR DESCRIPTION
### Why?
ubuntu-22.04 is EOL next year and our more powerful runners are already on ubuntu-24.04.  this upgrades stripe-python to ubuntu-24.04 so we can stay ahead of the EOL and standardize on a single runner version

### What?
- `test` job: `ubuntu-22.04` → `ubuntu-24.04`, removed stale comment about python 3.7 (no longer in the test matrix)

### See Also
- DEVSDK-2337: https://go/j/DEVSDK-2337