### PR TITLE
move publish job to trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,34 +111,20 @@ jobs:
       startsWith(github.ref, 'refs/tags/v')
     needs: [build, test, lint]
     runs-on: "ubuntu-24.04"
+    environment: publish
     permissions:
       contents: read
+      id-token: write
     steps:
-      - uses: extractions/setup-just@v2
-      - uses: actions/checkout@v3
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
-      - name: Set up Python 3
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-
-      - name: Install tools
-        run: just install-build-deps
-
       - name: Publish packages to PyPI
-        # could probably move this into a just recipe too?
-        run: |
-          set -ex
-          source .venv/bin/activate
-
-          python -m twine upload --verbose dist/*
-        env:
-          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
       - uses: stripe/openapi/actions/notify-release@master
         if: always()
         with:


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Our current release process uses a long-lived PyPI token to upload releases. While still supported, it's no longer the favored way to do Python releases because if that token leaks, attackers can publish your package.

The current best practice is "trusted publishing", where github communicates with PyPI to mint a short-lived token with publishing permissions on demand. We start a release, get a token, use that token for the release, then revoke it. 

The process is straightforward. We make these changes to our CI (using the official GH action for python publishing) and then log into PyPI and hit a checkbox to enable the feature. After that, publishing will work like it always had and we'll be able to delete the `TWINE_PASSWORD` secret.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- changed CI workflow to use the standard trusted publishing action
  - follows the standard practices and uses the required fields, such as `environment` and `id-token`

### See Also
<!-- Include any links or additional information that help explain this change. -->

- https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
- https://github.com/pypa/gh-action-pypi-publish