### PR TITLE
use ip address directly instead of localhost to speed up windows tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,9 @@ jobs:
 
       - name: "run tests"
         run: just test
+        env:
+          # Use IP instead of 'localhost' to avoid slow DNS resolution on Windows
+          STRIPE_MOCK_HOST: ${{ runner.os == 'Windows' && '127.0.0.1' || 'localhost' }}
 
   publish:
     name: Publish

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,8 @@ if StripeMock.start():
 else:
     MOCK_PORT = os.environ.get("STRIPE_MOCK_PORT", 12111)
 
-MOCK_API_BASE = "http://localhost:%s" % MOCK_PORT
+MOCK_HOST = os.environ.get("STRIPE_MOCK_HOST", "localhost")
+MOCK_API_BASE = f"http://{MOCK_HOST}:{MOCK_PORT}"
 MOCK_API_KEY = "sk_test_123"
 
 
@@ -36,12 +37,10 @@ def stop_stripe_mock():
 def pytest_configure(config):
     if not config.getoption("--nomock"):
         try:
-            requests.get("http://localhost:%s/" % MOCK_PORT)
+            requests.get(f"http://{MOCK_HOST}:{MOCK_PORT}/")
         except Exception:
             sys.exit(
-                "Couldn't reach stripe-mock at `localhost:%s`. Is "
-                "it running? Please see README for setup instructions."
-                % MOCK_PORT
+                f"Couldn't reach stripe-mock at `{MOCK_HOST}:{MOCK_PORT}`. Is it running? Please see README for setup instructions."
             )
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,7 @@
 import platform
 from threading import Thread, Lock
 import json
+import os
 import warnings
 import time
 
@@ -21,6 +22,8 @@ if platform.python_implementation() == "PyPy":
     pytest.skip("skip integration tests with PyPy", allow_module_level=True)
 
 from http.server import BaseHTTPRequestHandler, HTTPServer
+
+MOCK_HOST = os.environ.get("STRIPE_MOCK_HOST", "localhost")
 
 
 class MyTestHandler(BaseHTTPRequestHandler):
@@ -98,8 +101,8 @@ class TestIntegration(object):
             "max_network_retries": stripe.max_network_retries,
             "proxy": stripe.proxy,
         }
-        stripe.api_base = "http://localhost:12111"  # stripe-mock
-        stripe.upload_api_base = "http://localhost:12111"  # stripe-mock
+        stripe.api_base = f"http://{MOCK_HOST}:12111"  # stripe-mock
+        stripe.upload_api_base = f"http://{MOCK_HOST}:12111"  # stripe-mock
         stripe.api_key = "sk_test_123"
         stripe.default_http_client = None
         stripe._default_proxy = None
@@ -117,7 +120,7 @@ class TestIntegration(object):
     def setup_mock_server(self, handler):
         # Configure mock server.
         # Passing 0 as the port will cause a random free port to be chosen.
-        self.mock_server = HTTPServer(("localhost", 0), handler)
+        self.mock_server = HTTPServer((MOCK_HOST, 0), handler)
         _, self.mock_server_port = self.mock_server.server_address
 
         # Start running mock server in a separate thread.
@@ -132,7 +135,7 @@ class TestIntegration(object):
 
         self.setup_mock_server(MockServerRequestHandler)
 
-        stripe.api_base = "http://localhost:%s" % self.mock_server_port
+        stripe.api_base = f"http://{MOCK_HOST}:{self.mock_server_port}"
         stripe.Balance.retrieve()
         reqs = MockServerRequestHandler.get_requests(1)
         assert reqs[0].path == "/v1/balance"
@@ -143,7 +146,7 @@ class TestIntegration(object):
 
         self.setup_mock_server(MockServerRequestHandler)
 
-        stripe.proxy = "http://localhost:%s" % self.mock_server_port
+        stripe.proxy = f"http://{MOCK_HOST}:{self.mock_server_port}"
         stripe.Balance.retrieve()
         assert MockServerRequestHandler.num_requests == 1
 
@@ -165,7 +168,7 @@ class TestIntegration(object):
         self.setup_mock_server(MockServerRequestHandler)
 
         stripe.default_http_client = stripe.new_default_http_client(
-            proxy="http://localhost:%s" % self.mock_server_port
+            proxy=f"http://{MOCK_HOST}:{self.mock_server_port}"
         )
         stripe.Balance.retrieve()
         assert MockServerRequestHandler.num_requests == 1
@@ -178,8 +181,8 @@ class TestIntegration(object):
 
         client = stripe.StripeClient(
             "sk_test_123",
-            proxy="http://localhost:%s" % self.mock_server_port,
-            base_addresses={"api": "http://localhost:12111"},
+            proxy=f"http://{MOCK_HOST}:{self.mock_server_port}",
+            base_addresses={"api": f"http://{MOCK_HOST}:12111"},
         )
         client.balance.retrieve()
 
