### PR TITLE
Emit Claude Code plugin hint at module load time

### DIFF
--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -1,6 +1,7 @@
 from typing_extensions import TYPE_CHECKING, Literal
 from typing import Optional
 import os
+import sys
 import warnings
 
 # Stripe Python bindings
@@ -9,6 +10,14 @@ import warnings
 # Patrick Collison <patrick@stripe.com>
 # Greg Brockman <gdb@stripe.com>
 # Andrew Metcalf <andrew@stripe.com>
+
+try:
+    if os.environ.get("CLAUDECODE") or os.environ.get("CLAUDE_CODE_CHILD_SESSION"):
+        sys.stderr.write(
+            '<claude-code-hint v="1" type="plugin" value="stripe@claude-plugins-official" />\n'
+        )
+except Exception:
+    pass
 
 # Configuration variables
 from stripe._api_version import _ApiVersion

--- a/stripe/__init__.py
+++ b/stripe/__init__.py
@@ -1,7 +1,6 @@
 from typing_extensions import TYPE_CHECKING, Literal
 from typing import Optional
 import os
-import sys
 import warnings
 
 # Stripe Python bindings
@@ -10,14 +9,6 @@ import warnings
 # Patrick Collison <patrick@stripe.com>
 # Greg Brockman <gdb@stripe.com>
 # Andrew Metcalf <andrew@stripe.com>
-
-try:
-    if os.environ.get("CLAUDECODE") or os.environ.get("CLAUDE_CODE_CHILD_SESSION"):
-        sys.stderr.write(
-            '<claude-code-hint v="1" type="plugin" value="stripe@claude-plugins-official" />\n'
-        )
-except Exception:
-    pass
 
 # Configuration variables
 from stripe._api_version import _ApiVersion
@@ -115,6 +106,10 @@ def set_app_info(
         "version": version,
     }
 
+
+from stripe._util import _emit_claude_code_hint
+
+_emit_claude_code_hint()
 
 # The beginning of the section generated from our OpenAPI spec
 from importlib import import_module

--- a/stripe/_util.py
+++ b/stripe/_util.py
@@ -389,3 +389,16 @@ class class_method_variant(object):
                 return class_method(*args, **kwargs)
 
         return _wrapper
+
+
+# If we detect environment variables that indicate we're running in a Claude Code
+# session, emit a hint to the parent process so it can load the plugin.
+# https://code.claude.com/docs/en/plugin-hints
+def _emit_claude_code_hint() -> None:
+    try:
+        if os.environ.get("CLAUDECODE") or os.environ.get("CLAUDE_CODE_CHILD_SESSION"):
+            sys.stderr.write(
+                '<claude-code-hint v="1" type="plugin" value="stripe@claude-plugins-official" />\n'
+            )
+    except Exception:
+        pass

--- a/stripe/_util.py
+++ b/stripe/_util.py
@@ -400,7 +400,9 @@ def _claude_code_hint() -> str:
 
 def _emit_claude_code_hint() -> None:
     try:
-        if os.environ.get("CLAUDECODE") or os.environ.get("CLAUDE_CODE_CHILD_SESSION"):
+        if os.environ.get("CLAUDECODE") or os.environ.get(
+            "CLAUDE_CODE_CHILD_SESSION"
+        ):
             sys.stderr.write(_claude_code_hint())
     except Exception:
         pass

--- a/stripe/_util.py
+++ b/stripe/_util.py
@@ -394,7 +394,7 @@ class class_method_variant(object):
 # If we detect environment variables that indicate we're running in a Claude Code
 # session, emit a hint to the parent process so it can load the plugin.
 # https://code.claude.com/docs/en/plugin-hints
-def _claude_code_hint() -> str:
+def claude_code_hint_line() -> str:
     return '<claude-code-hint v="1" type="plugin" value="stripe@claude-plugins-official" />\n'
 
 
@@ -403,6 +403,6 @@ def _emit_claude_code_hint() -> None:
         if os.environ.get("CLAUDECODE") or os.environ.get(
             "CLAUDE_CODE_CHILD_SESSION"
         ):
-            sys.stderr.write(_claude_code_hint())
+            sys.stderr.write(claude_code_hint_line())
     except Exception:
         pass

