### PR TITLE
Replace source hash with Telemetry UUID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,15 +73,19 @@ jobs:
           path: dist/
 
   test:
-    runs-on: "ubuntu-24.04"
+    name: Test (${{ matrix.python_version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - "ubuntu-24.04"
         python_version:
           # The last ~5 versions, once we're on schedule
           # https://docs.stripe.com/sdks/versioning?lang=python#stripe-sdk-language-version-support-policy
+          # https://endoflife.date/python
           - "3.9"
           - "3.10"
           - "3.11"
@@ -91,7 +95,10 @@ jobs:
           - "pypy-3.9"
           - "pypy-3.10"
           - "pypy-3.11"
-    name: Test (${{ matrix.python_version }})
+        include:
+          - os: windows-latest
+            # use any modern-ish version
+            python_version: "3.14"
     steps:
       - uses: extractions/setup-just@v2
       - uses: actions/checkout@v3

--- a/justfile
+++ b/justfile
@@ -3,8 +3,9 @@ set quiet
 import? '../sdk-codegen/utils.just'
 
 VENV_NAME := ".venv"
+VENV_BIN := if os() == "windows" { VENV_NAME / "Scripts" } else { VENV_NAME / "bin" }
 
-export PATH := `pwd` / VENV_NAME / "bin:" + env('PATH')
+export PATH := `pwd` / VENV_BIN + ":" + env('PATH')
 
 _default:
     just --list --unsorted
@@ -82,7 +83,7 @@ update-certs:
 venv:
     [ -d {{ VENV_NAME }} ] || ( \
         python -m venv {{ VENV_NAME }} && \
-        {{ VENV_NAME }}/bin/python -I -m pip install -e . --quiet --disable-pip-version-check \
+        {{ VENV_BIN }}/python -I -m pip install -e . --quiet --disable-pip-version-check \
     )
 
 # called by tooling

--- a/stripe/_api_requestor.py
+++ b/stripe/_api_requestor.py
@@ -1,10 +1,7 @@
 from io import BytesIO, IOBase
-import functools
-import hashlib
 import json
 import os
 import platform
-import socket
 from typing import (
     Any,
     AsyncIterable,
@@ -72,19 +69,6 @@ HttpVerb = Literal["get", "post", "delete"]
 
 # Lazily initialized
 _default_proxy: Optional[str] = None
-
-
-@functools.lru_cache(maxsize=None)
-def _get_uname_hash() -> Optional[str]:
-    try:
-        parts: List[str] = list(platform.uname())
-        try:
-            parts.append(socket.gethostname())
-        except Exception:
-            pass
-        return hashlib.md5(" ".join(parts).encode()).hexdigest()
-    except Exception:
-        return None
 
 
 def _maybe_emit_stripe_notice(rheaders: Mapping[str, str]) -> None:
@@ -545,9 +529,11 @@ class _APIRequestor(object):
             "lang": "python",
             "httplib": self._get_http_client().name,
         }
-        uname_hash = _get_uname_hash()
-        if uname_hash is not None:
-            ua["source"] = uname_hash
+        if stripe.enable_telemetry:
+            from stripe._telemetry_id import get_telemetry_id
+
+            if (telemetry_id := get_telemetry_id()) is not None:
+                ua["telemetry_id"] = telemetry_id
         attr_funcs: List[Tuple[str, Callable[[], str]]] = [
             ("lang_version", platform.python_version),
         ]

--- a/stripe/_telemetry_id.py
+++ b/stripe/_telemetry_id.py
@@ -22,28 +22,29 @@ def get_telemetry_id() -> Optional[str]:
     global _cached_id, _loaded
     if _loaded:
         return _cached_id
-    _loaded = True
-
-    config_dir = get_config_dir()
-    if config_dir is None:
-        return None
-
-    file_path = config_dir / "telemetry_id"
 
     try:
-        if content := file_path.read_text().strip():
-            _cached_id = content
-            return _cached_id
-    except OSError:
-        pass
+        if (config_dir := get_config_dir()) is None:
+            return None
 
-    new_id = secrets.token_hex(16)
+        file_path = config_dir / "telemetry_id"
 
-    try:
-        config_dir.mkdir(parents=True, exist_ok=True)
-        file_path.write_text(new_id)
-    except OSError:
-        return None
+        try:
+            if content := file_path.read_text().strip():
+                _cached_id = content
+                return _cached_id
+        except OSError:
+            pass
 
-    _cached_id = new_id
-    return _cached_id
+        new_id = secrets.token_hex(16)
+
+        try:
+            config_dir.mkdir(parents=True, exist_ok=True)
+            file_path.write_text(new_id)
+        except OSError:
+            return None
+
+        _cached_id = new_id
+        return _cached_id
+    finally:
+        _loaded = True

--- a/stripe/_telemetry_id.py
+++ b/stripe/_telemetry_id.py
@@ -1,0 +1,49 @@
+import os
+import secrets
+from pathlib import Path
+from typing import Optional
+
+_cached_id: Optional[str] = None
+_loaded: bool = False
+
+
+def get_config_dir() -> Optional[Path]:
+    if os.name == "nt":
+        if appdata := os.environ.get("APPDATA"):
+            return Path(appdata) / "Stripe"
+        # APPDATA is set system wide, so it would be very unusual to hit this
+        return None
+    if xdg := os.environ.get("XDG_CONFIG_HOME"):
+        return Path(xdg) / "stripe"
+    return Path.home() / ".config" / "stripe"
+
+
+def get_telemetry_id() -> Optional[str]:
+    global _cached_id, _loaded
+    if _loaded:
+        return _cached_id
+    _loaded = True
+
+    config_dir = get_config_dir()
+    if config_dir is None:
+        return None
+
+    file_path = config_dir / "telemetry_id"
+
+    try:
+        if content := file_path.read_text().strip():
+            _cached_id = content
+            return _cached_id
+    except OSError:
+        pass
+
+    new_id = secrets.token_hex(16)
+
+    try:
+        config_dir.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(new_id)
+    except OSError:
+        return None
+
+    _cached_id = new_id
+    return _cached_id

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -789,27 +789,16 @@ class TestAPIRequestor(object):
             last_call.get_raw_header("X-Stripe-Client-User-Agent")
         )
 
-    def test_source_field_is_md5_hex(self, requestor, http_client_mock):
-        http_client_mock.stub_request(
-            "get", path=self.v1_path, rbody="{}", rcode=200
-        )
-        requestor.request("get", self.v1_path, {}, base_address="api")
-
-        last_call = http_client_mock.get_last_call()
-        client_ua = json.loads(
-            last_call.get_raw_header("X-Stripe-Client-User-Agent")
-        )
-        assert "source" in client_ua
-        assert re.fullmatch(r"[0-9a-f]{32}", client_ua["source"])
-
-    def test_source_field_absent_when_uname_fails(
+    def test_telemetry_id_field_is_hex(
         self, requestor, mocker, http_client_mock
     ):
         http_client_mock.stub_request(
             "get", path=self.v1_path, rbody="{}", rcode=200
         )
+        mocker.patch("stripe.enable_telemetry", True)
         mocker.patch(
-            "stripe._api_requestor._get_uname_hash", return_value=None
+            "stripe._telemetry_id.get_telemetry_id",
+            return_value="abcdef1234567890abcdef1234567890",
         )
         requestor.request("get", self.v1_path, {}, base_address="api")
 
@@ -817,7 +806,23 @@ class TestAPIRequestor(object):
         client_ua = json.loads(
             last_call.get_raw_header("X-Stripe-Client-User-Agent")
         )
-        assert "source" not in client_ua
+        assert "telemetry_id" in client_ua
+        assert re.fullmatch(r"[0-9a-f]{32}", client_ua["telemetry_id"])
+
+    def test_telemetry_id_absent_when_telemetry_disabled(
+        self, requestor, mocker, http_client_mock
+    ):
+        http_client_mock.stub_request(
+            "get", path=self.v1_path, rbody="{}", rcode=200
+        )
+        mocker.patch("stripe.enable_telemetry", False)
+        requestor.request("get", self.v1_path, {}, base_address="api")
+
+        last_call = http_client_mock.get_last_call()
+        client_ua = json.loads(
+            last_call.get_raw_header("X-Stripe-Client-User-Agent")
+        )
+        assert "telemetry_id" not in client_ua
 
     def test_uses_given_idempotency_key(self, requestor, http_client_mock):
         method = "post"

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -599,7 +599,10 @@ class ClientTestBase:
 
 class RequestsVerify(object):
     def __eq__(self, other):
-        return other and other.endswith("stripe/data/ca-certificates.crt")
+        if not other:
+            return False
+        normalized = other.replace("\\", "/")
+        return normalized.endswith("stripe/data/ca-certificates.crt")
 
 
 class TestRequestsClient(ClientTestBase):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -242,7 +242,8 @@ class TestIntegration(object):
         duration_ms = telemetry["last_request_metrics"]["request_duration_ms"]
         # The first request took 31 ms, so the client perceived
         # latency shouldn't be outside this range.
-        assert 30 < duration_ms < 300
+        # Windows CI can be significantly slower due to process startup overhead.
+        assert 30 < duration_ms < 5000
 
         usage = telemetry["last_request_metrics"]["usage"]
         assert usage == ["save"]

--- a/tests/test_multipart_data_generator.py
+++ b/tests/test_multipart_data_generator.py
@@ -72,7 +72,7 @@ class TestMultipartDataGenerator(object):
         assert http_body.find(file_contents) != -1
 
     def test_multipart_data_file_text(self):
-        with open(__file__, mode="r") as test_file:
+        with open(__file__, mode="r", encoding="utf-8") as test_file:
             self.run_test_multipart_data_with_file(test_file)
 
     def test_multipart_data_file_binary(self):

--- a/tests/test_telemetry_id.py
+++ b/tests/test_telemetry_id.py
@@ -1,0 +1,114 @@
+import os
+import re
+
+import pytest
+
+import stripe._telemetry_id as telemetry_mod
+from stripe._telemetry_id import get_config_dir, get_telemetry_id
+
+
+@pytest.fixture(autouse=True)
+def reset_telemetry_cache():
+    """Reset the module-level cache before every test so each test starts fresh."""
+    telemetry_mod._cached_id = None
+    telemetry_mod._loaded = False
+    yield
+    telemetry_mod._cached_id = None
+    telemetry_mod._loaded = False
+
+
+class TestGetConfigDir:
+    def test_xdg_config_home_respected(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.delenv("APPDATA", raising=False)
+        # Simulate non-Windows so XDG branch is taken
+        monkeypatch.setattr(os, "name", "posix")
+
+        result = get_config_dir()
+
+        assert result == tmp_path / "stripe"
+
+    def test_falls_back_to_home_config_stripe(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+        monkeypatch.delenv("APPDATA", raising=False)
+        monkeypatch.setattr(os, "name", "posix")
+
+        result = get_config_dir()
+
+        assert result is not None
+        # Should end with .config/stripe regardless of where $HOME is
+        assert result.parts[-1] == "stripe"
+        assert result.parts[-2] == ".config"
+
+
+class TestGetTelemetryId:
+    def test_returns_32_char_hex_string(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.setattr(os, "name", "posix")
+
+        result = get_telemetry_id()
+
+        assert result is not None
+        assert len(result) == 32
+        assert re.fullmatch(r"[0-9a-f]{32}", result)
+
+    def test_is_deterministic_after_first_call(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.setattr(os, "name", "posix")
+
+        first = get_telemetry_id()
+        second = get_telemetry_id()
+
+        assert first == second
+
+    def test_reads_existing_id_from_file(self, monkeypatch, tmp_path):
+        existing_id = "a" * 32
+        config_dir = tmp_path / "stripe"
+        config_dir.mkdir(parents=True)
+        (config_dir / "telemetry_id").write_text(existing_id)
+
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.setattr(os, "name", "posix")
+
+        result = get_telemetry_id()
+
+        assert result == existing_id
+
+    def test_generates_and_persists_new_id_when_file_absent(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.setattr(os, "name", "posix")
+
+        result = get_telemetry_id()
+
+        assert result is not None
+        persisted = (tmp_path / "stripe" / "telemetry_id").read_text()
+        assert persisted == result
+
+    def test_returns_none_when_write_fails(self, monkeypatch, tmp_path):
+        # Make the config dir a file so mkdir fails and write can't succeed
+        config_dir = tmp_path / "stripe"
+        config_dir.write_text("not a directory")
+
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.setattr(os, "name", "posix")
+
+        result = get_telemetry_id()
+
+        assert result is None
+
+    def test_creates_parent_directories_if_missing(
+        self, monkeypatch, tmp_path
+    ):
+        # tmp_path exists but the nested stripe subdir does not
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.setattr(os, "name", "posix")
+
+        assert not (tmp_path / "stripe").exists()
+
+        result = get_telemetry_id()
+
+        assert result is not None
+        assert (tmp_path / "stripe").is_dir()
+        assert (tmp_path / "stripe" / "telemetry_id").exists()

--- a/tests/test_telemetry_id.py
+++ b/tests/test_telemetry_id.py
@@ -1,10 +1,12 @@
-import os
 import re
+import sys
 
 import pytest
 
 import stripe._telemetry_id as telemetry_mod
 from stripe._telemetry_id import get_config_dir, get_telemetry_id
+
+is_windows = sys.platform == "win32"
 
 
 @pytest.fixture(autouse=True)
@@ -17,98 +19,93 @@ def reset_telemetry_cache():
     telemetry_mod._loaded = False
 
 
+@pytest.fixture()
+def config_home(monkeypatch, tmp_path):
+    """Point the config dir at tmp_path using the platform-appropriate env var."""
+    if is_windows:
+        monkeypatch.setenv("APPDATA", str(tmp_path))
+    else:
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    return tmp_path
+
+
+# The subdirectory name differs by platform
+stripe_subdir = "Stripe" if is_windows else "stripe"
+
+
 class TestGetConfigDir:
+    @pytest.mark.skipif(is_windows, reason="XDG not used on Windows")
     def test_xdg_config_home_respected(self, monkeypatch, tmp_path):
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-        monkeypatch.delenv("APPDATA", raising=False)
-        # Simulate non-Windows so XDG branch is taken
-        monkeypatch.setattr(os, "name", "posix")
 
         result = get_config_dir()
 
         assert result == tmp_path / "stripe"
 
-    def test_falls_back_to_home_config_stripe(self, monkeypatch, tmp_path):
+    @pytest.mark.skipif(is_windows, reason="XDG fallback not used on Windows")
+    def test_falls_back_to_home_config_stripe(self, monkeypatch):
         monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
-        monkeypatch.delenv("APPDATA", raising=False)
-        monkeypatch.setattr(os, "name", "posix")
 
         result = get_config_dir()
 
         assert result is not None
-        # Should end with .config/stripe regardless of where $HOME is
         assert result.parts[-1] == "stripe"
         assert result.parts[-2] == ".config"
 
+    @pytest.mark.skipif(not is_windows, reason="APPDATA only used on Windows")
+    def test_uses_appdata_on_windows(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("APPDATA", str(tmp_path))
+
+        result = get_config_dir()
+
+        assert result == tmp_path / "Stripe"
+
 
 class TestGetTelemetryId:
-    def test_returns_32_char_hex_string(self, monkeypatch, tmp_path):
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-        monkeypatch.setattr(os, "name", "posix")
-
+    def test_returns_32_char_hex_string(self, config_home):
         result = get_telemetry_id()
 
         assert result is not None
         assert len(result) == 32
         assert re.fullmatch(r"[0-9a-f]{32}", result)
 
-    def test_is_deterministic_after_first_call(self, monkeypatch, tmp_path):
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-        monkeypatch.setattr(os, "name", "posix")
-
+    def test_is_deterministic_after_first_call(self, config_home):
         first = get_telemetry_id()
         second = get_telemetry_id()
 
         assert first == second
 
-    def test_reads_existing_id_from_file(self, monkeypatch, tmp_path):
+    def test_reads_existing_id_from_file(self, config_home):
         existing_id = "a" * 32
-        config_dir = tmp_path / "stripe"
+        config_dir = config_home / stripe_subdir
         config_dir.mkdir(parents=True)
         (config_dir / "telemetry_id").write_text(existing_id)
-
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-        monkeypatch.setattr(os, "name", "posix")
 
         result = get_telemetry_id()
 
         assert result == existing_id
 
-    def test_generates_and_persists_new_id_when_file_absent(
-        self, monkeypatch, tmp_path
-    ):
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-        monkeypatch.setattr(os, "name", "posix")
-
+    def test_generates_and_persists_new_id_when_file_absent(self, config_home):
         result = get_telemetry_id()
 
         assert result is not None
-        persisted = (tmp_path / "stripe" / "telemetry_id").read_text()
+        persisted = (config_home / stripe_subdir / "telemetry_id").read_text()
         assert persisted == result
 
-    def test_returns_none_when_write_fails(self, monkeypatch, tmp_path):
+    def test_returns_none_when_write_fails(self, config_home):
         # Make the config dir a file so mkdir fails and write can't succeed
-        config_dir = tmp_path / "stripe"
+        config_dir = config_home / stripe_subdir
         config_dir.write_text("not a directory")
-
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-        monkeypatch.setattr(os, "name", "posix")
 
         result = get_telemetry_id()
 
         assert result is None
 
-    def test_creates_parent_directories_if_missing(
-        self, monkeypatch, tmp_path
-    ):
-        # tmp_path exists but the nested stripe subdir does not
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-        monkeypatch.setattr(os, "name", "posix")
-
-        assert not (tmp_path / "stripe").exists()
+    def test_creates_parent_directories_if_missing(self, config_home):
+        assert not (config_home / stripe_subdir).exists()
 
         result = get_telemetry_id()
 
         assert result is not None
-        assert (tmp_path / "stripe").is_dir()
-        assert (tmp_path / "stripe" / "telemetry_id").exists()
+        assert (config_home / stripe_subdir).is_dir()
+        assert (config_home / stripe_subdir / "telemetry_id").exists()


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Recently, we introduced the `source` hash in the user-agent header to help our support team track down exactly where incoming requests originated from.

They've reported back to us that this hasn't been as useful as we wanted, so we're going a different direction.

Instead, we're adopting an industry-standard method of persisting a small UUID on disk that we include with subsequent requests. It's easy for users to read this file and it contains no PII. It also honors our existing telemetry opt outs.

It's meant to be lightweight and failure tolerant.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- remove `source` key from user-agent header
- add `telemetry_id` to the user-agent header
- adjust tests accordingly

### See Also

<!-- Include any links or additional information that help explain this change. -->

- original request: [DEVSDK-3131](https://go/j/DEVSDK-3131)
- update request: [RUN_DEVSDK-2563](https://go/j/RUN_DEVSDK-2563)
