### PR TITLE
Support `EventNotification`s with singleton related objects

### DIFF
--- a/stripe/v2/core/__init__.py
+++ b/stripe/v2/core/__init__.py
@@ -4,6 +4,7 @@ from typing_extensions import TYPE_CHECKING
 from stripe.v2.core._event import (
     EventNotification as EventNotification,
     RelatedObject as RelatedObject,
+    RelatedSingletonObject as RelatedSingletonObject,
     Reason as Reason,
     ReasonRequest as ReasonRequest,
 )

--- a/stripe/v2/core/_event.py
+++ b/stripe/v2/core/_event.py
@@ -123,6 +123,18 @@ class RelatedObject:
         return f"<RelatedObject id={self.id} type={self.type} url={self.url}>"
 
 
+class RelatedSingletonObject:
+    type: str
+    url: str
+
+    def __init__(self, d) -> None:
+        self.type = d["type"]
+        self.url = d["url"]
+
+    def __repr__(self) -> str:
+        return f"<RelatedSingletonObject type={self.type} url={self.url}>"
+
+
 class EventNotification:
     """
     EventNotification represents the json that's delivered from an Event Destination. It's a basic struct-like object with a few convenience methods. Use `fetch_event()` to get the full event object.

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -45,6 +45,16 @@ def test_can_import_webhook_members() -> None:
     )
 
 
+def test_can_import_event_notification_members() -> None:
+    from stripe.v2.core import (
+        EventNotification,  # pyright: ignore[reportUnusedImport]
+        Reason,  # pyright: ignore[reportUnusedImport]
+        ReasonRequest,  # pyright: ignore[reportUnusedImport]
+        RelatedObject,  # pyright: ignore[reportUnusedImport]
+        RelatedSingletonObject,  # pyright: ignore[reportUnusedImport]
+    )
+
+
 def test_can_import_abstract() -> None:
     from stripe import (
         APIResource,  # pyright: ignore[reportUnusedImport]

--- a/tests/test_v2_event.py
+++ b/tests/test_v2_event.py
@@ -14,7 +14,11 @@ from stripe.events._v1_billing_meter_error_report_triggered_event import (
     V1BillingMeterErrorReportTriggeredEventNotification,
     V1BillingMeterErrorReportTriggeredEvent,
 )
-from stripe.v2.core._event import EventNotification, UnknownEventNotification
+from stripe.v2.core._event import (
+    EventNotification,
+    RelatedSingletonObject,
+    UnknownEventNotification,
+)
 from stripe.events._event_classes import ALL_EVENT_NOTIFICATIONS
 from stripe._webhook import WebhookPayload, WebhookSignature
 from tests.test_webhook import DUMMY_WEBHOOK_SECRET
@@ -197,6 +201,19 @@ class TestV2Event(object):
 
         assert type(event) is UnknownEventNotification
         assert event.related_object
+
+    def test_related_singleton_object_omits_id(self):
+        """
+        events whose related object is a singleton get a `RelatedSingletonObject`,
+        which has no `id` at all (instead of a perpetually-`None` one)
+        """
+        related_object = RelatedSingletonObject(
+            {"type": "balance", "url": "/v1/balance"}
+        )
+
+        assert related_object.type == "balance"
+        assert related_object.url == "/v1/balance"
+        assert not hasattr(related_object, "id")
 
     def test_raise_on_v1_payload(self, parse_event_notif: EventParser):
         v1_payload = json.dumps(


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

There are a few event notification types whose related object is a singleton. As a result, its `id` field will always be `null`. Rather than mark the root `RelatedObject` class as having a nullable string for its id (causing every user to have to do null checks even when we _know_ it'll be there), we're adding a second class and generating accordingly. There'll never be any ambiguity as ot whether a id field will be present in the response.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add `RelatedSingletonObject` class, which is a copy of `RelatedObject`, but without an `id`. I didn't do inheritance (when relevant) because it's such a tiny, colocated class. If the repetition bothers us, we can reassess.
- add related methods, as needed
- tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2825](https://go/j/RUN_DEVSDK-2825)
