### PR TITLE
Make Error fields generated

### DIFF
--- a/stripe/_error_object.py
+++ b/stripe/_error_object.py
@@ -5,24 +5,85 @@ from stripe._stripe_object import StripeObject
 from stripe._api_mode import ApiMode
 
 if TYPE_CHECKING:
+    # errorImports: The beginning of the section generated from our OpenAPI spec
     from stripe._payment_intent import PaymentIntent
+    from stripe._payment_method import PaymentMethod
     from stripe._setup_intent import SetupIntent
     from stripe._source import Source
-    from stripe._payment_method import PaymentMethod
+    # errorImports: The end of the section generated from our OpenAPI spec
 
 
 class ErrorObject(StripeObject):
+    # errorAnnotations: The beginning of the section generated from our OpenAPI spec
+    advice_code: Optional[str]
+    """
+    For card errors resulting from a card issuer decline, a short string indicating [how to proceed with an error](https://docs.stripe.com/declines#retrying-issuer-declines) if they provide one.
+    """
     charge: Optional[str]
+    """
+    For card errors, the ID of the failed charge.
+    """
     code: Optional[str]
+    """
+    For some errors that could be handled programmatically, a short string indicating the [error code](https://docs.stripe.com/error-codes) reported.
+    """
     decline_code: Optional[str]
+    """
+    For card errors resulting from a card issuer decline, a short string indicating the [card issuer's reason for the decline](https://docs.stripe.com/declines#issuer-declines) if they provide one.
+    """
     doc_url: Optional[str]
+    """
+    A URL to more information about the [error code](https://docs.stripe.com/error-codes) reported.
+    """
     message: Optional[str]
+    """
+    A human-readable message providing more details about the error. For card errors, these messages can be shown to your users.
+    """
+    network_advice_code: Optional[str]
+    """
+    For card errors resulting from a card issuer decline, a 2 digit code which indicates the advice given to merchant by the card network on how to proceed with an error.
+    """
+    network_decline_code: Optional[str]
+    """
+    For payments declined by the network, an alphanumeric code which indicates the reason the payment failed.
+    """
     param: Optional[str]
+    """
+    If the error is parameter-specific, the parameter related to the error. For example, you can use this to display a message near the correct form field.
+    """
     payment_intent: Optional["PaymentIntent"]
+    """
+    The PaymentIntent object for errors returned on a request involving a PaymentIntent.
+    """
     payment_method: Optional["PaymentMethod"]
+    """
+    The PaymentMethod object for errors returned on a request involving a PaymentMethod.
+    """
+    payment_method_type: Optional[str]
+    """
+    If the error is specific to the type of payment method, the payment method type that had a problem. This field is only populated for invoice-related errors.
+    """
+    request_log_url: Optional[str]
+    """
+    A URL to the request log entry in your dashboard.
+    """
     setup_intent: Optional["SetupIntent"]
+    """
+    The SetupIntent object for errors returned on a request involving a SetupIntent.
+    """
     source: Optional["Source"]
+    """
+    The PaymentSource object for errors returned on a request involving a PaymentSource.
+    """
     type: str
+    """
+    The type of error returned. One of `api_error`, `card_error`, `idempotency_error`, or `invalid_request_error`
+    """
+    user_message: Optional[str]
+    """
+    The user message associated with the error.
+    """
+    # errorAnnotations: The end of the section generated from our OpenAPI spec
 
     def refresh_from(
         self,
@@ -63,17 +124,25 @@ class ErrorObject(StripeObject):
         # values here to facilitate generic error handling.
         values = merge_dicts(
             {
+                # errorDefaults: The beginning of the section generated from our OpenAPI spec
+                "advice_code": None,
                 "charge": None,
                 "code": None,
                 "decline_code": None,
                 "doc_url": None,
                 "message": None,
+                "network_advice_code": None,
+                "network_decline_code": None,
                 "param": None,
                 "payment_intent": None,
                 "payment_method": None,
+                "payment_method_type": None,
+                "request_log_url": None,
                 "setup_intent": None,
                 "source": None,
                 "type": None,
+                "user_message": None,
+                # errorDefaults: The end of the section generated from our OpenAPI spec
             },
             values,
         )

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -54,6 +54,38 @@ class TestStripeError(object):
         assert err.error.code == "some_error"
         assert err.error.charge is None
 
+    def test_error_object_network_advice_code(self):
+        err = StripeError(
+            "message",
+            json_body={
+                "error": {
+                    "type": "card_error",
+                    "network_advice_code": "02",
+                }
+            },
+        )
+        assert err.error is not None
+        assert err.error.network_advice_code == "02"
+
+    def test_error_object_payment_intent(self):
+        err = StripeError(
+            "message",
+            json_body={
+                "error": {
+                    "type": "card_error",
+                    "payment_intent": {
+                        "id": "pi_123",
+                        "object": "payment_intent",
+                        "amount": 1000,
+                    },
+                }
+            },
+        )
+        assert err.error is not None
+        assert err.error.payment_intent is not None
+        assert err.error.payment_intent.id == "pi_123"
+        assert err.error.payment_intent.amount == 1000
+
     def test_error_object_not_dict(self):
         err = StripeError("message", json_body={"error": "not a dict"})
         assert err.error is None


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Our main API Error class has always been handwritten. As new fields have been added to `api_errors` in the spec over time (e.g. `advice_code`, `network_advice_code`, `network_decline_code`), we haven't picked them up in the SDKs.

This makes most of those properties generated so they stay in sync.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- Makes the fields on the API error object generated from the OpenAPI spec
- Adds section markers so codegen can maintain these fields going forward
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2568](https://go/j/RUN_DEVSDK-2568)
- https://github.com/stripe/stripe-go/issues/2384
