### PR TITLE
Fix long test durations

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -41,7 +41,7 @@ class RequestSnapshot:
 
 class MyTestHandler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
-    timeout = 30
+    timeout = 0.5
 
     num_requests = 0
 


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

After https://github.com/stripe/stripe-python/pull/1853, I noticed tests got really slow both locally in CI. 

Before:

<img width="222" height="52" alt="image" src="https://github.com/user-attachments/assets/f6789058-a066-4807-ab4c-8072938d8525" />

After:

<img width="227" height="56" alt="image" src="https://github.com/user-attachments/assets/df892f16-8ac4-4a6b-8bcf-399eb75db713" />

With this fix:

<img width="230" height="57" alt="image" src="https://github.com/user-attachments/assets/ddd308e6-571b-4412-a21a-d2daa940831b" />

Claude traced it to the timeout value, which doesn't set a _maximum_ amount of time to wait, but a _minimum_. So all affected tests were taking exactly 30 seconds instead of "up to":

```
30.01s teardown tests/test_integration.py::TestIntegration::test_measures_stripe_client_telemetry[trio]
30.01s teardown tests/test_integration.py::TestIntegration::test_passes_client_telemetry_when_enabled
30.00s teardown tests/test_integration.py::TestIntegration::test_async_httpx_stream[trio-httpx]
30.00s teardown tests/test_integration.py::TestIntegration::test_async_raw_request_unretryable[asyncio-httpx]
30.00s teardown tests/test_integration.py::TestIntegration::test_async_raw_request_success[trio-httpx]
30.00s teardown tests/test_integration.py::TestIntegration::test_async_raw_request_retries[trio-httpx]
30.00s teardown tests/test_integration.py::TestIntegration::test_hits_proxy_through_default_http_client
30.00s teardown tests/test_integration.py::TestIntegration::test_async_raw_request_retries[asyncio-httpx]
30.00s teardown tests/test_integration.py::TestIntegration::test_hits_proxy_through_custom_client
30.00s teardown tests/test_integration.py::TestIntegration::test_async_raw_request_unretryable[trio-httpx]
30.00s teardown tests/test_integration.py::TestIntegration::test_async_httpx_stream_error[asyncio-aiohttp]
30.00s teardown tests/test_integration.py::TestIntegration::test_hits_api_base
30.00s teardown tests/test_integration.py::TestIntegration::test_async_raw_request_success[asyncio-httpx]
30.00s teardown tests/test_integration.py::TestIntegration::test_async_raw_request_success[asyncio-aiohttp]
30.00s teardown tests/test_integration.py::TestIntegration::test_async_httpx_stream[asyncio-aiohttp]
30.00s teardown tests/test_integration.py::TestIntegration::test_async_httpx_stream_error[trio-httpx]
30.00s teardown tests/test_integration.py::TestIntegration::test_measures_stripe_client_telemetry[asyncio]
30.00s teardown tests/test_integration.py::TestIntegration::test_async_raw_request_unretryable[asyncio-aiohttp]
30.00s teardown tests/test_integration.py::TestIntegration::test_async_httpx_stream[asyncio-httpx]
30.00s teardown tests/test_integration.py::TestIntegration::test_async_httpx_stream_error[asyncio-httpx]
30.00s teardown tests/test_integration.py::TestIntegration::test_async_raw_request_retries[asyncio-aiohttp]
0.71s call     tests/test_exports.py::test_can_import_namespaced_resource
0.67s call     tests/test_exports.py::test_can_import_deeply_namespaced_service
0.66s call     tests/test_exports.py::test_can_import_namespaced_service
0.52s call     tests/test_integration.py::TestIntegration::test_async_raw_request_retries[trio-httpx]
0.52s call     tests/test_integration.py::TestIntegration::test_async_raw_request_retries[asyncio-httpx]
...
```

I don't _think_ this will reintroduce the flakiness (claude says the fix for that was defaulting to `HTTP/1.1`) but I'm also not super sure.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- reduced the timeout of our test handler