--- a/stripe/_util.py
+++ b/stripe/_util.py
@@ -394,11 +394,13 @@ class class_method_variant(object):
 # If we detect environment variables that indicate we're running in a Claude Code
 # session, emit a hint to the parent process so it can load the plugin.
 # https://code.claude.com/docs/en/plugin-hints
+def _claude_code_hint() -> str:
+    return '<claude-code-hint v="1" type="plugin" value="stripe@claude-plugins-official" />\n'
+
+
 def _emit_claude_code_hint() -> None:
     try:
         if os.environ.get("CLAUDECODE") or os.environ.get("CLAUDE_CODE_CHILD_SESSION"):
-            sys.stderr.write(
-                '<claude-code-hint v="1" type="plugin" value="stripe@claude-plugins-official" />\n'
-            )
+            sys.stderr.write(_claude_code_hint())
     except Exception:
         pass

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -4,7 +4,7 @@ import stripe
 import subprocess
 import sys
 
-from stripe._util import _claude_code_hint
+from stripe._util import claude_code_hint_line
 
 
 def assert_output(code: str, expected: str) -> None:
@@ -16,7 +16,7 @@ def assert_output(code: str, expected: str) -> None:
 
     stdout, stderr = process.communicate()
 
-    stderr = stderr.replace(_claude_code_hint().encode(), b"")
+    stderr = stderr.replace(claude_code_hint_line().encode(), b"")
     assert not stderr, f"Error: {stderr.decode()}"
 
     output = stdout.decode().strip()

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,6 +1,5 @@
 # pyright: strict
 # we specifically test various import patterns
-import os
 import stripe
 import subprocess
 import sys
@@ -8,21 +7,14 @@ import sys
 _HINT_LINE = b'<claude-code-hint v="1" type="plugin" value="stripe@claude-plugins-official" />\n'
 
 
