### PR TITLE
Add test to ensure webhook secrets are non-empty

### DIFF
--- a/examples/async_event_notification_handler_endpoint.py
+++ b/examples/async_event_notification_handler_endpoint.py
@@ -22,7 +22,7 @@ from stripe.events import V1BillingMeterErrorReportTriggeredEventNotification
 
 app = FastAPI()
 api_key = os.environ.get("STRIPE_API_KEY", "")
-webhook_secret = os.environ.get("WEBHOOK_SECRET", "")
+webhook_secret = os.environ["WEBHOOK_SECRET"]
 
 # Webhooks can be delivered more than once, so we track ids we've already
 # processed. In production, back this with something durable and shared

--- a/examples/event_notification_handler_endpoint.py
+++ b/examples/event_notification_handler_endpoint.py
@@ -19,7 +19,7 @@ from stripe.events import V1BillingMeterErrorReportTriggeredEventNotification
 
 app = Flask(__name__)
 api_key = os.environ.get("STRIPE_API_KEY", "")
-webhook_secret = os.environ.get("WEBHOOK_SECRET", "")
+webhook_secret = os.environ["WEBHOOK_SECRET"]
 
 # Webhooks can be delivered more than once, so we track ids we've already
 # processed. In production, back this with something durable and shared

--- a/examples/event_notification_webhook_handler.py
+++ b/examples/event_notification_webhook_handler.py
@@ -25,7 +25,7 @@ from flask import Flask, request, jsonify
 
 app = Flask(__name__)
 api_key = os.environ.get("STRIPE_API_KEY", "")
-webhook_secret = os.environ.get("WEBHOOK_SECRET", "")
+webhook_secret = os.environ["WEBHOOK_SECRET"]
 
 client = StripeClient(api_key)
 

--- a/examples/webhooks.py
+++ b/examples/webhooks.py
@@ -6,7 +6,7 @@ from flask import Flask, request
 # this is for handling v1-style Snapshot Events.
 # To handle v2-style Events, see `event_notification_webhook_handler.py`
 
-webhook_secret = os.environ.get("WEBHOOK_SECRET")
+webhook_secret = os.environ["WEBHOOK_SECRET"]
 
 app = Flask(__name__)
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -274,6 +274,16 @@ class TestStripeClientConstructEvent(object):
             )
         assert "parse_event_notification" in str(e.value)
 
+    @pytest.mark.parametrize("secret", [None, ""])
+    def test_raise_on_missing_secret(self, stripe_mock_stripe_client, secret):
+        with pytest.raises(
+            SignatureVerificationError,
+            match="No webhook secret value was provided",
+        ):
+            stripe_mock_stripe_client.construct_event(
+                DUMMY_WEBHOOK_PAYLOAD, generate_header(), secret
+            )
+
     def test_construct_event_inherits_requestor(self, http_client_mock):
         http_client_mock.stub_request("delete", "/v1/terminal/readers/rdr_123")
 


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

While other SDKs had to assert that a webhook secret was non-empty, python already did. So this just updates docs/example/tests to ensure we don't regress (without changing any actual code)

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- update examples
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2953](https://go/j/RUN_DEVSDK-2953)
