### PR TITLE
widen some webhook types

### DIFF
--- a/examples/async_event_notification_handler_endpoint.py
+++ b/examples/async_event_notification_handler_endpoint.py
@@ -95,8 +95,7 @@ async def webhook(request: Request):
 async def webhook_from_cloud_provider(request: Request):
     # no signature header to pass along; the channel already authenticated this event
     try:
-        body = await request.body()
-        await unverified_handler.handle_async(body.decode())
+        await unverified_handler.handle_async(await request.body())
         return Response(status_code=200)
     except Exception as e:
         return Response(content=str(e), status_code=500)

--- a/examples/async_event_notification_handler_endpoint.py
+++ b/examples/async_event_notification_handler_endpoint.py
@@ -95,7 +95,8 @@ async def webhook(request: Request):
 async def webhook_from_cloud_provider(request: Request):
     # no signature header to pass along; the channel already authenticated this event
     try:
-        await unverified_handler.handle_async(await request.body())
+        body = await request.body()
+        await unverified_handler.handle_async(body)
         return Response(status_code=200)
     except Exception as e:
         return Response(content=str(e), status_code=500)

--- a/examples/event_notification_handler_endpoint.py
+++ b/examples/event_notification_handler_endpoint.py
@@ -76,7 +76,9 @@ def handle_meter_error(
 @app.route("/webhook", methods=["POST"])
 def webhook():
     try:
-        handler.handle(request.data, request.headers.get("Stripe-Signature"))
+        webhook_body = request.data
+        sig_header = request.headers.get("Stripe-Signature")
+        handler.handle(webhook_body, sig_header)
         return jsonify(success=True), 200
     except Exception as e:
         return jsonify(error=str(e)), 500

--- a/examples/event_notification_handler_endpoint.py
+++ b/examples/event_notification_handler_endpoint.py
@@ -75,11 +75,8 @@ def handle_meter_error(
 
 @app.route("/webhook", methods=["POST"])
 def webhook():
-    webhook_body = request.data
-    sig_header = request.headers.get("Stripe-Signature")
-
     try:
-        handler.handle(webhook_body, sig_header)
+        handler.handle(request.data, request.headers.get("Stripe-Signature"))
         return jsonify(success=True), 200
     except Exception as e:
         return jsonify(error=str(e)), 500

--- a/examples/event_notification_webhook_handler.py
+++ b/examples/event_notification_webhook_handler.py
@@ -32,12 +32,11 @@ client = StripeClient(api_key)
 
 @app.route("/webhook", methods=["POST"])
 def webhook():
-    webhook_body = request.data
-    sig_header = request.headers.get("Stripe-Signature")
-
     try:
         event_notif = client.parse_event_notification(
-            webhook_body, sig_header, webhook_secret
+            request.data,
+            request.headers.get("Stripe-Signature"),
+            webhook_secret,
         )
 
         # type checkers will narrow the type based on the `type` property

--- a/examples/event_notification_webhook_handler.py
+++ b/examples/event_notification_webhook_handler.py
@@ -33,10 +33,11 @@ client = StripeClient(api_key)
 @app.route("/webhook", methods=["POST"])
 def webhook():
     try:
+        webhook_body = request.data
+        sig_header = request.headers.get("Stripe-Signature")
+
         event_notif = client.parse_event_notification(
-            request.data,
-            request.headers.get("Stripe-Signature"),
-            webhook_secret,
+            webhook_body, sig_header, webhook_secret
         )
 
         # type checkers will narrow the type based on the `type` property

--- a/examples/webhooks.py
+++ b/examples/webhooks.py
@@ -13,7 +13,7 @@ app = Flask(__name__)
 
 @app.route("/webhooks", methods=["POST"])
 def webhooks():
-    payload = request.data.decode("utf-8")
+    payload = request.data
     received_sig = request.headers.get("Stripe-Signature", None)
 
     try:

--- a/stripe/_event_notification_handler.py
+++ b/stripe/_event_notification_handler.py
@@ -617,9 +617,10 @@ class StripeEventNotificationHandler(_SyncEventNotificationHandler):
     def __init__(
         self,
         client: "StripeClient",
-        webhook_secret: str,
+        webhook_secret: Optional[str],
         fallback_callback: FallbackCallback,
     ) -> None:
+        """`webhook_secret` is only marked as `Optional` so it plays nicely with the types commonly returned from web frameworks. This raises a `ValueError` if a secret is not provided."""
         super().__init__(client, fallback_callback)
         if not webhook_secret:
             raise ValueError("webhook_secret must be a non-empty string")
@@ -684,9 +685,10 @@ class AsyncStripeEventNotificationHandler(_AsyncEventNotificationHandler):
     def __init__(
         self,
         client: "StripeClient",
-        webhook_secret: str,
+        webhook_secret: Optional[str],
         fallback_callback: AsyncFallbackCallback,
     ) -> None:
+        """`webhook_secret` is only marked as `Optional` so it plays nicely with the types commonly returned from web frameworks. This raises a `ValueError` if a secret is not provided."""
         super().__init__(client, fallback_callback)
         if not webhook_secret:
             raise ValueError("webhook_secret must be a non-empty string")

--- a/stripe/_event_notification_handler.py
+++ b/stripe/_event_notification_handler.py
@@ -33,6 +33,7 @@ from typing import (
 
 # Import at runtime for isinstance check and type annotations
 from stripe.v2.core._event import EventNotification, UnknownEventNotification
+from stripe._webhook import WebhookPayload
 
 if TYPE_CHECKING:
     from stripe._stripe_client import StripeClient
@@ -624,7 +625,12 @@ class StripeEventNotificationHandler(_SyncEventNotificationHandler):
             raise ValueError("webhook_secret must be a non-empty string")
         self._webhook_secret = webhook_secret
 
-    def handle(self, webhook_body: str, sig_header: str):
+    def handle(self, webhook_body: WebhookPayload, sig_header: Optional[str]):
+        """
+        Process an incoming webhook, routing it to the correct registered callback (or your fallback).
+
+        `sig_header` is only marked as `Optional` so it plays nicely with the types commonly returned from web frameworks. This raises a `SignatureVerificationError` if a signature is not provided.
+        """
         # set before parsing, so that even a failed parse locks out registration.
         # modification isn't thread-safe, but we expect callbacks to get registered synchronously at startup
         # making a race condition here unlikely
@@ -655,7 +661,10 @@ class StripeEventNotificationHandlerWithoutVerification(
     Prefer `StripeEventNotificationHandler.without_verification()` or `client.notification_handler_without_verification()` instead of constructing it directly.
     """
 
-    def handle(self, webhook_body: str):
+    def handle(self, webhook_body: WebhookPayload):
+        """
+        Process an incoming webhook, routing it to the correct registered callback (or your fallback) without signature verification.
+        """
         self._has_handled_events = True
 
         event_notif = (
@@ -683,7 +692,14 @@ class AsyncStripeEventNotificationHandler(_AsyncEventNotificationHandler):
             raise ValueError("webhook_secret must be a non-empty string")
         self._webhook_secret = webhook_secret
 
-    async def handle_async(self, webhook_body: str, sig_header: str):
+    async def handle_async(
+        self, webhook_body: WebhookPayload, sig_header: Optional[str]
+    ):
+        """
+        Process an incoming webhook, routing it to the correct registered callback (or your fallback).
+
+        `sig_header` is only marked as `Optional` so it plays nicely with the types commonly returned from web frameworks. This raises a `SignatureVerificationError` if a signature is not provided.
+        """
         self._has_handled_events = True
 
         event_notif = self._client.parse_event_notification(
@@ -711,7 +727,10 @@ class AsyncStripeEventNotificationHandlerWithoutVerification(
     Prefer `AsyncStripeEventNotificationHandler.without_verification()` or `client.async_notification_handler_without_verification()` instead of constructing it directly.
     """
 
-    async def handle_async(self, webhook_body: str):
+    async def handle_async(self, webhook_body: WebhookPayload):
+        """
+        Process an incoming webhook, routing it to the correct registered callback (or your fallback) without signature verification.
+        """
         self._has_handled_events = True
 
         event_notif = (

--- a/stripe/_stripe_client.py
+++ b/stripe/_stripe_client.py
@@ -30,6 +30,7 @@ from stripe._stripe_response import StripeResponse
 from stripe._util import _convert_to_stripe_object, get_api_mode
 from stripe._webhook import (
     Webhook,
+    WebhookPayload,
     WebhookSignature,
     maybe_extract_from_cloud_provider_envelope,
 )
@@ -224,12 +225,14 @@ class StripeClient(object):
 
     def construct_event(
         self,
-        payload: Union[bytes, str],
-        sig_header: str,
+        payload: WebhookPayload,
+        sig_header: Optional[str],
         secret: str,
         tolerance: int = Webhook.DEFAULT_TOLERANCE,
     ) -> Event:
-        """Constructs a [snapshot event](https://docs.stripe.com/event-destinations#snapshot-payload) from an incoming webhook after verifying its authenticity. To work with a webhook that has already been verified (i.e. one from a cloud provider, an asynchronous queue, or during testing), see `construct_event_without_verification`."""
+        """Constructs a [snapshot event](https://docs.stripe.com/event-destinations#snapshot-payload) from an incoming webhook after verifying its authenticity. To work with a webhook that has already been verified (i.e. one from a cloud provider, an asynchronous queue, or during testing), see `construct_event_without_verification`.
+
+        `sig_header` is only marked as `Optional` so it plays nicely with the types commonly returned from web frameworks. This raises a `SignatureVerificationError` if a signature is not provided."""
         return Webhook.construct_event(
             payload,
             sig_header,
@@ -240,7 +243,7 @@ class StripeClient(object):
 
     def construct_event_without_verification(
         self,
-        payload: Union[bytes, str],
+        payload: WebhookPayload,
     ) -> Event:
         """Constructs a [snapshot event](https://docs.stripe.com/event-destinations#snapshot-payload) from an incoming webhook without first verifying its authenticity. Should be used after calling `Webhook.verify_header(...)` or with input from a trusted source (such as [AWS EventBridge](https://docs.stripe.com/event-destinations/eventbridge), or [Azure Event Grid](https://docs.stripe.com/event-destinations/eventgrid) payload). Or, to verify & construct in a single call, use `Webhook.construct_event(...)` instead."""
         return Webhook.construct_event_without_verification(
@@ -249,28 +252,24 @@ class StripeClient(object):
 
     def parse_event_notification(
         self,
-        raw: Union[bytes, str, bytearray],
-        sig_header: str,
+        raw: WebhookPayload,
+        sig_header: Optional[str],
         secret: str,
         tolerance: int = Webhook.DEFAULT_TOLERANCE,
     ) -> "ALL_EVENT_NOTIFICATIONS":
-        """Constructs a [thin event notification](https://docs.stripe.com/event-destinations#thin-payload) from an incoming webhook after verifying its authenticity. To work with a webhook that has already been verified (i.e. one from a cloud provider, an asynchronous queue, or during testing), see `parse_event_notification_without_verification`."""
-        payload = (
-            cast(Union[bytes, bytearray], raw).decode("utf-8")
-            if hasattr(raw, "decode")
-            else cast(str, raw)
-        )
+        """Constructs a [thin event notification](https://docs.stripe.com/event-destinations#thin-payload) from an incoming webhook after verifying its authenticity. To work with a webhook that has already been verified (i.e. one from a cloud provider, an asynchronous queue, or during testing), see `parse_event_notification_without_verification`.
 
-        WebhookSignature.verify_header(payload, sig_header, secret, tolerance)
+        `sig_header` is only marked as `Optional` so it plays nicely with the types commonly returned from web frameworks. This raises a `SignatureVerificationError` if a signature is not provided."""
+        WebhookSignature.verify_header(raw, sig_header, secret, tolerance)
 
         return cast(
             "ALL_EVENT_NOTIFICATIONS",
-            EventNotification.from_json(payload, self),
+            EventNotification.from_json(raw, self),
         )
 
     def parse_event_notification_without_verification(
         self,
-        payload: Union[bytes, str],
+        payload: WebhookPayload,
     ) -> "ALL_EVENT_NOTIFICATIONS":
         """Constructs a [thin event notification](https://docs.stripe.com/event-destinations#thin-payload) from an incoming webhook without first verifying its authenticity. Should be used after calling `Webhook.verify_header(...)` or with input from a trusted source (such as [AWS EventBridge](https://docs.stripe.com/event-destinations/eventbridge), or [Azure Event Grid](https://docs.stripe.com/event-destinations/eventgrid) payload). Or, to verify & parse in a single call, use `parse_event_notification(...)` instead."""
 

--- a/stripe/_stripe_client.py
+++ b/stripe/_stripe_client.py
@@ -227,12 +227,12 @@ class StripeClient(object):
         self,
         payload: WebhookPayload,
         sig_header: Optional[str],
-        secret: str,
+        secret: Optional[str],
         tolerance: int = Webhook.DEFAULT_TOLERANCE,
     ) -> Event:
         """Constructs a [snapshot event](https://docs.stripe.com/event-destinations#snapshot-payload) from an incoming webhook after verifying its authenticity. To work with a webhook that has already been verified (i.e. one from a cloud provider, an asynchronous queue, or during testing), see `construct_event_without_verification`.
 
-        `sig_header` is only marked as `Optional` so it plays nicely with the types commonly returned from web frameworks. This raises a `SignatureVerificationError` if a signature is not provided."""
+        `sig_header` and `secret` are only marked as `Optional` so they play nicely with the types commonly returned from web frameworks. This raises a `SignatureVerificationError` if either is missing."""
         return Webhook.construct_event(
             payload,
             sig_header,
@@ -254,12 +254,12 @@ class StripeClient(object):
         self,
         raw: WebhookPayload,
         sig_header: Optional[str],
-        secret: str,
+        secret: Optional[str],
         tolerance: int = Webhook.DEFAULT_TOLERANCE,
     ) -> "ALL_EVENT_NOTIFICATIONS":
         """Constructs a [thin event notification](https://docs.stripe.com/event-destinations#thin-payload) from an incoming webhook after verifying its authenticity. To work with a webhook that has already been verified (i.e. one from a cloud provider, an asynchronous queue, or during testing), see `parse_event_notification_without_verification`.
 
-        `sig_header` is only marked as `Optional` so it plays nicely with the types commonly returned from web frameworks. This raises a `SignatureVerificationError` if a signature is not provided."""
+        `sig_header` and `secret` are only marked as `Optional` so they play nicely with the types commonly returned from web frameworks. This raises a `SignatureVerificationError` if either is missing."""
         WebhookSignature.verify_header(raw, sig_header, secret, tolerance)
 
         return cast(
@@ -363,10 +363,14 @@ class StripeClient(object):
         )
 
     def notification_handler(
-        self, webhook_secret: str, fallback_callback: FallbackCallback
+        self,
+        webhook_secret: Optional[str],
+        fallback_callback: FallbackCallback,
     ) -> StripeEventNotificationHandler:
         """
         Returns an StripeEventNotificationHandler instance tied to this client.
+
+        `webhook_secret` is only marked as `Optional` so it plays nicely with the types commonly returned from web frameworks. This raises a `ValueError` if a secret is not provided.
         """
         return StripeEventNotificationHandler(
             self, webhook_secret, fallback_callback
@@ -386,11 +390,15 @@ class StripeClient(object):
         )
 
     def async_notification_handler(
-        self, webhook_secret: str, fallback_callback: AsyncFallbackCallback
+        self,
+        webhook_secret: Optional[str],
+        fallback_callback: AsyncFallbackCallback,
     ) -> AsyncStripeEventNotificationHandler:
         """
         Returns an AsyncStripeEventNotificationHandler instance tied to this client.
         Register `async def` callbacks on it and run them using `await handler.handle_async()`.
+
+        `webhook_secret` is only marked as `Optional` so it plays nicely with the types commonly returned from web frameworks. This raises a `ValueError` if a secret is not provided.
         """
         return AsyncStripeEventNotificationHandler(
             self, webhook_secret, fallback_callback

--- a/stripe/_webhook.py
+++ b/stripe/_webhook.py
@@ -67,7 +67,7 @@ class Webhook(object):
     def construct_event(
         payload: WebhookPayload,
         sig_header: Optional[str],
-        secret: str,
+        secret: Optional[str],
         tolerance: int = DEFAULT_TOLERANCE,
         api_key: Optional[str] = None,
         api_requestor: Optional[_APIRequestor] = None,
@@ -133,10 +133,12 @@ class WebhookSignature(object):
         cls,
         payload: WebhookPayload,
         header: Optional[str],
-        secret: str,
+        secret: Optional[str],
         tolerance=None,
     ):
-        """Verifies the authenticity (and recency) of a webhook, throwing a `SignatureVerificationError` if there's a mismatch. Useful for quickly validating incoming webhooks before storing them for later processing (at which time you can use the `*_without_verification` methods for parsing)."""
+        """Verifies the authenticity (and recency) of a webhook, throwing a `SignatureVerificationError` if there's a mismatch. Useful for quickly validating incoming webhooks before storing them for later processing (at which time you can use the `*_without_verification` methods for parsing).
+
+        `sig_header` and `secret` are only marked as `Optional` so they play nicely with the types commonly returned from web frameworks. This raises a `SignatureVerificationError` if either is missing."""
         # the signature is computed over the string form of the body, so binary
         # input has to be decoded before it's interpolated below
         if isinstance(payload, (bytes, bytearray)):
@@ -145,6 +147,12 @@ class WebhookSignature(object):
         if not header:
             raise SignatureVerificationError(
                 "No Stripe-Signature header value was provided. Read it from the incoming request's headers and pass it in; if this webhook has already been verified (or came from a trusted source), use one of the `*_without_verification` methods instead.",
+                header,
+                payload,
+            )
+        if not secret:
+            raise SignatureVerificationError(
+                "No webhook secret value was provided. It should start with `whsec_`",
                 header,
                 payload,
             )

--- a/stripe/_webhook.py
+++ b/stripe/_webhook.py
@@ -12,6 +12,12 @@ from stripe._util import secure_compare
 from stripe._error import SignatureVerificationError
 from stripe._api_requestor import _APIRequestor
 
+WebhookPayload = Union[str, bytes, bytearray]
+"""
+The raw body of an incoming webhook, as read off the request body.
+Intentionally wide to work nicely with existing types from Django/Flask/FastAPI .
+"""
+
 
 def build_v1_event(values: Dict[str, Any], requestor: _APIRequestor) -> Event:
     """
@@ -26,14 +32,12 @@ def build_v1_event(values: Dict[str, Any], requestor: _APIRequestor) -> Event:
     )
 
 
-def maybe_extract_from_cloud_provider_envelope(
-    payload: Union[bytes, str],
-):
+def maybe_extract_from_cloud_provider_envelope(payload: WebhookPayload):
     """
     Internal helper to extract the inner type from a cloud provider envelope (regardless of what's in there).
     If the payload is already a raw Stripe event (object is 'event' or 'v2.core.event'), returns the parsed dict as-is.
     """
-    if isinstance(payload, bytes):
+    if isinstance(payload, (bytes, bytearray)):
         payload = payload.decode("utf-8")
 
     data = json.loads(payload, object_pairs_hook=OrderedDict)
@@ -61,17 +65,16 @@ class Webhook(object):
 
     @staticmethod
     def construct_event(
-        payload: Union[bytes, str],
-        sig_header: str,
+        payload: WebhookPayload,
+        sig_header: Optional[str],
         secret: str,
         tolerance: int = DEFAULT_TOLERANCE,
         api_key: Optional[str] = None,
         api_requestor: Optional[_APIRequestor] = None,
     ):
-        """Constructs a [snapshot event](https://docs.stripe.com/event-destinations#snapshot-payload) from an incoming webhook after verifying its authenticity. To work with a webhook that has already been verified (i.e. one from a cloud provider, an asynchronous queue, or during testing), see `construct_event_without_verification`."""
-        if isinstance(payload, (bytes, bytearray)):
-            payload = payload.decode("utf-8")
+        """Constructs a [snapshot event](https://docs.stripe.com/event-destinations#snapshot-payload) from an incoming webhook after verifying its authenticity. To work with a webhook that has already been verified (i.e. one from a cloud provider, an asynchronous queue, or during testing), see `construct_event_without_verification`.
 
+        `sig_header` is only marked as `Optional` so it plays nicely with the types commonly returned from web frameworks. This raises a `SignatureVerificationError` if a signature is not provided."""
         WebhookSignature.verify_header(payload, sig_header, secret, tolerance)
 
         return build_v1_event(
@@ -84,8 +87,7 @@ class Webhook(object):
 
     @staticmethod
     def construct_event_without_verification(
-        payload: Union[bytes, str],
-        api_requestor: Optional[_APIRequestor] = None,
+        payload: WebhookPayload, api_requestor: Optional[_APIRequestor] = None
     ):
         """Constructs a [snapshot event](https://docs.stripe.com/event-destinations#snapshot-payload) from an incoming webhook without first verifying its authenticity. Should be used after calling `WebhookSignature.verify_header(...)` or with input from a trusted source (such as [AWS EventBridge](https://docs.stripe.com/event-destinations/eventbridge), or [Azure Event Grid](https://docs.stripe.com/event-destinations/eventgrid) payload). Or, to verify & construct in a single call, use `Webhook.construct_event(...)` instead."""
         return build_v1_event(
@@ -129,12 +131,24 @@ class WebhookSignature(object):
     @classmethod
     def verify_header(
         cls,
-        payload: Union[bytes, str],
-        header: str,
+        payload: WebhookPayload,
+        header: Optional[str],
         secret: str,
         tolerance=None,
     ):
         """Verifies the authenticity (and recency) of a webhook, throwing a `SignatureVerificationError` if there's a mismatch. Useful for quickly validating incoming webhooks before storing them for later processing (at which time you can use the `*_without_verification` methods for parsing)."""
+        # the signature is computed over the string form of the body, so binary
+        # input has to be decoded before it's interpolated below
+        if isinstance(payload, (bytes, bytearray)):
+            payload = payload.decode("utf-8")
+
+        if not header:
+            raise SignatureVerificationError(
+                "No Stripe-Signature header value was provided. Read it from the incoming request's headers and pass it in; if this webhook has already been verified (or came from a trusted source), use one of the `*_without_verification` methods instead.",
+                header,
+                payload,
+            )
+
         try:
             timestamp, signatures = cls._get_timestamp_and_signatures(
                 header, cls.EXPECTED_SCHEME

--- a/stripe/v2/core/_event.py
+++ b/stripe/v2/core/_event.py
@@ -10,6 +10,7 @@ from typing_extensions import Literal, TYPE_CHECKING
 from stripe._stripe_object import StripeObject, UntypedStripeObject
 from stripe._util import get_api_mode
 from stripe._stripe_context import StripeContext
+from stripe._webhook import WebhookPayload
 
 if TYPE_CHECKING:
     from stripe._stripe_client import StripeClient
@@ -175,16 +176,22 @@ class EventNotification:
 
     @staticmethod
     def from_json(
-        payload: Union[str, Dict[str, Any]], client: "StripeClient"
+        payload: Union[WebhookPayload, Dict[str, Any]], client: "StripeClient"
     ) -> "EventNotification":
         """
         Helper for constructing an Event Notification. Doesn't perform signature validation, so you
         should use StripeClient.parse_event_notification() instead for initial handling.
         This is useful in unit tests and working with EventNotifications whose authenticity you've already validated.
         """
-        parsed_body = (
-            json.loads(payload) if isinstance(payload, str) else payload
-        )
+        if isinstance(payload, dict):
+            parsed_body = payload
+        else:
+            parsed_body = json.loads(
+                payload.decode("utf-8")
+                if isinstance(payload, (bytes, bytearray))
+                else payload
+            )
+
         if parsed_body.get("object") == "event":
             raise ValueError(
                 "You passed a webhook payload to StripeClient.parse_event_notification, which expects a thin event notification. Use StripeClient.construct_event instead."

--- a/tests/test_cloud_provider.py
+++ b/tests/test_cloud_provider.py
@@ -6,6 +6,11 @@ import stripe
 from stripe._webhook import Webhook
 from stripe.v2.core._event import EventNotification
 
+BINARY_ENCODERS = [
+    lambda p: p.encode("utf-8"),
+    lambda p: bytearray(p, "utf-8"),
+]
+
 
 @pytest.fixture
 def client():
@@ -178,6 +183,21 @@ class TestConstructEventWithoutVerification:
         with pytest.raises(ValueError, match="Unrecognized event format"):
             client.construct_event_without_verification(payload)
 
+    @pytest.mark.parametrize(
+        "payload_fixture", ["eventbridge_payload", "eventgrid_payload"]
+    )
+    @pytest.mark.parametrize(
+        "encode", BINARY_ENCODERS, ids=["bytes", "bytearray"]
+    )
+    def test_binary_envelope(self, request, client, payload_fixture, encode):
+        """An envelope can arrive as bytes or a bytearray, which is how many frameworks expose it"""
+        payload = request.getfixturevalue(payload_fixture)
+
+        result = client.construct_event_without_verification(encode(payload))
+
+        assert isinstance(result, stripe.Event)
+        assert result.type == "customer.created"
+
     def test_webhook_static_method_eventbridge(self, eventbridge_payload):
         result = Webhook.construct_event_without_verification(
             eventbridge_payload
@@ -200,6 +220,27 @@ class TestParseEventNotificationWithoutVerification:
             eventgrid_notification_payload
         )
         assert result.id == "evt_test_790"
+        assert result.type == "v2.core.event_destination.ping"
+
+    @pytest.mark.parametrize(
+        "payload_fixture",
+        [
+            "eventbridge_notification_payload",
+            "eventgrid_notification_payload",
+        ],
+    )
+    @pytest.mark.parametrize(
+        "encode", BINARY_ENCODERS, ids=["bytes", "bytearray"]
+    )
+    def test_binary_envelope(self, request, client, payload_fixture, encode):
+        """An envelope can arrive as bytes or a bytearray, which is how many frameworks expose it"""
+        payload = request.getfixturevalue(payload_fixture)
+
+        result = client.parse_event_notification_without_verification(
+            encode(payload)
+        )
+
+        assert isinstance(result, EventNotification)
         assert result.type == "v2.core.event_destination.ping"
 
     def test_v1_event_suggests_construct_event_without_verification(

--- a/tests/test_event_notification_handler.py
+++ b/tests/test_event_notification_handler.py
@@ -607,30 +607,35 @@ class TestEventNotificationHandler:
 
         assert rand_int(None, None) == 4  # type: ignore
 
-    def test_rejects_empty_webhook_secret(
-        self, stripe_client: StripeClient, fallback_callback: Mock
+    @pytest.mark.parametrize("webhook_secret", [None, ""])
+    def test_rejects_missing_webhook_secret(
+        self,
+        stripe_client: StripeClient,
+        fallback_callback: Mock,
+        webhook_secret: Optional[str],
     ) -> None:
-        """Test that the constructor rejects an empty webhook secret"""
+        """`webhook_secret` is typed as optional for web framework ergonomics, but a missing one is still an error"""
         with pytest.raises(
             ValueError, match="webhook_secret must be a non-empty string"
         ):
             StripeEventNotificationHandler(
                 client=stripe_client,
-                webhook_secret="",
+                webhook_secret=webhook_secret,
                 fallback_callback=fallback_callback,
             )
 
-    def test_rejects_none_webhook_secret(
-        self, stripe_client: StripeClient, fallback_callback: Mock
+    @pytest.mark.parametrize("webhook_secret", [None, ""])
+    def test_client_factory_rejects_missing_webhook_secret(
+        self,
+        stripe_client: StripeClient,
+        fallback_callback: Mock,
+        webhook_secret: Optional[str],
     ) -> None:
-        """Test that the constructor rejects a None webhook secret"""
         with pytest.raises(
             ValueError, match="webhook_secret must be a non-empty string"
         ):
-            StripeEventNotificationHandler(
-                client=stripe_client,
-                webhook_secret=None,  # type: ignore
-                fallback_callback=fallback_callback,
+            stripe_client.notification_handler(
+                webhook_secret, fallback_callback
             )
 
     def test_no_pre_handle_hook_registered_handler_still_runs(
@@ -1333,16 +1338,34 @@ class TestAsyncEventNotificationHandler:
                 AsyncMock()
             )
 
-    def test_rejects_empty_webhook_secret(
-        self, stripe_client: StripeClient, fallback_callback: AsyncMock
+    @pytest.mark.parametrize("webhook_secret", [None, ""])
+    def test_rejects_missing_webhook_secret(
+        self,
+        stripe_client: StripeClient,
+        fallback_callback: AsyncMock,
+        webhook_secret: Optional[str],
     ) -> None:
         with pytest.raises(
             ValueError, match="webhook_secret must be a non-empty string"
         ):
             AsyncStripeEventNotificationHandler(
                 client=stripe_client,
-                webhook_secret="",
+                webhook_secret=webhook_secret,
                 fallback_callback=fallback_callback,
+            )
+
+    @pytest.mark.parametrize("webhook_secret", [None, ""])
+    def test_client_factory_rejects_missing_webhook_secret(
+        self,
+        stripe_client: StripeClient,
+        fallback_callback: AsyncMock,
+        webhook_secret: Optional[str],
+    ) -> None:
+        with pytest.raises(
+            ValueError, match="webhook_secret must be a non-empty string"
+        ):
+            stripe_client.async_notification_handler(
+                webhook_secret, fallback_callback
             )
 
     @pytest.mark.anyio

--- a/tests/test_event_notification_handler.py
+++ b/tests/test_event_notification_handler.py
@@ -527,6 +527,40 @@ class TestEventNotificationHandler:
         with pytest.raises(SignatureVerificationError):
             event_handler.handle(v1_billing_meter_payload, "invalid_signature")
 
+    @pytest.mark.parametrize(
+        "encode",
+        [lambda p: p.encode("utf-8"), lambda p: bytearray(p, "utf-8")],
+        ids=["bytes", "bytearray"],
+    )
+    def test_handles_binary_webhook_body(
+        self,
+        event_handler: StripeEventNotificationHandler,
+        v1_billing_meter_payload: str,
+        encode,
+    ) -> None:
+        """The body can arrive as bytes or a bytearray, which is how many frameworks expose it"""
+        callback = Mock()
+        event_handler.on_v1_billing_meter_error_report_triggered(callback)
+
+        sig_header = generate_header(payload=v1_billing_meter_payload)
+        event_handler.handle(encode(v1_billing_meter_payload), sig_header)
+
+        callback.assert_called_once()
+
+    @pytest.mark.parametrize("sig_header", [None, ""])
+    def test_rejects_missing_sig_header(
+        self,
+        event_handler: StripeEventNotificationHandler,
+        v1_billing_meter_payload: str,
+        sig_header: Optional[str],
+    ) -> None:
+        """A missing header (a common integration mistake) gets its own error message"""
+        with pytest.raises(
+            SignatureVerificationError,
+            match="No Stripe-Signature header value was provided",
+        ):
+            event_handler.handle(v1_billing_meter_payload, sig_header)
+
     def test_registered_event_types_empty(
         self, event_handler: StripeEventNotificationHandler
     ) -> None:
@@ -849,6 +883,26 @@ class TestEventNotificationHandlerWithoutVerification:
 
         # No signature needed - just the payload
         handler_without_verification.handle(v1_billing_meter_payload)
+
+        handler.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "encode",
+        [lambda p: p.encode("utf-8"), lambda p: bytearray(p, "utf-8")],
+        ids=["bytes", "bytearray"],
+    )
+    def test_handles_binary_webhook_body(
+        self,
+        handler_without_verification,
+        v1_billing_meter_payload: str,
+        encode,
+    ) -> None:
+        handler = Mock()
+        handler_without_verification.on_v1_billing_meter_error_report_triggered(
+            handler
+        )
+
+        handler_without_verification.handle(encode(v1_billing_meter_payload))
 
         handler.assert_called_once()
 
@@ -1302,6 +1356,44 @@ class TestAsyncEventNotificationHandler:
                 v1_billing_meter_payload, "t=1,v1=not-a-sig"
             )
 
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "encode",
+        [lambda p: p.encode("utf-8"), lambda p: bytearray(p, "utf-8")],
+        ids=["bytes", "bytearray"],
+    )
+    async def test_handles_binary_webhook_body(
+        self,
+        event_handler: AsyncStripeEventNotificationHandler,
+        v1_billing_meter_payload: str,
+        encode,
+    ) -> None:
+        callback = AsyncMock()
+        event_handler.on_v1_billing_meter_error_report_triggered(callback)
+
+        sig_header = generate_header(payload=v1_billing_meter_payload)
+        await event_handler.handle_async(
+            encode(v1_billing_meter_payload), sig_header
+        )
+
+        callback.assert_called_once()
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("sig_header", [None, ""])
+    async def test_rejects_missing_sig_header(
+        self,
+        event_handler: AsyncStripeEventNotificationHandler,
+        v1_billing_meter_payload: str,
+        sig_header: Optional[str],
+    ) -> None:
+        with pytest.raises(
+            SignatureVerificationError,
+            match="No Stripe-Signature header value was provided",
+        ):
+            await event_handler.handle_async(
+                v1_billing_meter_payload, sig_header
+            )
+
 
 class TestAsyncEventNotificationHandlerWithoutVerification:
     @pytest.fixture(scope="function")
@@ -1370,6 +1462,25 @@ class TestAsyncEventNotificationHandlerWithoutVerification:
         assert isinstance(
             received, V1BillingMeterErrorReportTriggeredEventNotification
         )
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "encode",
+        [lambda p: p.encode("utf-8"), lambda p: bytearray(p, "utf-8")],
+        ids=["bytes", "bytearray"],
+    )
+    async def test_handles_binary_webhook_body(
+        self,
+        handler: AsyncStripeEventNotificationHandlerWithoutVerification,
+        v1_billing_meter_payload: str,
+        encode,
+    ) -> None:
+        callback = AsyncMock()
+        handler.on_v1_billing_meter_error_report_triggered(callback)
+
+        await handler.handle_async(encode(v1_billing_meter_payload))
+
+        callback.assert_called_once()
 
     @pytest.mark.anyio
     async def test_pre_handle_gates_handling(

--- a/tests/test_v2_event.py
+++ b/tests/test_v2_event.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Callable, Dict, Union
+from typing import Any, Callable, Dict, Optional, Union
 from typing_extensions import assert_type
 
 import pytest
@@ -218,6 +218,26 @@ class TestV2Event(object):
         with pytest.raises(SignatureVerificationError):
             stripe_client.parse_event_notification(
                 v2_payload_no_data, "bad header", DUMMY_WEBHOOK_SECRET
+            )
+
+    @pytest.mark.parametrize("secret", [None, ""])
+    def test_rejects_missing_secret(
+        self,
+        stripe_client: StripeClient,
+        v2_payload_no_data: str,
+        secret: Optional[str],
+    ):
+        """`secret` is typed as optional for web framework ergonomics, but a missing one is still an error"""
+        with pytest.raises(
+            SignatureVerificationError,
+            match="No webhook secret value was provided",
+        ):
+            stripe_client.parse_event_notification(
+                v2_payload_no_data,
+                WebhookSignature.generate_signature_header(
+                    v2_payload_no_data, DUMMY_WEBHOOK_SECRET
+                ),
+                secret,
             )
 
     def test_v2_events_data_type(self, http_client_mock, v2_payload_with_data):

--- a/tests/test_v2_event.py
+++ b/tests/test_v2_event.py
@@ -1,5 +1,5 @@
 import json
-from typing import Callable
+from typing import Any, Callable, Dict, Union
 from typing_extensions import assert_type
 
 import pytest
@@ -14,12 +14,17 @@ from stripe.events._v1_billing_meter_error_report_triggered_event import (
     V1BillingMeterErrorReportTriggeredEventNotification,
     V1BillingMeterErrorReportTriggeredEvent,
 )
-from stripe.v2.core._event import UnknownEventNotification
+from stripe.v2.core._event import EventNotification, UnknownEventNotification
 from stripe.events._event_classes import ALL_EVENT_NOTIFICATIONS
-from stripe._webhook import WebhookSignature
+from stripe._webhook import WebhookPayload, WebhookSignature
 from tests.test_webhook import DUMMY_WEBHOOK_SECRET
 
 EventParser = Callable[[str], ALL_EVENT_NOTIFICATIONS]
+
+BINARY_ENCODERS = [
+    lambda p: p.encode("utf-8"),
+    lambda p: bytearray(p, "utf-8"),
+]
 
 
 class TestV2Event(object):
@@ -124,6 +129,52 @@ class TestV2Event(object):
         # this isn't for constructing events, it's for parsing thin ones
         assert not hasattr(notif, "data")
         assert notif.reason is None
+
+    @pytest.mark.parametrize(
+        "encode", BINARY_ENCODERS, ids=["bytes", "bytearray"]
+    )
+    def test_parses_binary_event_notif(
+        self,
+        stripe_client: StripeClient,
+        v2_payload_no_data: str,
+        encode: Callable[[str], WebhookPayload],
+    ):
+        """The body can arrive as bytes or a bytearray, which is how many frameworks expose it"""
+        notif = stripe_client.parse_event_notification(
+            encode(v2_payload_no_data),
+            WebhookSignature.generate_signature_header(
+                v2_payload_no_data, DUMMY_WEBHOOK_SECRET
+            ),
+            DUMMY_WEBHOOK_SECRET,
+        )
+
+        assert isinstance(
+            notif, V1BillingMeterErrorReportTriggeredEventNotification
+        )
+        assert notif.id == "evt_234"
+
+    @pytest.mark.parametrize(
+        "to_payload",
+        [lambda p: p, *BINARY_ENCODERS, json.loads],
+        ids=["str", "bytes", "bytearray", "dict"],
+    )
+    def test_from_json_accepts_every_payload_shape(
+        self,
+        stripe_client: StripeClient,
+        v2_payload_no_data: str,
+        to_payload: Callable[[str], Union[WebhookPayload, Dict[str, Any]]],
+    ):
+        """`from_json` is public (for pre-verified payloads & tests), so it takes the same shapes the parse methods do"""
+        notif = EventNotification.from_json(
+            to_payload(v2_payload_no_data), stripe_client
+        )
+
+        assert isinstance(
+            notif, V1BillingMeterErrorReportTriggeredEventNotification
+        )
+        assert notif.id == "evt_234"
+        assert notif.related_object
+        assert notif.related_object.id == "mtr_123"
 
     def test_parses_unknown_event_notif(self, parse_event_notif: EventParser):
         event = parse_event_notif(

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -109,6 +109,27 @@ class TestWebhook(object):
 
 
 class TestWebhookSignature(object):
+    @pytest.mark.parametrize("header", [None, ""])
+    def test_raise_on_missing_header(self, header):
+        with pytest.raises(
+            SignatureVerificationError,
+            match="No Stripe-Signature header value was provided",
+        ):
+            stripe.WebhookSignature.verify_header(
+                DUMMY_WEBHOOK_PAYLOAD, header, DUMMY_WEBHOOK_SECRET
+            )
+
+    @pytest.mark.parametrize(
+        "encode",
+        [lambda p: p.encode("utf-8"), lambda p: bytearray(p, "utf-8")],
+        ids=["bytes", "bytearray"],
+    )
+    def test_verifies_binary_payload(self, encode):
+        header = generate_header()
+        assert stripe.WebhookSignature.verify_header(
+            encode(DUMMY_WEBHOOK_PAYLOAD), header, DUMMY_WEBHOOK_SECRET
+        )
+
     def test_raise_on_malformed_header(self):
         header = "i'm not even a real signature header"
         with pytest.raises(

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -99,6 +99,16 @@ class TestWebhook(object):
         )
         assert isinstance(event, stripe.Event)
 
+    @pytest.mark.parametrize("secret", [None, ""])
+    def test_raise_on_missing_secret(self, secret):
+        with pytest.raises(
+            SignatureVerificationError,
+            match="No webhook secret value was provided",
+        ):
+            stripe.Webhook.construct_event(
+                DUMMY_WEBHOOK_PAYLOAD, generate_header(), secret
+            )
+
     def test_raise_on_v2_payload(self):
         header = generate_header(payload=DUMMY_V2_WEBHOOK_PAYLOAD)
         with pytest.raises(ValueError) as e:
@@ -117,6 +127,16 @@ class TestWebhookSignature(object):
         ):
             stripe.WebhookSignature.verify_header(
                 DUMMY_WEBHOOK_PAYLOAD, header, DUMMY_WEBHOOK_SECRET
+            )
+
+    @pytest.mark.parametrize("secret", [None, ""])
+    def test_raise_on_missing_secret(self, secret):
+        with pytest.raises(
+            SignatureVerificationError,
+            match="No webhook secret value was provided",
+        ):
+            stripe.WebhookSignature.verify_header(
+                DUMMY_WEBHOOK_PAYLOAD, generate_header(), secret
             )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We were a little inconsistent with what string-like types our (now many) webhook methods took. So first off, we should be consistent. But, this also means we have a better integration with common web frameworks, because we natively accept (and handle) their `request.body` type without the user having to potentially decode! Same goes for a potentially missing header- we'll accept it and throw an error vs the user having to verify it themselves.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- ensure all webhook-related methods accept the new union types of `str | bytes | bytearray`
- ensure signature headers are typed as optional, but note that they throw errors when not present.
- many tests

## See also

- [DEVSDK-3228](https://go/j/DEVSDK-3228)
