### PR TITLE
Remove unused Retry-After header support

### DIFF
--- a/stripe/_http_client.py
+++ b/stripe/_http_client.py
@@ -85,7 +85,6 @@ class HTTPClient(object):
 
     MAX_DELAY = 5
     INITIAL_DELAY = 0.5
-    MAX_RETRY_AFTER = 60
     _proxy: Optional[_Proxy]
     _verify_ssl_certs: bool
 
@@ -162,23 +161,7 @@ class HTTPClient(object):
 
         return False
 
-    def _retry_after_header(
-        self, response: Optional[Tuple[Any, Any, Mapping[str, str]]] = None
-    ):
-        if response is None:
-            return None
-        _, _, rheaders = response
-
-        try:
-            return int(rheaders["retry-after"])
-        except (KeyError, ValueError):
-            return None
-
-    def _sleep_time_seconds(
-        self,
-        num_retries: int,
-        response: Optional[Tuple[Any, Any, Mapping[str, str]]] = None,
-    ) -> float:
+    def _sleep_time_seconds(self, num_retries: int) -> float:
         """
         Apply exponential backoff with initial_network_retry_delay on the number of num_retries so far as inputs.
         Do not allow the number to exceed `max_network_retry_delay`.
@@ -192,11 +175,6 @@ class HTTPClient(object):
 
         # But never sleep less than the base sleep seconds.
         sleep_seconds = max(HTTPClient.INITIAL_DELAY, sleep_seconds)
-
-        # And never sleep less than the time the API asks us to wait, assuming it's a reasonable ask.
-        retry_after = self._retry_after_header(response) or 0
-        if retry_after <= HTTPClient.MAX_RETRY_AFTER:
-            sleep_seconds = max(retry_after, sleep_seconds)
 
         return sleep_seconds
 
@@ -311,7 +289,7 @@ class HTTPClient(object):
                         % connection_error.user_message
                     )
                 num_retries += 1
-                sleep_time = self._sleep_time_seconds(num_retries, response)
+                sleep_time = self._sleep_time_seconds(num_retries)
                 _util.log_info(
                     (
                         "Initiating retry %i for request %s %s after "
@@ -469,7 +447,7 @@ class HTTPClient(object):
                         % connection_error.user_message
                     )
                 num_retries += 1
-                sleep_time = self._sleep_time_seconds(num_retries, response)
+                sleep_time = self._sleep_time_seconds(num_retries)
                 _util.log_info(
                     (
                         "Initiating retry %i for request %s %s after "

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -168,23 +168,6 @@ class TestRetrySleepTimeDefaultHttpClient:
         expected = [0.5, 1.0, 2.0, 4.0, max_delay, max_delay, max_delay]
         self.assert_sleep_times(client, expected)
 
-    def test_retry_after_header(self):
-        client = _http_client.new_default_http_client()
-        client._add_jitter_time = lambda sleep_seconds: sleep_seconds
-
-        # Prefer retry-after if it's bigger
-        assert 30 == client._sleep_time_seconds(
-            2, (None, 409, {"retry-after": "30"})
-        )
-        # Prefer default if it's bigger
-        assert 2 == client._sleep_time_seconds(
-            3, (None, 409, {"retry-after": "1"})
-        )
-        # Ignore crazy-big values
-        assert 1 == client._sleep_time_seconds(
-            2, (None, 409, {"retry-after": "300"})
-        )
-
     def test_randomness_added(self):
         client = _http_client.new_default_http_client()
         random_value = 0.8


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We confirmed in [RUN_API-26216](https://go/j/RUN_API-26216) that the Stripe API doesn't (and has not ever, as far as we can tell) sent `Retry-After` to external consumers.

This was one of the SDKs that included support for reading that header. Given that it's always a no-op, we can remove the dead code.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- remove the code that reads the `Retry-After` header and associated calculations
- remove related tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

[RUN_DEVSDK-2569](https://go/j/RUN_DEVSDK-2569)
