### PR TITLE
Adds v2-event-imports section to static v2/core/_event.py file

### DIFF
--- a/stripe/v2/core/_event.py
+++ b/stripe/v2/core/_event.py
@@ -2,6 +2,8 @@
 
 import json
 from typing import Any, ClassVar, Dict, Optional, cast
+# v2-event-imports: The beginning of the section generated from our OpenAPI spec
+# v2-event-imports: The end of the section generated from our OpenAPI spec
 
 from typing_extensions import Literal, TYPE_CHECKING
 


### PR DESCRIPTION
### Why?
The latest release includes better types for "open" enums, i.e. enums that can contain values added to the API after the SDK release.  These types are declared with typing.Union, but we cannot import Union without actually using it or else we anger the linter.  We changed our code generator to expect a dynamic section in v2/core/_event.py  to make sure the imports generate correctly.  This PR adopts a dynamic section already in our beta and private-preview branches to correspond with that change.

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

### What?
- adds v2-event-imports section to manually maintained _event.py file.  this matches the file format used in beta and private-preview
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

### See Also
<!-- Include any links or additional information that help explain this change. -->

