### PR TITLE
Add `stripe.major_api_version` constant

### DIFF
--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -30,6 +30,7 @@ connect_api_base: str = DEFAULT_CONNECT_API_BASE
 upload_api_base: str = DEFAULT_UPLOAD_API_BASE
 meter_events_api_base: str = DEFAULT_METER_EVENTS_API_BASE
 api_version: str = _ApiVersion.CURRENT
+major_api_version: str = _ApiVersion.CURRENT_MAJOR
 verify_ssl_certs: bool = True
 proxy: Optional[str] = None
 default_http_client: Optional["HTTPClient"] = None


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We've been generating information about the current API version into the SDKs for a while (codegen PR `2555`), but accidentally didn't make those constants user-facing.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- adds a user-facing `major_api_version` constant set to the generated value (currently `"dahlia"`)

### See Also

<!-- Include any links or additional information that help explain this change. -->

- (originally from https://github.com/stripe/stripe-java/issues/2001)