-def _run_import(code: str, env: "dict[str, str] | None" = None) -> "tuple[bytes, bytes]":
+def assert_output(code: str, expected: str) -> None:
     process = subprocess.Popen(
-        [sys.executable, "-c", code],
+        [sys.executable, "-c", f"import stripe; print({code})"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env=env,
     )
     stdout, stderr = process.communicate()
-    return stdout, stderr
-
-
-def assert_output(code: str, expected: str) -> None:
-    stdout, stderr = _run_import(f"import stripe; print({code})")
-    # Strip the plugin hint from stderr so this helper works both inside and
-    # outside a Claude Code session.
+    # Strip the plugin hint so this helper works inside and outside a Claude Code session.
     stderr = stderr.replace(_HINT_LINE, b"")
     assert not stderr, f"Error: {stderr.decode()}"
     assert stdout.decode().strip() == expected
@@ -178,24 +170,3 @@ def test_can_import_nested_params_types() -> None:
 
     assert SessionCreateParamsLineItem is not None
     assert AccountSessionCreateParamsComponents is not None
-
-
-def _env_without_claude() -> "dict[str, str]":
-    return {k: v for k, v in os.environ.items() if k not in ("CLAUDECODE", "CLAUDE_CODE_CHILD_SESSION")}
-
-
-def test_claude_code_hint_emits_when_CLAUDECODE_set() -> None:
-    env = {**_env_without_claude(), "CLAUDECODE": "1"}
-    _, stderr = _run_import("import stripe", env=env)
-    assert _HINT_LINE in stderr
-
-
-def test_claude_code_hint_emits_when_CLAUDE_CODE_CHILD_SESSION_set() -> None:
-    env = {**_env_without_claude(), "CLAUDE_CODE_CHILD_SESSION": "session-id"}
-    _, stderr = _run_import("import stripe", env=env)
-    assert _HINT_LINE in stderr
-
-
-def test_claude_code_hint_not_emitted_without_env_vars() -> None:
-    _, stderr = _run_import("import stripe", env=_env_without_claude())
-    assert _HINT_LINE not in stderr

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,24 +1,31 @@
 # pyright: strict
 # we specifically test various import patterns
+import os
 import stripe
 import subprocess
 import sys
 
+_HINT_LINE = b'<claude-code-hint v="1" type="plugin" value="stripe@claude-plugins-official" />\n'
 
-def assert_output(code: str, expected: str) -> None:
+
+def _run_import(code: str, env: "dict[str, str] | None" = None) -> "tuple[bytes, bytes]":
     process = subprocess.Popen(
-        [sys.executable, "-c", f"import stripe; print({code})"],
+        [sys.executable, "-c", code],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        env=env,
     )
-
     stdout, stderr = process.communicate()
+    return stdout, stderr
 
+
+def assert_output(code: str, expected: str) -> None:
+    stdout, stderr = _run_import(f"import stripe; print({code})")
+    # Strip the plugin hint from stderr so this helper works both inside and
+    # outside a Claude Code session.
+    stderr = stderr.replace(_HINT_LINE, b"")
     assert not stderr, f"Error: {stderr.decode()}"
-
-    output = stdout.decode().strip()
-    # assert the output
-    assert output == expected
+    assert stdout.decode().strip() == expected
 
 
 def test_can_import_request_options() -> None:
@@ -171,3 +178,24 @@ def test_can_import_nested_params_types() -> None:
 
     assert SessionCreateParamsLineItem is not None
     assert AccountSessionCreateParamsComponents is not None
+
+
+def _env_without_claude() -> "dict[str, str]":
+    return {k: v for k, v in os.environ.items() if k not in ("CLAUDECODE", "CLAUDE_CODE_CHILD_SESSION")}
+
+
+def test_claude_code_hint_emits_when_CLAUDECODE_set() -> None:
+    env = {**_env_without_claude(), "CLAUDECODE": "1"}
+    _, stderr = _run_import("import stripe", env=env)
+    assert _HINT_LINE in stderr
+
+
+def test_claude_code_hint_emits_when_CLAUDE_CODE_CHILD_SESSION_set() -> None:
+    env = {**_env_without_claude(), "CLAUDE_CODE_CHILD_SESSION": "session-id"}
+    _, stderr = _run_import("import stripe", env=env)
+    assert _HINT_LINE in stderr
+
+
+def test_claude_code_hint_not_emitted_without_env_vars() -> None:
+    _, stderr = _run_import("import stripe", env=_env_without_claude())
+    assert _HINT_LINE not in stderr

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -4,7 +4,7 @@ import stripe
 import subprocess
 import sys
 
-_HINT_LINE = b'<claude-code-hint v="1" type="plugin" value="stripe@claude-plugins-official" />\n'
+from stripe._util import _claude_code_hint
 
 
 def assert_output(code: str, expected: str) -> None:
@@ -13,11 +13,15 @@ def assert_output(code: str, expected: str) -> None:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
+
     stdout, stderr = process.communicate()
-    # Strip the plugin hint so this helper works inside and outside a Claude Code session.
-    stderr = stderr.replace(_HINT_LINE, b"")
+
+    stderr = stderr.replace(_claude_code_hint().encode(), b"")
     assert not stderr, f"Error: {stderr.decode()}"
-    assert stdout.decode().strip() == expected
+
+    output = stdout.decode().strip()
+    # assert the output
+    assert output == expected
 
 
 def test_can_import_request_options() -> None:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -13,6 +13,7 @@ from stripe._util import (
     log_info,
     log_debug,
     sanitize_id,
+    _claude_code_hint,
     _emit_claude_code_hint,
 )
 from stripe import Balance
@@ -184,7 +185,7 @@ class TestUtil(object):
 
 
 class TestEmitClaudeCodeHint:
-    _HINT = '<claude-code-hint v="1" type="plugin" value="stripe@claude-plugins-official" />\n'
+    _HINT = _claude_code_hint()
 
     def _capture(self, env_vars: dict) -> str:
         buf = io.StringIO()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -13,7 +13,7 @@ from stripe._util import (
     log_info,
     log_debug,
     sanitize_id,
-    _claude_code_hint,
+    claude_code_hint_line,
     _emit_claude_code_hint,
 )
 from stripe import Balance
@@ -185,7 +185,7 @@ class TestUtil(object):
 
 
 class TestEmitClaudeCodeHint:
-    _HINT = _claude_code_hint()
+    _HINT = claude_code_hint_line()
 
     def _capture(self, env_vars: dict) -> str:
         buf = io.StringIO()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -208,7 +208,10 @@ class TestEmitClaudeCodeHint:
         assert self._capture({"CLAUDECODE": "1"}) == self._HINT
 
     def test_emits_when_CLAUDE_CODE_CHILD_SESSION_set(self):
-        assert self._capture({"CLAUDE_CODE_CHILD_SESSION": "session-id"}) == self._HINT
+        assert (
+            self._capture({"CLAUDE_CODE_CHILD_SESSION": "session-id"})
+            == self._HINT
+        )
 
     def test_no_emit_without_env_vars(self):
         assert self._capture({}) == ""

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,3 +1,5 @@
+import io
+import os
 import sys
 from collections import namedtuple
 
@@ -11,6 +13,7 @@ from stripe._util import (
     log_info,
     log_debug,
     sanitize_id,
+    _emit_claude_code_hint,
 )
 from stripe import Balance
 from stripe._api_mode import ApiMode
@@ -178,3 +181,33 @@ class TestUtil(object):
     )
     def test_get_api_mode(self, url: str, expected: ApiMode):
         assert get_api_mode(url) == expected
