### PR TITLE
Merge to private-preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ This release changes the pinned API version to 2026-07-29.dahlia.
   * Add support for `additional_addresses` on `V2.Core.Account.Identity.BusinessDetail`, `v2.core.AccountCreateParamsIdentityBusinessDetail`, `v2.core.AccountModifyParamsIdentityBusinessDetail`, and `v2.core.AccountTokenCreateParamsIdentityBusinessDetail`
   * Add support for snapshot events `financial_connections.account.expected_deactivation_date_updated`, `financial_connections.account.supported_payment_method_types_updated`, and `financial_connections.account.upcoming_deactivation` with resource `financial_connections.Account`
   * Add support for snapshot events `financial_connections.authorization.expected_deactivation_date_updated` and `financial_connections.authorization.upcoming_deactivation` with resource `financial_connections.Authorization`
+  * Enum type annotations for non-exhaustive ("open") enums are now typed as `Union[Literal[...], str]` instead of plain `Literal[...]`. Many Stripe enums are open, meaning new values may appear in new versions of the API. This change ensures these fields have the correct type for both the values known at SDK release time and other values that may be added later. Refer to the [API Reference](https://docs.stripe.com) for the latest set of allowed values.
 * [#1853](https://github.com/stripe/stripe-python/pull/1853) Fix intermittent Windows test flake in async httpx integration tests
 * [#1849](https://github.com/stripe/stripe-python/pull/1849) Use ip address directly instead of localhost to speed up windows tests
 

--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -30,6 +30,7 @@ connect_api_base: str = DEFAULT_CONNECT_API_BASE
 upload_api_base: str = DEFAULT_UPLOAD_API_BASE
 meter_events_api_base: str = DEFAULT_METER_EVENTS_API_BASE
 api_version: str = _ApiVersion.CURRENT
+major_api_version: str = _ApiVersion.CURRENT_MAJOR
 verify_ssl_certs: bool = True
 proxy: Optional[str] = None
 default_http_client: Optional["HTTPClient"] = None

--- a/stripe/v2/core/_event.py
+++ b/stripe/v2/core/_event.py
@@ -2,6 +2,8 @@
 
 import json
 from typing import Any, ClassVar, Dict, Optional, cast
+# v2-event-imports: The beginning of the section generated from our OpenAPI spec
+# v2-event-imports: The end of the section generated from our OpenAPI spec
 
 from typing_extensions import Literal, TYPE_CHECKING
 


### PR DESCRIPTION
### Why?

Routine merge of master changes into the private-preview release channel.

### What?

Merged master into private-preview using sdk-codegen's automerge tooling (`tools/automerge/python-private-preview.yaml`). One conflict in `stripe/v2/core/_event.py` was resolved by taking master's new `v2-event-imports` section markers and regenerating the private-preview code to fill them in.

### See Also



## Changelog

No user-facing changes — this is a merge commit only.