@@ -194,9 +197,9 @@ class TestIntegration(object):
         client = stripe.StripeClient(
             "sk_test_123",
             http_client=new_default_http_client(
-                proxy="http://localhost:%s" % self.mock_server_port
+                proxy=f"http://{MOCK_HOST}:{self.mock_server_port}"
             ),
-            base_addresses={"api": "http://localhost:12111"},
+            base_addresses={"api": f"http://{MOCK_HOST}:12111"},
         )
         client.balance.retrieve()
 
@@ -218,7 +221,7 @@ class TestIntegration(object):
                 ]
 
         self.setup_mock_server(MockServerRequestHandler)
-        stripe.api_base = "http://localhost:%s" % self.mock_server_port
+        stripe.api_base = f"http://{MOCK_HOST}:{self.mock_server_port}"
         stripe.enable_telemetry = True
 
         cus = stripe.Customer("cus_xyz")
@@ -283,7 +286,7 @@ class TestIntegration(object):
                 ]
 
         self.setup_mock_server(MockServerRequestHandler)
-        stripe.api_base = "http://localhost:%s" % self.mock_server_port
+        stripe.api_base = f"http://{MOCK_HOST}:{self.mock_server_port}"
         stripe.enable_telemetry = True
         stripe.default_http_client = stripe.RequestsClient()
 
@@ -319,7 +322,7 @@ class TestIntegration(object):
         client = stripe.StripeClient(
             "sk_test_123",
             base_addresses={
-                "api": "http://localhost:%s" % self.mock_server_port
+                "api": f"http://{MOCK_HOST}:{self.mock_server_port}"
             },
         )
         await client.customers.create_async()
@@ -365,7 +368,7 @@ class TestIntegration(object):
         client = StripeClient(
             "sk_test_123",
             base_addresses={
-                "api": "http://localhost:%s" % self.mock_server_port
+                "api": f"http://{MOCK_HOST}:{self.mock_server_port}"
             },
         )
         resp = await client.raw_request_async(
@@ -385,7 +388,7 @@ class TestIntegration(object):
     ):
         class MockServerRequestHandler(MyTestHandler):
             def do_request(self, n):
-                time.sleep(0.02)
+                time.sleep(0.5)
                 return super().do_request(n)
 
         self.setup_mock_server(MockServerRequestHandler)
@@ -416,7 +419,7 @@ class TestIntegration(object):
                 "sk_test_123",
                 http_client=hc,
                 base_addresses={
-                    "api": "http://localhost:%s" % self.mock_server_port
+                    "api": f"http://{MOCK_HOST}:{self.mock_server_port}"
                 },
                 max_network_retries=0,
             )
@@ -450,7 +453,7 @@ class TestIntegration(object):
         client = StripeClient(
             "sk_test_123",
             base_addresses={
-                "api": "http://localhost:%s" % self.mock_server_port
+                "api": f"http://{MOCK_HOST}:{self.mock_server_port}"
             },
             max_network_retries=stripe.max_network_retries,
         )
@@ -483,7 +486,7 @@ class TestIntegration(object):
             client = StripeClient(
                 "sk_test_123",
                 base_addresses={
-                    "api": "http://localhost:%s" % self.mock_server_port
+                    "api": f"http://{MOCK_HOST}:{self.mock_server_port}"
                 },
             )
             await client.raw_request_async(
@@ -502,7 +505,7 @@ class TestIntegration(object):
                 return (200, None, b"hello")
 
         self.setup_mock_server(MockServerRequestHandler)
-        stripe.upload_api_base = "http://localhost:%s" % self.mock_server_port
+        stripe.upload_api_base = f"http://{MOCK_HOST}:{self.mock_server_port}"
 
         result = await stripe.Quote.pdf_async("qt_123")
         assert str(await result.read_async(), "utf-8") == "hello"
@@ -515,7 +518,7 @@ class TestIntegration(object):
                 return (400, None, b'{"error": {"message": "bad request"}}')
 
         self.setup_mock_server(MockServerRequestHandler)
-        stripe.upload_api_base = "http://localhost:%s" % self.mock_server_port
+        stripe.upload_api_base = f"http://{MOCK_HOST}:{self.mock_server_port}"
 
         try:
             await stripe.Quote.pdf_async("qt_123")


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

fast-follow for https://github.com/stripe/stripe-python/pull/1846, which added windows tests. Windows DNS resolution is slow, so use the IP address of stripe-mock directly.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- use IP address instead of `localhost` for faster tests
- raise timeout slightly to account for slow requests on windows
