### PR TITLE
Carry private-preview's CI workflow branch list on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
       - beta
+      - private-preview
       - sdk-release/**
       - feature/**
     tags:


### PR DESCRIPTION
### Why?

Our codegen GitHub Actions job's push to latest-codegen-private-preview is rejected by GitHub: the master→private-preview merge produces a `ci.yml` that exists nowhere in the repository, and the App performing the push has no workflows permission. GitHub allows changes to workflow files that are carried forward in merged commits, so this PR adds in any lines that were exclusive to the private preview branch's workflow file to ensure a merge with no additional workflow file changes.

### What?

- adds `private-preview` to `on.push.branches`

### See Also