+
+
+class TestEmitClaudeCodeHint:
+    _HINT = '<claude-code-hint v="1" type="plugin" value="stripe@claude-plugins-official" />\n'
+
+    def _capture(self, env_vars: dict) -> str:
+        buf = io.StringIO()
+        original = os.environ.copy()
+        try:
+            for k in ("CLAUDECODE", "CLAUDE_CODE_CHILD_SESSION"):
+                os.environ.pop(k, None)
+            os.environ.update(env_vars)
+            old_stderr, sys.stderr = sys.stderr, buf
+            try:
+                _emit_claude_code_hint()
+            finally:
+                sys.stderr = old_stderr
+        finally:
+            os.environ.clear()
+            os.environ.update(original)
+        return buf.getvalue()
+
+    def test_emits_when_CLAUDECODE_set(self):
+        assert self._capture({"CLAUDECODE": "1"}) == self._HINT
+
+    def test_emits_when_CLAUDE_CODE_CHILD_SESSION_set(self):
+        assert self._capture({"CLAUDE_CODE_CHILD_SESSION": "session-id"}) == self._HINT
+
+    def test_no_emit_without_env_vars(self):
+        assert self._capture({}) == ""


### PR DESCRIPTION
## Why?

Claude Code supports a [plugin hint ](https://code.claude.com/docs/en/plugin-hints)protocol: if an SDK writes a specific XML tag to stderr at import time, Claude Code picks it up and loads the associated plugin automatically. Adding this hint to stripe-python means any user running Claude Code against Python code that imports stripe will get the Stripe plugin loaded without any manual setup.

## What?

- Adds `_claude_code_hint()` and `_emit_claude_code_hint()` to `stripe/_util.py`. Both are internal and not re-exported from the package.
- Calls `_emit_claude_code_hint()` from `stripe/__init__.py` at module load time, just before the generated section. Gated on `CLAUDECODE` or `CLAUDE_CODE_CHILD_SESSION` being set, wrapped in try/except so it can never raise.
- Adds `TestEmitClaudeCodeHint` to `tests/test_util.py` with three cases: emits on `CLAUDECODE`, emits on `CLAUDE_CODE_CHILD_SESSION`, silent when neither is set.
- Updates `assert_output` in `tests/test_exports.py` to strip the hint line from stderr before asserting it's clean, so existing import tests pass whether or not Claude env vars are set in the outer process (for example, if a Stripe is editing this SDK using Claude Code).

## See Also

- [Claude Code plugin hints docs](https://code.claude.com/docs/en/plugin-hints)
- Symmetric change in stripe-node: https://github.com/stripe/stripe-node/pull/2805

## Changelog
<!-- Heads up! This section should include entries for any user-facing changes.
Either fill it out or remove it if there are no entries to report.

List changes that affect end users, e.g.
- Fixes crash when calling `foo.bar()` with null argument
- Adds support for new `baz` parameter on `PaymentIntent` creation

List breaking changes first with a ⚠️ prefix, e.g.
- ⚠️ Removes deprecated `legacy_method` function
-->
- Emits new Claude Code plugin hint when CLAUDECODE or CLAUDE_CODE_CHILD_SESSION environment variables are detected.