### PR TITLE
Fix intermittent Windows test flake in async httpx integration tests

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -26,6 +26,19 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 MOCK_HOST = os.environ.get("STRIPE_MOCK_HOST", "localhost")
 
 
+class RequestSnapshot:
+    """Snapshot of request attributes, captured at handle time.
+
+    With HTTP/1.1 keep-alive, multiple requests reuse the same handler
+    instance whose attributes get overwritten on each request.
+    """
+
+    def __init__(self, handler):
+        self.command = handler.command
+        self.path = handler.path
+        self.headers = handler.headers
+
+
 class MyTestHandler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
     timeout = 30
@@ -37,10 +50,10 @@ class MyTestHandler(BaseHTTPRequestHandler):
     @classmethod
     def _add_request(cls, req):
         q = cls.requests[id(cls)]
-        q.put(req)
+        q.put(RequestSnapshot(req))
 
     @classmethod
-    def get_requests(cls, n) -> List[BaseHTTPRequestHandler]:
+    def get_requests(cls, n) -> List[RequestSnapshot]:
         reqs = []
         for _ in range(n):
             reqs.append(cls.requests[id(cls)].get(False))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -27,6 +27,9 @@ MOCK_HOST = os.environ.get("STRIPE_MOCK_HOST", "localhost")
 
 
 class MyTestHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    timeout = 30
+
     num_requests = 0
 
     requests = defaultdict(Queue)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -33,7 +33,7 @@ class RequestSnapshot:
     instance whose attributes get overwritten on each request.
     """
 
-    def __init__(self, handler):
+    def __init__(self, handler: BaseHTTPRequestHandler):
         self.command = handler.command
         self.path = handler.path
         self.headers = handler.headers

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -55,6 +55,12 @@ class MyTestHandler(BaseHTTPRequestHandler):
         return self._do_request()
 
     def _do_request(self):
+        # Drain the request body so it doesn't pollute the next request
+        # on the keep-alive connection.
+        content_length = int(self.headers.get("Content-Length", 0))
+        if content_length:
+            self.rfile.read(content_length)
+
         n = self.__class__.num_requests
         self.__class__.num_requests += 1
         self._add_request(self)


### PR DESCRIPTION
### Why?
BaseHTTPRequestHandler defaults to protocol_version "HTTP/1.0", which sets close_connection=True after every response. On Windows, the socket close can race with the async httpx client reading the response body, causing ReadError (Windows discards buffered TCP data on RST more aggressively than Linux).

Setting protocol_version to "HTTP/1.1" keeps the connection alive, eliminating the race. The 30s timeout is a backstop against the handler blocking on readline if the client never closes the connection.


Committed-By-Agent: claude

### What?
- Sets the `BaseHTTPRequestHandler` protocol version to HTTP/1.1, and timeout to 30s
- Updates tests to not assume we're dropping the connection between requests

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

### See Also
<!-- Include any links or additional information that help explain this change. -->

## Changelog
<!-- Heads up! This section should include entries for any user-facing changes.
Either fill it out or remove it if there are no entries to report.

List changes that affect end users, e.g.
- Fixes crash when calling `foo.bar()` with null argument
- Adds support for new `baz` parameter on `PaymentIntent` creation

List breaking changes first with a ⚠️ prefix, e.g.
- ⚠️ Removes deprecated `legacy_method` function
-->
