### PR TITLE
Surface `object` property on `EventNotification`

### DIFF
--- a/stripe/v2/core/_event.py
+++ b/stripe/v2/core/_event.py
@@ -143,6 +143,10 @@ class EventNotification:
     """
     Livemode indicates if the event is from a production(true) or test(false) account.
     """
+    object: str
+    """
+    String representing the object's type. Objects of the same type share the same value.
+    """
     context: Optional[StripeContext] = None
     """
     [Optional] Authentication context needed to fetch the event or related object.
@@ -156,6 +160,7 @@ class EventNotification:
         self, parsed_body: Dict[str, Any], client: "StripeClient"
     ) -> None:
         self.id = parsed_body["id"]
+        self.object = parsed_body["object"]
         self.type = parsed_body["type"]
         self.created = parsed_body["created"]
         self.livemode = bool(parsed_body.get("livemode"))

--- a/tests/test_stripe_context.py
+++ b/tests/test_stripe_context.py
@@ -156,6 +156,7 @@ class TestStripeContextIntegration:
         mock_client = Mock()
         parsed_body = {
             "id": "evt_123",
+            "object": "v2.core.event",
             "type": "test.event",
             "created": "2023-01-01T00:00:00Z",
             "livemode": False,
@@ -171,6 +172,7 @@ class TestStripeContextIntegration:
         mock_client = Mock()
         parsed_body = {
             "id": "evt_123",
+            "object": "v2.core.event",
             "type": "test.event",
             "created": "2023-01-01T00:00:00Z",
             "livemode": False,
@@ -184,6 +186,7 @@ class TestStripeContextIntegration:
         mock_client = Mock()
         parsed_body = {
             "id": "evt_123",
+            "object": "v2.core.event",
             "type": "test.event",
             "created": "2023-01-01T00:00:00Z",
             "livemode": False,

--- a/tests/test_v2_event.py
+++ b/tests/test_v2_event.py
@@ -102,6 +102,7 @@ class TestV2Event(object):
             notif, V1BillingMeterErrorReportTriggeredEventNotification
         )
         assert notif.id == "evt_234"
+        assert notif.object == "v2.core.event"
 
         assert notif.related_object
         assert notif.related_object.id == "mtr_123"


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

`object` is present in the original payload, but we didn't surface it on the `EventNotification` class. Because `"v2.core.event"` is the only value that will ever be present, It didn't seem worth adding it to the interface.

I also wanted to better differentiate `EventNotification`s from all other `StripeObject`s (since they _do_ behave differently).

But, that also means interacting with it along with other objects is unnecessarily complicated. From the [original ruby issue](https://github.com/stripe/stripe-ruby/issues/1860):

```rb
def v1?(event)
  (event.try(:object) || event.try(:dig, "object")) == "event"
end

def v2?(event)
  event.is_a?(::Stripe::V2::Core::EventNotification) || # thin event notification
    (event.try(:object) || event.try(:dig, "object")) == "v2.core.event"
end
```

Because the value is present in the original response, it doesn't make sense to eat it.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add public `object` property to `EventNotification`
- add test

### See Also

<!-- Include any links or additional information that help explain this change. -->

- originally brought up in [stripe/stripe-ruby#1860](https://github.com/stripe/stripe-ruby/issues/1860)
- [DEVSDK-3101](https://go/j/DEVSDK-3101)
